### PR TITLE
updater: Fix webhook URL

### DIFF
--- a/updater.go
+++ b/updater.go
@@ -190,7 +190,12 @@ func (u Updater) SetWebhook(path string, webhook Webhook) (bool, error) {
 
 	v := url.Values{}
 	
-	webhookURL := strings.TrimSuffix(webhook.URL, "/") + path
+	/*
+	** if URL has "/" symbol, we doesn't want to add second "/"
+	** function TrimSuffix remove "/", if it exists
+	** after this we can add "/" symbol
+	*/
+	webhookURL := strings.TrimSuffix(webhook.URL, "/") + "/" + path
 	v.Add("url", webhookURL)
 	// v.Add("certificate", ) // todo: add certificate support
 	v.Add("max_connections", strconv.Itoa(webhook.MaxConnections))


### PR DESCRIPTION
After commit fd45bea9f10530a339f22f67714ea8bb38a89214 we doesn't add "/" symbol before path.