### PR TITLE
Fixed invalid link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Golang Telegram Bot library
 
-Heavily inspired by the [python-telegram-bot library](github.com/python-telegram-bot/python-telegram-bot),
+Heavily inspired by the [python-telegram-bot library](https://github.com/python-telegram-bot/python-telegram-bot),
 this package is a code-generated wrapper for the telegram bot api. We also provide an extensions package which 
 defines an updater/dispatcher pattern to avoid having to rewrite update processing.
 


### PR DESCRIPTION
A link in the readme was only github.com without https://, what made him relative and so not working. Only added this = 1 line, 8 letters.
So, shouln't have any (negative) impact