### PR TITLE
Make it possible to define how to handle groups upon a handled error

### DIFF
--- a/ext/dispatcher.go
+++ b/ext/dispatcher.go
@@ -13,9 +13,17 @@ import (
 
 const DefaultMaxRoutines = 50
 
+type DispatcherAction int64
+
+const (
+	DispatcherActionNoop DispatcherAction = iota
+	DispatcherActionContinueGroups
+	DispatcherActionEndGroups
+)
+
 type Dispatcher struct {
 	// Error handles any errors that occur during handler execution.
-	Error func(ctx *Context, err error)
+	Error func(ctx *Context, err error) DispatcherAction
 	// Panic handles any panics that occur during handler execution.
 	// If this field is nil, the stack is logged to stderr.
 	Panic func(ctx *Context, stack []byte)
@@ -37,7 +45,7 @@ type Dispatcher struct {
 
 type DispatcherOpts struct {
 	// Error handles any errors that occur during handler execution.
-	Error func(ctx *Context, err error)
+	Error func(ctx *Context, err error) DispatcherAction
 	// Panic handles any panics that occur during handler execution.
 	// If no panic is defined, the stack is logged to
 	Panic func(ctx *Context, stack []byte)
@@ -53,7 +61,7 @@ type DispatcherOpts struct {
 func NewDispatcher(updates chan json.RawMessage, opts *DispatcherOpts) *Dispatcher {
 	var limiter chan struct{}
 
-	var errFunc func(ctx *Context, err error)
+	var errFunc func(ctx *Context, err error) DispatcherAction
 	var panicFunc func(ctx *Context, stack []byte)
 
 	maxRoutines := DefaultMaxRoutines
@@ -189,16 +197,37 @@ func (d *Dispatcher) ProcessUpdate(b *gotgbot.Bot, update *gotgbot.Update) {
 			err := handler.HandleUpdate(b, ctx)
 			if err != nil {
 				switch err {
-				case EndGroups:
-					return
 				case ContinueGroups:
+					// Continue handling current group.
 					continue
+
+				case EndGroups:
+					// Stop all group handling.
+					return
+
 				default:
+					action := DispatcherActionNoop
 					if d.Error != nil {
-						d.Error(ctx, err)
+						action = d.Error(ctx, err)
+					}
+
+					switch action {
+					case DispatcherActionNoop:
+						// Move on to next group; same action as if group had been successful.
+					case DispatcherActionContinueGroups:
+						// Continue handling current group.
+						continue
+					case DispatcherActionEndGroups:
+						// Stop all group handling.
+						return
+					default:
+						d.ErrorLog.Printf("unknown action %d, ending groups here", action)
+						return
 					}
 				}
+
 			}
+
 			break // move to next group
 		}
 	}


### PR DESCRIPTION
# What

Improve the error handling logic to allow for custom group handling depending on the outcome of the error. This should allow for more flexibility to handle errors in automated ways.

# Impact

Should cause a minor breaking change where the `dispatcher.Error()` function now has a return value. This is fine, since we are still in beta. 
