### PR TITLE
Update to Bot API 5.3

### DIFF
--- a/ext/handlers/chatmember.go
+++ b/ext/handlers/chatmember.go
@@ -24,7 +24,7 @@ func (c ChatMember) CheckUpdate(b *gotgbot.Bot, u *gotgbot.Update) bool {
 	if u.ChatMember == nil {
 		return false
 	}
-	
+
 	return c.Filter == nil || c.Filter(u.ChatMember)
 }
 

--- a/ext/handlers/filters/chatmember/chatmember.go
+++ b/ext/handlers/filters/chatmember/chatmember.go
@@ -9,12 +9,11 @@ func All(_ *gotgbot.ChatMemberUpdated) bool {
 	return true
 }
 
-// TODO: Reenable
-//func UserId(id int64) filters.ChatMember {
-//	return func(cm *gotgbot.ChatMemberUpdated) bool {
-//		return cm.NewChatMember.User.Id == id
-//	}
-//}
+func UserId(id int64) filters.ChatMember {
+	return func(cm *gotgbot.ChatMemberUpdated) bool {
+		return cm.NewChatMember.GetUser().Id == id
+	}
+}
 
 func FromUserId(id int64) filters.ChatMember {
 	return func(cm *gotgbot.ChatMemberUpdated) bool {
@@ -48,15 +47,14 @@ func InviteLink(cm *gotgbot.ChatMemberUpdated) bool {
 	return cm.InviteLink != nil
 }
 
-// TODO: Reenable
-//func NewStatus(status string) filters.ChatMember {
-//	return func(cm *gotgbot.ChatMemberUpdated) bool {
-//		return cm.NewChatMember.Status == status
-//	}
-//}
-//
-//func OldStatus(status string) filters.ChatMember {
-//	return func(cm *gotgbot.ChatMemberUpdated) bool {
-//		return cm.OldChatMember.Status == status
-//	}
-//}
+func NewStatus(status string) filters.ChatMember {
+	return func(cm *gotgbot.ChatMemberUpdated) bool {
+		return cm.NewChatMember.GetStatus() == status
+	}
+}
+
+func OldStatus(status string) filters.ChatMember {
+	return func(cm *gotgbot.ChatMemberUpdated) bool {
+		return cm.OldChatMember.GetStatus() == status
+	}
+}

--- a/ext/handlers/filters/chatmember/chatmember.go
+++ b/ext/handlers/filters/chatmember/chatmember.go
@@ -9,11 +9,12 @@ func All(_ *gotgbot.ChatMemberUpdated) bool {
 	return true
 }
 
-func UserId(id int64) filters.ChatMember {
-	return func(cm *gotgbot.ChatMemberUpdated) bool {
-		return cm.NewChatMember.User.Id == id
-	}
-}
+// TODO: Reenable
+//func UserId(id int64) filters.ChatMember {
+//	return func(cm *gotgbot.ChatMemberUpdated) bool {
+//		return cm.NewChatMember.User.Id == id
+//	}
+//}
 
 func FromUserId(id int64) filters.ChatMember {
 	return func(cm *gotgbot.ChatMemberUpdated) bool {
@@ -47,14 +48,15 @@ func InviteLink(cm *gotgbot.ChatMemberUpdated) bool {
 	return cm.InviteLink != nil
 }
 
-func NewStatus(status string) filters.ChatMember {
-	return func(cm *gotgbot.ChatMemberUpdated) bool {
-		return cm.NewChatMember.Status == status
-	}
-}
-
-func OldStatus(status string) filters.ChatMember {
-	return func(cm *gotgbot.ChatMemberUpdated) bool {
-		return cm.OldChatMember.Status == status
-	}
-}
+// TODO: Reenable
+//func NewStatus(status string) filters.ChatMember {
+//	return func(cm *gotgbot.ChatMemberUpdated) bool {
+//		return cm.NewChatMember.Status == status
+//	}
+//}
+//
+//func OldStatus(status string) filters.ChatMember {
+//	return func(cm *gotgbot.ChatMemberUpdated) bool {
+//		return cm.OldChatMember.Status == status
+//	}
+//}

--- a/ext/handlers/filters/message/message.go
+++ b/ext/handlers/filters/message/message.go
@@ -1,8 +1,8 @@
 package message
 
 import (
-	"strings"
 	"regexp"
+	"strings"
 
 	"github.com/PaulSonOfLars/gotgbot/v2"
 	"github.com/PaulSonOfLars/gotgbot/v2/ext/handlers/filters"

--- a/gen_helpers.go
+++ b/gen_helpers.go
@@ -23,6 +23,11 @@ func (sq ShippingQuery) Answer(b *Bot, ok bool, opts *AnswerShippingQueryOpts) (
 	return b.AnswerShippingQuery(sq.Id, ok, opts)
 }
 
+// BanMember Helper method for Bot.BanChatMember
+func (c Chat) BanMember(b *Bot, userId int64, opts *BanChatMemberOpts) (bool, error) {
+	return b.BanChatMember(c.Id, userId, opts)
+}
+
 // Copy Helper method for Bot.CopyMessage
 func (m Message) Copy(b *Bot, chatId int64, opts *CopyMessageOpts) (*MessageId, error) {
 	return b.CopyMessage(chatId, m.Chat.Id, m.MessageId, opts)
@@ -158,9 +163,9 @@ func (c Chat) GetMember(b *Bot, userId int64) (*ChatMember, error) {
 	return b.GetChatMember(c.Id, userId)
 }
 
-// GetMembersCount Helper method for Bot.GetChatMembersCount
-func (c Chat) GetMembersCount(b *Bot) (int64, error) {
-	return b.GetChatMembersCount(c.Id)
+// GetMemberCount Helper method for Bot.GetChatMemberCount
+func (c Chat) GetMemberCount(b *Bot) (int64, error) {
+	return b.GetChatMemberCount(c.Id)
 }
 
 // Get Helper method for Bot.GetFile
@@ -171,11 +176,6 @@ func (f File) Get(b *Bot) (*File, error) {
 // GetProfilePhotos Helper method for Bot.GetUserProfilePhotos
 func (u User) GetProfilePhotos(b *Bot, opts *GetUserProfilePhotosOpts) (*UserProfilePhotos, error) {
 	return b.GetUserProfilePhotos(u.Id, opts)
-}
-
-// KickMember Helper method for Bot.KickChatMember
-func (c Chat) KickMember(b *Bot, userId int64, opts *KickChatMemberOpts) (bool, error) {
-	return b.KickChatMember(c.Id, userId, opts)
 }
 
 // Leave Helper method for Bot.LeaveChat

--- a/gen_helpers.go
+++ b/gen_helpers.go
@@ -159,7 +159,7 @@ func (c Chat) GetAdministrators(b *Bot) ([]ChatMember, error) {
 }
 
 // GetMember Helper method for Bot.GetChatMember
-func (c Chat) GetMember(b *Bot, userId int64) (*ChatMember, error) {
+func (c Chat) GetMember(b *Bot, userId int64) (ChatMember, error) {
 	return b.GetChatMember(c.Id, userId)
 }
 

--- a/gen_methods.go
+++ b/gen_methods.go
@@ -242,6 +242,43 @@ func (bot *Bot) AnswerShippingQuery(shippingQueryId string, ok bool, opts *Answe
 	return b, json.Unmarshal(r, &b)
 }
 
+// BanChatMemberOpts is the set of optional fields for Bot.BanChatMember.
+type BanChatMemberOpts struct {
+	// Date when the user will be unbanned, unix time. If user is banned for more than 366 days or less than 30 seconds from the current time they are considered to be banned forever. Applied for supergroups and channels only.
+	UntilDate int64
+	// Pass True to delete all messages from the chat for the user that is being removed. If False, the user will be able to see messages in the group that were sent before the user was removed. Always True for supergroups and channels.
+	RevokeMessages bool
+}
+
+// BanChatMember Use this method to ban a user in a group, a supergroup or a channel. In the case of supergroups and channels, the user will not be able to return to the chat on their own using invite links, etc., unless unbanned first. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns True on success.
+// - chat_id (type int64): Unique identifier for the target group or username of the target supergroup or channel (in the format @channelusername)
+// - user_id (type int64): Unique identifier of the target user
+// - opts (type BanChatMemberOpts): All optional parameters.
+// https://core.telegram.org/bots/api#banchatmember
+func (bot *Bot) BanChatMember(chatId int64, userId int64, opts *BanChatMemberOpts) (bool, error) {
+	v := urlLib.Values{}
+	if chatId != 0 {
+		v.Add("chat_id", strconv.FormatInt(chatId, 10))
+	}
+	if userId != 0 {
+		v.Add("user_id", strconv.FormatInt(userId, 10))
+	}
+	if opts != nil {
+		if opts.UntilDate != 0 {
+			v.Add("until_date", strconv.FormatInt(opts.UntilDate, 10))
+		}
+		v.Add("revoke_messages", strconv.FormatBool(opts.RevokeMessages))
+	}
+
+	r, err := bot.Get("banChatMember", v)
+	if err != nil {
+		return false, err
+	}
+
+	var b bool
+	return b, json.Unmarshal(r, &b)
+}
+
 // Close Use this method to close the bot instance before moving it from one local server to another. You need to delete the webhook before calling this method to ensure that the bot isn't launched again after server restart. The method will return error 429 in the first 10 minutes after the bot is launched. Returns True on success. Requires no parameters.
 // https://core.telegram.org/bots/api#close
 func (bot *Bot) Close() (bool, error) {
@@ -494,6 +531,37 @@ func (bot *Bot) DeleteMessage(chatId int64, messageId int64) (bool, error) {
 	}
 
 	r, err := bot.Get("deleteMessage", v)
+	if err != nil {
+		return false, err
+	}
+
+	var b bool
+	return b, json.Unmarshal(r, &b)
+}
+
+// DeleteMyCommandsOpts is the set of optional fields for Bot.DeleteMyCommands.
+type DeleteMyCommandsOpts struct {
+	// A JSON-serialized object, describing scope of users for which the commands are relevant. Defaults to BotCommandScopeDefault.
+	Scope BotCommandScope
+	// A two-letter ISO 639-1 language code. If empty, commands will be applied to all users from the given scope, for whose language there are no dedicated commands
+	LanguageCode string
+}
+
+// DeleteMyCommands Use this method to delete the list of the bot's commands for the given scope and user language. After deletion, higher level commands will be shown to affected users. Returns True on success.
+// - opts (type DeleteMyCommandsOpts): All optional parameters.
+// https://core.telegram.org/bots/api#deletemycommands
+func (bot *Bot) DeleteMyCommands(opts *DeleteMyCommandsOpts) (bool, error) {
+	v := urlLib.Values{}
+	if opts != nil {
+		bs, err := json.Marshal(opts.Scope)
+		if err != nil {
+			return false, fmt.Errorf("failed to marshal field scope: %w", err)
+		}
+		v.Add("scope", string(bs))
+		v.Add("language_code", opts.LanguageCode)
+	}
+
+	r, err := bot.Get("deleteMyCommands", v)
 	if err != nil {
 		return false, err
 	}
@@ -958,16 +1026,16 @@ func (bot *Bot) GetChatMember(chatId int64, userId int64) (*ChatMember, error) {
 	return &c, json.Unmarshal(r, &c)
 }
 
-// GetChatMembersCount Use this method to get the number of members in a chat. Returns Int on success.
+// GetChatMemberCount Use this method to get the number of members in a chat. Returns Int on success.
 // - chat_id (type int64): Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
-// https://core.telegram.org/bots/api#getchatmemberscount
-func (bot *Bot) GetChatMembersCount(chatId int64) (int64, error) {
+// https://core.telegram.org/bots/api#getchatmembercount
+func (bot *Bot) GetChatMemberCount(chatId int64) (int64, error) {
 	v := urlLib.Values{}
 	if chatId != 0 {
 		v.Add("chat_id", strconv.FormatInt(chatId, 10))
 	}
 
-	r, err := bot.Get("getChatMembersCount", v)
+	r, err := bot.Get("getChatMemberCount", v)
 	if err != nil {
 		return 0, err
 	}
@@ -1045,11 +1113,27 @@ func (bot *Bot) GetMe() (*User, error) {
 	return &u, json.Unmarshal(r, &u)
 }
 
-// GetMyCommands Use this method to get the current list of the bot's commands. Requires no parameters. Returns Array of BotCommand on success.
-// Methods and objects used in the inline mode are described in the Inline mode section.
+// GetMyCommandsOpts is the set of optional fields for Bot.GetMyCommands.
+type GetMyCommandsOpts struct {
+	// A JSON-serialized object, describing scope of users. Defaults to BotCommandScopeDefault.
+	Scope BotCommandScope
+	// A two-letter ISO 639-1 language code or an empty string
+	LanguageCode string
+}
+
+// GetMyCommands Use this method to get the current list of the bot's commands for the given scope and user language. Returns Array of BotCommand on success. If commands aren't set, an empty list is returned.
+// - opts (type GetMyCommandsOpts): All optional parameters.
 // https://core.telegram.org/bots/api#getmycommands
-func (bot *Bot) GetMyCommands() ([]BotCommand, error) {
+func (bot *Bot) GetMyCommands(opts *GetMyCommandsOpts) ([]BotCommand, error) {
 	v := urlLib.Values{}
+	if opts != nil {
+		bs, err := json.Marshal(opts.Scope)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal field scope: %w", err)
+		}
+		v.Add("scope", string(bs))
+		v.Add("language_code", opts.LanguageCode)
+	}
 
 	r, err := bot.Get("getMyCommands", v)
 	if err != nil {
@@ -1168,43 +1252,6 @@ func (bot *Bot) GetWebhookInfo() (*WebhookInfo, error) {
 
 	var w WebhookInfo
 	return &w, json.Unmarshal(r, &w)
-}
-
-// KickChatMemberOpts is the set of optional fields for Bot.KickChatMember.
-type KickChatMemberOpts struct {
-	// Date when the user will be unbanned, unix time. If user is banned for more than 366 days or less than 30 seconds from the current time they are considered to be banned forever. Applied for supergroups and channels only.
-	UntilDate int64
-	// Pass True to delete all messages from the chat for the user that is being removed. If False, the user will be able to see messages in the group that were sent before the user was removed. Always True for supergroups and channels.
-	RevokeMessages bool
-}
-
-// KickChatMember Use this method to kick a user from a group, a supergroup or a channel. In the case of supergroups and channels, the user will not be able to return to the chat on their own using invite links, etc., unless unbanned first. The bot must be an administrator in the chat for this to work and must have the appropriate admin rights. Returns True on success.
-// - chat_id (type int64): Unique identifier for the target group or username of the target supergroup or channel (in the format @channelusername)
-// - user_id (type int64): Unique identifier of the target user
-// - opts (type KickChatMemberOpts): All optional parameters.
-// https://core.telegram.org/bots/api#kickchatmember
-func (bot *Bot) KickChatMember(chatId int64, userId int64, opts *KickChatMemberOpts) (bool, error) {
-	v := urlLib.Values{}
-	if chatId != 0 {
-		v.Add("chat_id", strconv.FormatInt(chatId, 10))
-	}
-	if userId != 0 {
-		v.Add("user_id", strconv.FormatInt(userId, 10))
-	}
-	if opts != nil {
-		if opts.UntilDate != 0 {
-			v.Add("until_date", strconv.FormatInt(opts.UntilDate, 10))
-		}
-		v.Add("revoke_messages", strconv.FormatBool(opts.RevokeMessages))
-	}
-
-	r, err := bot.Get("kickChatMember", v)
-	if err != nil {
-		return false, err
-	}
-
-	var b bool
-	return b, json.Unmarshal(r, &b)
 }
 
 // LeaveChat Use this method for your bot to leave a group, supergroup or channel. Returns True on success.
@@ -2175,16 +2222,6 @@ type SendMessageOpts struct {
 }
 
 // SendMessage Use this method to send text messages. On success, the sent Message is returned.
-// The Bot API supports basic formatting for messages. You can use bold, italic, underlined and strikethrough text, as well as inline links and pre-formatted code in your bots' messages. Telegram clients will render them accordingly. You can use either markdown-style or HTML-style formatting.
-// Note that Telegram clients will display an alert to the user before opening an inline link ('Open this link?' together with the full URL).
-// Message entities can be nested, providing following restrictions are met:- If two entities has common characters then one of them is fully contained inside another.- bold, italic, underline and strikethrough entities can contain and to be contained in any other entities, except pre and code.- All other entities can't contain each other.
-// Links tg://user?id=<user_id> can be used to mention a user by their ID without using a username. Please note:
-// To use this mode, pass MarkdownV2 in the parse_mode field. Use the following syntax in your message:
-// Please note:
-// To use this mode, pass HTML in the parse_mode field. The following tags are currently supported:
-// Please note:
-// This is a legacy mode, retained for backward compatibility. To use this mode, pass Markdown in the parse_mode field. Use the following syntax in your message:
-// Please note:
 // - chat_id (type int64): Unique identifier for the target chat or username of the target channel (in the format @channelusername)
 // - text (type string): Text of the message to be sent, 1-4096 characters after entities parsing
 // - opts (type SendMessageOpts): All optional parameters.
@@ -3060,10 +3097,19 @@ func (bot *Bot) SetGameScore(userId int64, score int64, opts *SetGameScoreOpts) 
 	return &m, json.Unmarshal(r, &m)
 }
 
-// SetMyCommands Use this method to change the list of the bot's commands. Returns True on success.
+// SetMyCommandsOpts is the set of optional fields for Bot.SetMyCommands.
+type SetMyCommandsOpts struct {
+	// A JSON-serialized object, describing scope of users for which the commands are relevant. Defaults to BotCommandScopeDefault.
+	Scope BotCommandScope
+	// A two-letter ISO 639-1 language code. If empty, commands will be applied to all users from the given scope, for whose language there are no dedicated commands
+	LanguageCode string
+}
+
+// SetMyCommands Use this method to change the list of the bot's commands. See https://core.telegram.org/bots#commands for more details about bot commands. Returns True on success.
 // - commands (type []BotCommand): A JSON-serialized list of bot commands to be set as the list of the bot's commands. At most 100 commands can be specified.
+// - opts (type SetMyCommandsOpts): All optional parameters.
 // https://core.telegram.org/bots/api#setmycommands
-func (bot *Bot) SetMyCommands(commands []BotCommand) (bool, error) {
+func (bot *Bot) SetMyCommands(commands []BotCommand, opts *SetMyCommandsOpts) (bool, error) {
 	v := urlLib.Values{}
 	if commands != nil {
 		bs, err := json.Marshal(commands)
@@ -3071,6 +3117,14 @@ func (bot *Bot) SetMyCommands(commands []BotCommand) (bool, error) {
 			return false, fmt.Errorf("failed to marshal field commands: %w", err)
 		}
 		v.Add("commands", string(bs))
+	}
+	if opts != nil {
+		bs, err := json.Marshal(opts.Scope)
+		if err != nil {
+			return false, fmt.Errorf("failed to marshal field scope: %w", err)
+		}
+		v.Add("scope", string(bs))
+		v.Add("language_code", opts.LanguageCode)
 	}
 
 	r, err := bot.Get("setMyCommands", v)
@@ -3328,7 +3382,7 @@ type UnbanChatMemberOpts struct {
 	OnlyIfBanned bool
 }
 
-// UnbanChatMember Use this method to unban a previously kicked user in a supergroup or channel. The user will not return to the group or channel automatically, but will be able to join via link, etc. The bot must be an administrator for this to work. By default, this method guarantees that after the call the user is not a member of the chat, but will be able to join it. So if the user is a member of the chat they will also be removed from the chat. If you don't want this, use the parameter only_if_banned. Returns True on success.
+// UnbanChatMember Use this method to unban a previously banned user in a supergroup or channel. The user will not return to the group or channel automatically, but will be able to join via link, etc. The bot must be an administrator for this to work. By default, this method guarantees that after the call the user is not a member of the chat, but will be able to join it. So if the user is a member of the chat they will also be removed from the chat. If you don't want this, use the parameter only_if_banned. Returns True on success.
 // - chat_id (type int64): Unique identifier for the target group or username of the target supergroup or channel (in the format @username)
 // - user_id (type int64): Unique identifier of the target user
 // - opts (type UnbanChatMemberOpts): All optional parameters.

--- a/gen_methods.go
+++ b/gen_methods.go
@@ -1008,7 +1008,7 @@ func (bot *Bot) GetChatAdministrators(chatId int64) ([]ChatMember, error) {
 // - chat_id (type int64): Unique identifier for the target chat or username of the target supergroup or channel (in the format @channelusername)
 // - user_id (type int64): Unique identifier of the target user
 // https://core.telegram.org/bots/api#getchatmember
-func (bot *Bot) GetChatMember(chatId int64, userId int64) (*ChatMember, error) {
+func (bot *Bot) GetChatMember(chatId int64, userId int64) (ChatMember, error) {
 	v := urlLib.Values{}
 	if chatId != 0 {
 		v.Add("chat_id", strconv.FormatInt(chatId, 10))
@@ -1023,7 +1023,7 @@ func (bot *Bot) GetChatMember(chatId int64, userId int64) (*ChatMember, error) {
 	}
 
 	var c ChatMember
-	return &c, json.Unmarshal(r, &c)
+	return c, json.Unmarshal(r, &c)
 }
 
 // GetChatMemberCount Use this method to get the number of members in a chat. Returns Int on success.

--- a/gen_methods.go
+++ b/gen_methods.go
@@ -1022,8 +1022,7 @@ func (bot *Bot) GetChatMember(chatId int64, userId int64) (ChatMember, error) {
 		return nil, err
 	}
 
-	var c ChatMember
-	return c, json.Unmarshal(r, &c)
+	return unmarshalChatMember(r)
 }
 
 // GetChatMemberCount Use this method to get the number of members in a chat. Returns Int on success.

--- a/gen_methods.go
+++ b/gen_methods.go
@@ -344,7 +344,7 @@ func (bot *Bot) CopyMessage(chatId int64, fromChatId int64, messageId int64, opt
 		}
 		v.Add("allow_sending_without_reply", strconv.FormatBool(opts.AllowSendingWithoutReply))
 		if opts.ReplyMarkup != nil {
-			bs, err := opts.ReplyMarkup.ReplyMarkup()
+			bs, err := json.Marshal(opts.ReplyMarkup)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 			}
@@ -1544,7 +1544,7 @@ func (bot *Bot) SendAnimation(chatId int64, animation InputFile, opts *SendAnima
 		}
 		v.Add("allow_sending_without_reply", strconv.FormatBool(opts.AllowSendingWithoutReply))
 		if opts.ReplyMarkup != nil {
-			bs, err := opts.ReplyMarkup.ReplyMarkup()
+			bs, err := json.Marshal(opts.ReplyMarkup)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 			}
@@ -1662,7 +1662,7 @@ func (bot *Bot) SendAudio(chatId int64, audio InputFile, opts *SendAudioOpts) (*
 		}
 		v.Add("allow_sending_without_reply", strconv.FormatBool(opts.AllowSendingWithoutReply))
 		if opts.ReplyMarkup != nil {
-			bs, err := opts.ReplyMarkup.ReplyMarkup()
+			bs, err := json.Marshal(opts.ReplyMarkup)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 			}
@@ -1738,7 +1738,7 @@ func (bot *Bot) SendContact(chatId int64, phoneNumber string, firstName string, 
 		}
 		v.Add("allow_sending_without_reply", strconv.FormatBool(opts.AllowSendingWithoutReply))
 		if opts.ReplyMarkup != nil {
-			bs, err := opts.ReplyMarkup.ReplyMarkup()
+			bs, err := json.Marshal(opts.ReplyMarkup)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 			}
@@ -1786,7 +1786,7 @@ func (bot *Bot) SendDice(chatId int64, opts *SendDiceOpts) (*Message, error) {
 		}
 		v.Add("allow_sending_without_reply", strconv.FormatBool(opts.AllowSendingWithoutReply))
 		if opts.ReplyMarkup != nil {
-			bs, err := opts.ReplyMarkup.ReplyMarkup()
+			bs, err := json.Marshal(opts.ReplyMarkup)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 			}
@@ -1895,7 +1895,7 @@ func (bot *Bot) SendDocument(chatId int64, document InputFile, opts *SendDocumen
 		}
 		v.Add("allow_sending_without_reply", strconv.FormatBool(opts.AllowSendingWithoutReply))
 		if opts.ReplyMarkup != nil {
-			bs, err := opts.ReplyMarkup.ReplyMarkup()
+			bs, err := json.Marshal(opts.ReplyMarkup)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 			}
@@ -2133,7 +2133,7 @@ func (bot *Bot) SendLocation(chatId int64, latitude float64, longitude float64, 
 		}
 		v.Add("allow_sending_without_reply", strconv.FormatBool(opts.AllowSendingWithoutReply))
 		if opts.ReplyMarkup != nil {
-			bs, err := opts.ReplyMarkup.ReplyMarkup()
+			bs, err := json.Marshal(opts.ReplyMarkup)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 			}
@@ -2248,7 +2248,7 @@ func (bot *Bot) SendMessage(chatId int64, text string, opts *SendMessageOpts) (*
 		}
 		v.Add("allow_sending_without_reply", strconv.FormatBool(opts.AllowSendingWithoutReply))
 		if opts.ReplyMarkup != nil {
-			bs, err := opts.ReplyMarkup.ReplyMarkup()
+			bs, err := json.Marshal(opts.ReplyMarkup)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 			}
@@ -2331,7 +2331,7 @@ func (bot *Bot) SendPhoto(chatId int64, photo InputFile, opts *SendPhotoOpts) (*
 		}
 		v.Add("allow_sending_without_reply", strconv.FormatBool(opts.AllowSendingWithoutReply))
 		if opts.ReplyMarkup != nil {
-			bs, err := opts.ReplyMarkup.ReplyMarkup()
+			bs, err := json.Marshal(opts.ReplyMarkup)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 			}
@@ -2428,7 +2428,7 @@ func (bot *Bot) SendPoll(chatId int64, question string, options []string, opts *
 		}
 		v.Add("allow_sending_without_reply", strconv.FormatBool(opts.AllowSendingWithoutReply))
 		if opts.ReplyMarkup != nil {
-			bs, err := opts.ReplyMarkup.ReplyMarkup()
+			bs, err := json.Marshal(opts.ReplyMarkup)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 			}
@@ -2496,7 +2496,7 @@ func (bot *Bot) SendSticker(chatId int64, sticker InputFile, opts *SendStickerOp
 		}
 		v.Add("allow_sending_without_reply", strconv.FormatBool(opts.AllowSendingWithoutReply))
 		if opts.ReplyMarkup != nil {
-			bs, err := opts.ReplyMarkup.ReplyMarkup()
+			bs, err := json.Marshal(opts.ReplyMarkup)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 			}
@@ -2565,7 +2565,7 @@ func (bot *Bot) SendVenue(chatId int64, latitude float64, longitude float64, tit
 		}
 		v.Add("allow_sending_without_reply", strconv.FormatBool(opts.AllowSendingWithoutReply))
 		if opts.ReplyMarkup != nil {
-			bs, err := opts.ReplyMarkup.ReplyMarkup()
+			bs, err := json.Marshal(opts.ReplyMarkup)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 			}
@@ -2689,7 +2689,7 @@ func (bot *Bot) SendVideo(chatId int64, video InputFile, opts *SendVideoOpts) (*
 		}
 		v.Add("allow_sending_without_reply", strconv.FormatBool(opts.AllowSendingWithoutReply))
 		if opts.ReplyMarkup != nil {
-			bs, err := opts.ReplyMarkup.ReplyMarkup()
+			bs, err := json.Marshal(opts.ReplyMarkup)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 			}
@@ -2790,7 +2790,7 @@ func (bot *Bot) SendVideoNote(chatId int64, videoNote InputFile, opts *SendVideo
 		}
 		v.Add("allow_sending_without_reply", strconv.FormatBool(opts.AllowSendingWithoutReply))
 		if opts.ReplyMarkup != nil {
-			bs, err := opts.ReplyMarkup.ReplyMarkup()
+			bs, err := json.Marshal(opts.ReplyMarkup)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 			}
@@ -2878,7 +2878,7 @@ func (bot *Bot) SendVoice(chatId int64, voice InputFile, opts *SendVoiceOpts) (*
 		}
 		v.Add("allow_sending_without_reply", strconv.FormatBool(opts.AllowSendingWithoutReply))
 		if opts.ReplyMarkup != nil {
-			bs, err := opts.ReplyMarkup.ReplyMarkup()
+			bs, err := json.Marshal(opts.ReplyMarkup)
 			if err != nil {
 				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 			}

--- a/gen_types.go
+++ b/gen_types.go
@@ -84,6 +84,7 @@ type BotCommandScope interface {
 	MergeBotCommandScope() MergedBotCommandScope
 }
 
+// MergedBotCommandScope is a helper type to simplify interactions with the various BotCommandScope subtypes.
 type MergedBotCommandScope struct {
 	// Scope type, must be default
 	Type string `json:"type,omitempty"`
@@ -101,6 +102,7 @@ func (v MergedBotCommandScope) GetType() string {
 // MergedBotCommandScope.botCommandScope is a dummy method to avoid interface implementation.
 func (v MergedBotCommandScope) botCommandScope() {}
 
+// MergeBotCommandScope returns a MergedBotCommandScope struct to simplify working with types in a non-generic world.
 func (v MergedBotCommandScope) MergeBotCommandScope() MergedBotCommandScope {
 	return v
 }
@@ -114,13 +116,14 @@ func (v BotCommandScopeAllChatAdministrators) GetType() string {
 	return "all_chat_administrators"
 }
 
-// MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+// MergeBotCommandScope returns a MergedBotCommandScope struct to simplify working with types in a non-generic world.
 func (v BotCommandScopeAllChatAdministrators) MergeBotCommandScope() MergedBotCommandScope {
 	return MergedBotCommandScope{
 		Type: "all_chat_administrators",
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v BotCommandScopeAllChatAdministrators) MarshalJSON() ([]byte, error) {
 	type alias BotCommandScopeAllChatAdministrators
 	a := struct {
@@ -145,13 +148,14 @@ func (v BotCommandScopeAllGroupChats) GetType() string {
 	return "all_group_chats"
 }
 
-// MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+// MergeBotCommandScope returns a MergedBotCommandScope struct to simplify working with types in a non-generic world.
 func (v BotCommandScopeAllGroupChats) MergeBotCommandScope() MergedBotCommandScope {
 	return MergedBotCommandScope{
 		Type: "all_group_chats",
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v BotCommandScopeAllGroupChats) MarshalJSON() ([]byte, error) {
 	type alias BotCommandScopeAllGroupChats
 	a := struct {
@@ -176,13 +180,14 @@ func (v BotCommandScopeAllPrivateChats) GetType() string {
 	return "all_private_chats"
 }
 
-// MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+// MergeBotCommandScope returns a MergedBotCommandScope struct to simplify working with types in a non-generic world.
 func (v BotCommandScopeAllPrivateChats) MergeBotCommandScope() MergedBotCommandScope {
 	return MergedBotCommandScope{
 		Type: "all_private_chats",
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v BotCommandScopeAllPrivateChats) MarshalJSON() ([]byte, error) {
 	type alias BotCommandScopeAllPrivateChats
 	a := struct {
@@ -210,7 +215,7 @@ func (v BotCommandScopeChat) GetType() string {
 	return "chat"
 }
 
-// MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+// MergeBotCommandScope returns a MergedBotCommandScope struct to simplify working with types in a non-generic world.
 func (v BotCommandScopeChat) MergeBotCommandScope() MergedBotCommandScope {
 	return MergedBotCommandScope{
 		Type:   "chat",
@@ -218,6 +223,7 @@ func (v BotCommandScopeChat) MergeBotCommandScope() MergedBotCommandScope {
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v BotCommandScopeChat) MarshalJSON() ([]byte, error) {
 	type alias BotCommandScopeChat
 	a := struct {
@@ -245,7 +251,7 @@ func (v BotCommandScopeChatAdministrators) GetType() string {
 	return "chat_administrators"
 }
 
-// MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+// MergeBotCommandScope returns a MergedBotCommandScope struct to simplify working with types in a non-generic world.
 func (v BotCommandScopeChatAdministrators) MergeBotCommandScope() MergedBotCommandScope {
 	return MergedBotCommandScope{
 		Type:   "chat_administrators",
@@ -253,6 +259,7 @@ func (v BotCommandScopeChatAdministrators) MergeBotCommandScope() MergedBotComma
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v BotCommandScopeChatAdministrators) MarshalJSON() ([]byte, error) {
 	type alias BotCommandScopeChatAdministrators
 	a := struct {
@@ -282,7 +289,7 @@ func (v BotCommandScopeChatMember) GetType() string {
 	return "chat_member"
 }
 
-// MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+// MergeBotCommandScope returns a MergedBotCommandScope struct to simplify working with types in a non-generic world.
 func (v BotCommandScopeChatMember) MergeBotCommandScope() MergedBotCommandScope {
 	return MergedBotCommandScope{
 		Type:   "chat_member",
@@ -291,6 +298,7 @@ func (v BotCommandScopeChatMember) MergeBotCommandScope() MergedBotCommandScope 
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v BotCommandScopeChatMember) MarshalJSON() ([]byte, error) {
 	type alias BotCommandScopeChatMember
 	a := struct {
@@ -315,13 +323,14 @@ func (v BotCommandScopeDefault) GetType() string {
 	return "default"
 }
 
-// MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+// MergeBotCommandScope returns a MergedBotCommandScope struct to simplify working with types in a non-generic world.
 func (v BotCommandScopeDefault) MergeBotCommandScope() MergedBotCommandScope {
 	return MergedBotCommandScope{
 		Type: "default",
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v BotCommandScopeDefault) MarshalJSON() ([]byte, error) {
 	type alias BotCommandScopeDefault
 	a := struct {
@@ -443,6 +452,7 @@ type ChatMember interface {
 	MergeChatMember() MergedChatMember
 }
 
+// MergedChatMember is a helper type to simplify interactions with the various ChatMember subtypes.
 type MergedChatMember struct {
 	// The member's status in the chat, always "creator"
 	Status string `json:"status,omitempty"`
@@ -503,10 +513,13 @@ func (v MergedChatMember) GetUser() User {
 // MergedChatMember.chatMember is a dummy method to avoid interface implementation.
 func (v MergedChatMember) chatMember() {}
 
+// MergeChatMember returns a MergedChatMember struct to simplify working with types in a non-generic world.
 func (v MergedChatMember) MergeChatMember() MergedChatMember {
 	return v
 }
 
+// unmarshalChatMember is a JSON unmarshal helper to marshal the right structs into a ChatMember interface
+// based on the Status field.
 func unmarshalChatMember(d json.RawMessage) (ChatMember, error) {
 	if len(d) == 0 {
 		return nil, nil
@@ -616,7 +629,7 @@ func (v ChatMemberAdministrator) GetUser() User {
 	return v.User
 }
 
-// MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
+// MergeChatMember returns a MergedChatMember struct to simplify working with types in a non-generic world.
 func (v ChatMemberAdministrator) MergeChatMember() MergedChatMember {
 	return MergedChatMember{
 		Status:              "administrator",
@@ -637,6 +650,7 @@ func (v ChatMemberAdministrator) MergeChatMember() MergedChatMember {
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Status value.
 func (v ChatMemberAdministrator) MarshalJSON() ([]byte, error) {
 	type alias ChatMemberAdministrator
 	a := struct {
@@ -671,7 +685,7 @@ func (v ChatMemberBanned) GetUser() User {
 	return v.User
 }
 
-// MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
+// MergeChatMember returns a MergedChatMember struct to simplify working with types in a non-generic world.
 func (v ChatMemberBanned) MergeChatMember() MergedChatMember {
 	return MergedChatMember{
 		Status:    "banned",
@@ -680,6 +694,7 @@ func (v ChatMemberBanned) MergeChatMember() MergedChatMember {
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Status value.
 func (v ChatMemberBanned) MarshalJSON() ([]byte, error) {
 	type alias ChatMemberBanned
 	a := struct {
@@ -712,7 +727,7 @@ func (v ChatMemberLeft) GetUser() User {
 	return v.User
 }
 
-// MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
+// MergeChatMember returns a MergedChatMember struct to simplify working with types in a non-generic world.
 func (v ChatMemberLeft) MergeChatMember() MergedChatMember {
 	return MergedChatMember{
 		Status: "left",
@@ -720,6 +735,7 @@ func (v ChatMemberLeft) MergeChatMember() MergedChatMember {
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Status value.
 func (v ChatMemberLeft) MarshalJSON() ([]byte, error) {
 	type alias ChatMemberLeft
 	a := struct {
@@ -752,7 +768,7 @@ func (v ChatMemberMember) GetUser() User {
 	return v.User
 }
 
-// MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
+// MergeChatMember returns a MergedChatMember struct to simplify working with types in a non-generic world.
 func (v ChatMemberMember) MergeChatMember() MergedChatMember {
 	return MergedChatMember{
 		Status: "member",
@@ -760,6 +776,7 @@ func (v ChatMemberMember) MergeChatMember() MergedChatMember {
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Status value.
 func (v ChatMemberMember) MarshalJSON() ([]byte, error) {
 	type alias ChatMemberMember
 	a := struct {
@@ -796,7 +813,7 @@ func (v ChatMemberOwner) GetUser() User {
 	return v.User
 }
 
-// MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
+// MergeChatMember returns a MergedChatMember struct to simplify working with types in a non-generic world.
 func (v ChatMemberOwner) MergeChatMember() MergedChatMember {
 	return MergedChatMember{
 		Status:      "owner",
@@ -806,6 +823,7 @@ func (v ChatMemberOwner) MergeChatMember() MergedChatMember {
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Status value.
 func (v ChatMemberOwner) MarshalJSON() ([]byte, error) {
 	type alias ChatMemberOwner
 	a := struct {
@@ -858,7 +876,7 @@ func (v ChatMemberRestricted) GetUser() User {
 	return v.User
 }
 
-// MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
+// MergeChatMember returns a MergedChatMember struct to simplify working with types in a non-generic world.
 func (v ChatMemberRestricted) MergeChatMember() MergedChatMember {
 	return MergedChatMember{
 		Status:                "restricted",
@@ -876,6 +894,7 @@ func (v ChatMemberRestricted) MergeChatMember() MergedChatMember {
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Status value.
 func (v ChatMemberRestricted) MarshalJSON() ([]byte, error) {
 	type alias ChatMemberRestricted
 	a := struct {
@@ -908,6 +927,7 @@ type ChatMemberUpdated struct {
 	InviteLink *ChatInviteLink `json:"invite_link,omitempty"`
 }
 
+// UnmarshalJSON is a custom JSON unmarshaller to use the helpers which allow for unmarshalling structs into interfaces.
 func (v *ChatMemberUpdated) UnmarshalJSON(b []byte) error {
 	// All fields in ChatMemberUpdated, with interface fields as json.RawMessage
 	type tmp struct {
@@ -1203,6 +1223,7 @@ type InlineQueryResult interface {
 	MergeInlineQueryResult() MergedInlineQueryResult
 }
 
+// MergedInlineQueryResult is a helper type to simplify interactions with the various InlineQueryResult subtypes.
 type MergedInlineQueryResult struct {
 	// Type of the result, must be audio
 	Type string `json:"type,omitempty"`
@@ -1341,6 +1362,7 @@ func (v MergedInlineQueryResult) GetId() string {
 // MergedInlineQueryResult.inlineQueryResult is a dummy method to avoid interface implementation.
 func (v MergedInlineQueryResult) inlineQueryResult() {}
 
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v MergedInlineQueryResult) MergeInlineQueryResult() MergedInlineQueryResult {
 	return v
 }
@@ -1380,7 +1402,7 @@ func (v InlineQueryResultArticle) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultArticle) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "article",
@@ -1397,6 +1419,7 @@ func (v InlineQueryResultArticle) MergeInlineQueryResult() MergedInlineQueryResu
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultArticle) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultArticle
 	a := struct {
@@ -1448,7 +1471,7 @@ func (v InlineQueryResultAudio) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultAudio) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "audio",
@@ -1465,6 +1488,7 @@ func (v InlineQueryResultAudio) MergeInlineQueryResult() MergedInlineQueryResult
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultAudio) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultAudio
 	a := struct {
@@ -1510,7 +1534,7 @@ func (v InlineQueryResultCachedAudio) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultCachedAudio) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "audio",
@@ -1524,6 +1548,7 @@ func (v InlineQueryResultCachedAudio) MergeInlineQueryResult() MergedInlineQuery
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultCachedAudio) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultCachedAudio
 	a := struct {
@@ -1573,7 +1598,7 @@ func (v InlineQueryResultCachedDocument) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultCachedDocument) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "document",
@@ -1589,6 +1614,7 @@ func (v InlineQueryResultCachedDocument) MergeInlineQueryResult() MergedInlineQu
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultCachedDocument) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultCachedDocument
 	a := struct {
@@ -1635,7 +1661,7 @@ func (v InlineQueryResultCachedGif) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultCachedGif) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "gif",
@@ -1650,6 +1676,7 @@ func (v InlineQueryResultCachedGif) MergeInlineQueryResult() MergedInlineQueryRe
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultCachedGif) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultCachedGif
 	a := struct {
@@ -1696,7 +1723,7 @@ func (v InlineQueryResultCachedMpeg4Gif) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultCachedMpeg4Gif) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "mpeg4_gif",
@@ -1711,6 +1738,7 @@ func (v InlineQueryResultCachedMpeg4Gif) MergeInlineQueryResult() MergedInlineQu
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultCachedMpeg4Gif) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultCachedMpeg4Gif
 	a := struct {
@@ -1759,7 +1787,7 @@ func (v InlineQueryResultCachedPhoto) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultCachedPhoto) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "photo",
@@ -1775,6 +1803,7 @@ func (v InlineQueryResultCachedPhoto) MergeInlineQueryResult() MergedInlineQuery
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultCachedPhoto) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultCachedPhoto
 	a := struct {
@@ -1814,7 +1843,7 @@ func (v InlineQueryResultCachedSticker) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultCachedSticker) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "sticker",
@@ -1825,6 +1854,7 @@ func (v InlineQueryResultCachedSticker) MergeInlineQueryResult() MergedInlineQue
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultCachedSticker) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultCachedSticker
 	a := struct {
@@ -1873,7 +1903,7 @@ func (v InlineQueryResultCachedVideo) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultCachedVideo) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "video",
@@ -1889,6 +1919,7 @@ func (v InlineQueryResultCachedVideo) MergeInlineQueryResult() MergedInlineQuery
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultCachedVideo) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultCachedVideo
 	a := struct {
@@ -1936,7 +1967,7 @@ func (v InlineQueryResultCachedVoice) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultCachedVoice) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "voice",
@@ -1951,6 +1982,7 @@ func (v InlineQueryResultCachedVoice) MergeInlineQueryResult() MergedInlineQuery
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultCachedVoice) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultCachedVoice
 	a := struct {
@@ -2002,7 +2034,7 @@ func (v InlineQueryResultContact) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultContact) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "contact",
@@ -2019,6 +2051,7 @@ func (v InlineQueryResultContact) MergeInlineQueryResult() MergedInlineQueryResu
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultContact) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultContact
 	a := struct {
@@ -2076,7 +2109,7 @@ func (v InlineQueryResultDocument) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultDocument) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "document",
@@ -2096,6 +2129,7 @@ func (v InlineQueryResultDocument) MergeInlineQueryResult() MergedInlineQueryRes
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultDocument) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultDocument
 	a := struct {
@@ -2133,7 +2167,7 @@ func (v InlineQueryResultGame) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultGame) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:          "game",
@@ -2143,6 +2177,7 @@ func (v InlineQueryResultGame) MergeInlineQueryResult() MergedInlineQueryResult 
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultGame) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultGame
 	a := struct {
@@ -2199,7 +2234,7 @@ func (v InlineQueryResultGif) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultGif) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "gif",
@@ -2219,6 +2254,7 @@ func (v InlineQueryResultGif) MergeInlineQueryResult() MergedInlineQueryResult {
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultGif) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultGif
 	a := struct {
@@ -2276,7 +2312,7 @@ func (v InlineQueryResultLocation) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultLocation) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                 "location",
@@ -2296,6 +2332,7 @@ func (v InlineQueryResultLocation) MergeInlineQueryResult() MergedInlineQueryRes
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultLocation) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultLocation
 	a := struct {
@@ -2352,7 +2389,7 @@ func (v InlineQueryResultMpeg4Gif) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultMpeg4Gif) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "mpeg4_gif",
@@ -2372,6 +2409,7 @@ func (v InlineQueryResultMpeg4Gif) MergeInlineQueryResult() MergedInlineQueryRes
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultMpeg4Gif) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultMpeg4Gif
 	a := struct {
@@ -2426,7 +2464,7 @@ func (v InlineQueryResultPhoto) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultPhoto) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "photo",
@@ -2445,6 +2483,7 @@ func (v InlineQueryResultPhoto) MergeInlineQueryResult() MergedInlineQueryResult
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultPhoto) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultPhoto
 	a := struct {
@@ -2504,7 +2543,7 @@ func (v InlineQueryResultVenue) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultVenue) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "venue",
@@ -2525,6 +2564,7 @@ func (v InlineQueryResultVenue) MergeInlineQueryResult() MergedInlineQueryResult
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultVenue) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultVenue
 	a := struct {
@@ -2583,7 +2623,7 @@ func (v InlineQueryResultVideo) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultVideo) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "video",
@@ -2604,6 +2644,7 @@ func (v InlineQueryResultVideo) MergeInlineQueryResult() MergedInlineQueryResult
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultVideo) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultVideo
 	a := struct {
@@ -2653,7 +2694,7 @@ func (v InlineQueryResultVoice) GetId() string {
 	return v.Id
 }
 
-// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with types in a non-generic world.
 func (v InlineQueryResultVoice) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "voice",
@@ -2669,6 +2710,7 @@ func (v InlineQueryResultVoice) MergeInlineQueryResult() MergedInlineQueryResult
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InlineQueryResultVoice) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultVoice
 	a := struct {
@@ -2789,6 +2831,7 @@ type InputMedia interface {
 	MergeInputMedia() MergedInputMedia
 }
 
+// MergedInputMedia is a helper type to simplify interactions with the various InputMedia subtypes.
 type MergedInputMedia struct {
 	// Type of the result, must be animation
 	Type string `json:"type,omitempty"`
@@ -2831,6 +2874,7 @@ func (v MergedInputMedia) GetMedia() InputFile {
 // MergedInputMedia.inputMedia is a dummy method to avoid interface implementation.
 func (v MergedInputMedia) inputMedia() {}
 
+// MergeInputMedia returns a MergedInputMedia struct to simplify working with types in a non-generic world.
 func (v MergedInputMedia) MergeInputMedia() MergedInputMedia {
 	return v
 }
@@ -2888,7 +2932,7 @@ func (v InputMediaAnimation) GetMedia() InputFile {
 	return v.Media
 }
 
-// MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
+// MergeInputMedia returns a MergedInputMedia struct to simplify working with types in a non-generic world.
 func (v InputMediaAnimation) MergeInputMedia() MergedInputMedia {
 	return MergedInputMedia{
 		Type:            "animation",
@@ -2903,6 +2947,7 @@ func (v InputMediaAnimation) MergeInputMedia() MergedInputMedia {
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InputMediaAnimation) MarshalJSON() ([]byte, error) {
 	type alias InputMediaAnimation
 	a := struct {
@@ -2971,7 +3016,7 @@ func (v InputMediaAudio) GetMedia() InputFile {
 	return v.Media
 }
 
-// MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
+// MergeInputMedia returns a MergedInputMedia struct to simplify working with types in a non-generic world.
 func (v InputMediaAudio) MergeInputMedia() MergedInputMedia {
 	return MergedInputMedia{
 		Type:            "audio",
@@ -2986,6 +3031,7 @@ func (v InputMediaAudio) MergeInputMedia() MergedInputMedia {
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InputMediaAudio) MarshalJSON() ([]byte, error) {
 	type alias InputMediaAudio
 	a := struct {
@@ -3050,7 +3096,7 @@ func (v InputMediaDocument) GetMedia() InputFile {
 	return v.Media
 }
 
-// MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
+// MergeInputMedia returns a MergedInputMedia struct to simplify working with types in a non-generic world.
 func (v InputMediaDocument) MergeInputMedia() MergedInputMedia {
 	return MergedInputMedia{
 		Type:                        "document",
@@ -3063,6 +3109,7 @@ func (v InputMediaDocument) MergeInputMedia() MergedInputMedia {
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InputMediaDocument) MarshalJSON() ([]byte, error) {
 	type alias InputMediaDocument
 	a := struct {
@@ -3123,7 +3170,7 @@ func (v InputMediaPhoto) GetMedia() InputFile {
 	return v.Media
 }
 
-// MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
+// MergeInputMedia returns a MergedInputMedia struct to simplify working with types in a non-generic world.
 func (v InputMediaPhoto) MergeInputMedia() MergedInputMedia {
 	return MergedInputMedia{
 		Type:            "photo",
@@ -3134,6 +3181,7 @@ func (v InputMediaPhoto) MergeInputMedia() MergedInputMedia {
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InputMediaPhoto) MarshalJSON() ([]byte, error) {
 	type alias InputMediaPhoto
 	a := struct {
@@ -3204,7 +3252,7 @@ func (v InputMediaVideo) GetMedia() InputFile {
 	return v.Media
 }
 
-// MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
+// MergeInputMedia returns a MergedInputMedia struct to simplify working with types in a non-generic world.
 func (v InputMediaVideo) MergeInputMedia() MergedInputMedia {
 	return MergedInputMedia{
 		Type:              "video",
@@ -3220,6 +3268,7 @@ func (v InputMediaVideo) MergeInputMedia() MergedInputMedia {
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Type value.
 func (v InputMediaVideo) MarshalJSON() ([]byte, error) {
 	type alias InputMediaVideo
 	a := struct {
@@ -3565,6 +3614,7 @@ type PassportElementError interface {
 	MergePassportElementError() MergedPassportElementError
 }
 
+// MergedPassportElementError is a helper type to simplify interactions with the various PassportElementError subtypes.
 type MergedPassportElementError struct {
 	// Error source, must be data
 	Source string `json:"source,omitempty"`
@@ -3602,6 +3652,7 @@ func (v MergedPassportElementError) GetMessage() string {
 // MergedPassportElementError.passportElementError is a dummy method to avoid interface implementation.
 func (v MergedPassportElementError) passportElementError() {}
 
+// MergePassportElementError returns a MergedPassportElementError struct to simplify working with types in a non-generic world.
 func (v MergedPassportElementError) MergePassportElementError() MergedPassportElementError {
 	return v
 }
@@ -3634,7 +3685,7 @@ func (v PassportElementErrorDataField) GetMessage() string {
 	return v.Message
 }
 
-// MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+// MergePassportElementError returns a MergedPassportElementError struct to simplify working with types in a non-generic world.
 func (v PassportElementErrorDataField) MergePassportElementError() MergedPassportElementError {
 	return MergedPassportElementError{
 		Source:    "data",
@@ -3645,6 +3696,7 @@ func (v PassportElementErrorDataField) MergePassportElementError() MergedPasspor
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Source value.
 func (v PassportElementErrorDataField) MarshalJSON() ([]byte, error) {
 	type alias PassportElementErrorDataField
 	a := struct {
@@ -3686,7 +3738,7 @@ func (v PassportElementErrorFile) GetMessage() string {
 	return v.Message
 }
 
-// MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+// MergePassportElementError returns a MergedPassportElementError struct to simplify working with types in a non-generic world.
 func (v PassportElementErrorFile) MergePassportElementError() MergedPassportElementError {
 	return MergedPassportElementError{
 		Source:   "file",
@@ -3696,6 +3748,7 @@ func (v PassportElementErrorFile) MergePassportElementError() MergedPassportElem
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Source value.
 func (v PassportElementErrorFile) MarshalJSON() ([]byte, error) {
 	type alias PassportElementErrorFile
 	a := struct {
@@ -3737,7 +3790,7 @@ func (v PassportElementErrorFiles) GetMessage() string {
 	return v.Message
 }
 
-// MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+// MergePassportElementError returns a MergedPassportElementError struct to simplify working with types in a non-generic world.
 func (v PassportElementErrorFiles) MergePassportElementError() MergedPassportElementError {
 	return MergedPassportElementError{
 		Source:     "files",
@@ -3747,6 +3800,7 @@ func (v PassportElementErrorFiles) MergePassportElementError() MergedPassportEle
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Source value.
 func (v PassportElementErrorFiles) MarshalJSON() ([]byte, error) {
 	type alias PassportElementErrorFiles
 	a := struct {
@@ -3788,7 +3842,7 @@ func (v PassportElementErrorFrontSide) GetMessage() string {
 	return v.Message
 }
 
-// MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+// MergePassportElementError returns a MergedPassportElementError struct to simplify working with types in a non-generic world.
 func (v PassportElementErrorFrontSide) MergePassportElementError() MergedPassportElementError {
 	return MergedPassportElementError{
 		Source:   "front_side",
@@ -3798,6 +3852,7 @@ func (v PassportElementErrorFrontSide) MergePassportElementError() MergedPasspor
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Source value.
 func (v PassportElementErrorFrontSide) MarshalJSON() ([]byte, error) {
 	type alias PassportElementErrorFrontSide
 	a := struct {
@@ -3839,7 +3894,7 @@ func (v PassportElementErrorReverseSide) GetMessage() string {
 	return v.Message
 }
 
-// MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+// MergePassportElementError returns a MergedPassportElementError struct to simplify working with types in a non-generic world.
 func (v PassportElementErrorReverseSide) MergePassportElementError() MergedPassportElementError {
 	return MergedPassportElementError{
 		Source:   "reverse_side",
@@ -3849,6 +3904,7 @@ func (v PassportElementErrorReverseSide) MergePassportElementError() MergedPassp
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Source value.
 func (v PassportElementErrorReverseSide) MarshalJSON() ([]byte, error) {
 	type alias PassportElementErrorReverseSide
 	a := struct {
@@ -3890,7 +3946,7 @@ func (v PassportElementErrorSelfie) GetMessage() string {
 	return v.Message
 }
 
-// MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+// MergePassportElementError returns a MergedPassportElementError struct to simplify working with types in a non-generic world.
 func (v PassportElementErrorSelfie) MergePassportElementError() MergedPassportElementError {
 	return MergedPassportElementError{
 		Source:   "selfie",
@@ -3900,6 +3956,7 @@ func (v PassportElementErrorSelfie) MergePassportElementError() MergedPassportEl
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Source value.
 func (v PassportElementErrorSelfie) MarshalJSON() ([]byte, error) {
 	type alias PassportElementErrorSelfie
 	a := struct {
@@ -3941,7 +3998,7 @@ func (v PassportElementErrorTranslationFile) GetMessage() string {
 	return v.Message
 }
 
-// MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+// MergePassportElementError returns a MergedPassportElementError struct to simplify working with types in a non-generic world.
 func (v PassportElementErrorTranslationFile) MergePassportElementError() MergedPassportElementError {
 	return MergedPassportElementError{
 		Source:   "translation_file",
@@ -3951,6 +4008,7 @@ func (v PassportElementErrorTranslationFile) MergePassportElementError() MergedP
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Source value.
 func (v PassportElementErrorTranslationFile) MarshalJSON() ([]byte, error) {
 	type alias PassportElementErrorTranslationFile
 	a := struct {
@@ -3992,7 +4050,7 @@ func (v PassportElementErrorTranslationFiles) GetMessage() string {
 	return v.Message
 }
 
-// MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+// MergePassportElementError returns a MergedPassportElementError struct to simplify working with types in a non-generic world.
 func (v PassportElementErrorTranslationFiles) MergePassportElementError() MergedPassportElementError {
 	return MergedPassportElementError{
 		Source:     "translation_files",
@@ -4002,6 +4060,7 @@ func (v PassportElementErrorTranslationFiles) MergePassportElementError() Merged
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Source value.
 func (v PassportElementErrorTranslationFiles) MarshalJSON() ([]byte, error) {
 	type alias PassportElementErrorTranslationFiles
 	a := struct {
@@ -4043,7 +4102,7 @@ func (v PassportElementErrorUnspecified) GetMessage() string {
 	return v.Message
 }
 
-// MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+// MergePassportElementError returns a MergedPassportElementError struct to simplify working with types in a non-generic world.
 func (v PassportElementErrorUnspecified) MergePassportElementError() MergedPassportElementError {
 	return MergedPassportElementError{
 		Source:      "unspecified",
@@ -4053,6 +4112,7 @@ func (v PassportElementErrorUnspecified) MergePassportElementError() MergedPassp
 	}
 }
 
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the Source value.
 func (v PassportElementErrorUnspecified) MarshalJSON() ([]byte, error) {
 	type alias PassportElementErrorUnspecified
 	a := struct {

--- a/gen_types.go
+++ b/gen_types.go
@@ -2705,8 +2705,6 @@ type PassportElementError interface {
 // PassportElementErrorDataField Represents an issue in one of the data fields that was provided by the user. The error is considered resolved when the field's value changes.
 // https://core.telegram.org/bots/api#passportelementerrordatafield
 type PassportElementErrorDataField struct {
-	// Error source, must be data
-	Source string `json:"source,omitempty"`
 	// The section of the user's Telegram Passport which has the error, one of "personal_details", "passport", "driver_license", "identity_card", "internal_passport", "address"
 	Type string `json:"type,omitempty"`
 	// Name of the data field which has the error
@@ -2748,8 +2746,6 @@ func (v PassportElementErrorDataField) PassportElementError() ([]byte, error) {
 // PassportElementErrorFile Represents an issue with a document scan. The error is considered resolved when the file with the document scan changes.
 // https://core.telegram.org/bots/api#passportelementerrorfile
 type PassportElementErrorFile struct {
-	// Error source, must be file
-	Source string `json:"source,omitempty"`
 	// The section of the user's Telegram Passport which has the issue, one of "utility_bill", "bank_statement", "rental_agreement", "passport_registration", "temporary_registration"
 	Type string `json:"type,omitempty"`
 	// Base64-encoded file hash
@@ -2789,8 +2785,6 @@ func (v PassportElementErrorFile) PassportElementError() ([]byte, error) {
 // PassportElementErrorFiles Represents an issue with a list of scans. The error is considered resolved when the list of files containing the scans changes.
 // https://core.telegram.org/bots/api#passportelementerrorfiles
 type PassportElementErrorFiles struct {
-	// Error source, must be files
-	Source string `json:"source,omitempty"`
 	// The section of the user's Telegram Passport which has the issue, one of "utility_bill", "bank_statement", "rental_agreement", "passport_registration", "temporary_registration"
 	Type string `json:"type,omitempty"`
 	// List of base64-encoded file hashes
@@ -2830,8 +2824,6 @@ func (v PassportElementErrorFiles) PassportElementError() ([]byte, error) {
 // PassportElementErrorFrontSide Represents an issue with the front side of a document. The error is considered resolved when the file with the front side of the document changes.
 // https://core.telegram.org/bots/api#passportelementerrorfrontside
 type PassportElementErrorFrontSide struct {
-	// Error source, must be front_side
-	Source string `json:"source,omitempty"`
 	// The section of the user's Telegram Passport which has the issue, one of "passport", "driver_license", "identity_card", "internal_passport"
 	Type string `json:"type,omitempty"`
 	// Base64-encoded hash of the file with the front side of the document
@@ -2871,8 +2863,6 @@ func (v PassportElementErrorFrontSide) PassportElementError() ([]byte, error) {
 // PassportElementErrorReverseSide Represents an issue with the reverse side of a document. The error is considered resolved when the file with reverse side of the document changes.
 // https://core.telegram.org/bots/api#passportelementerrorreverseside
 type PassportElementErrorReverseSide struct {
-	// Error source, must be reverse_side
-	Source string `json:"source,omitempty"`
 	// The section of the user's Telegram Passport which has the issue, one of "driver_license", "identity_card"
 	Type string `json:"type,omitempty"`
 	// Base64-encoded hash of the file with the reverse side of the document
@@ -2912,8 +2902,6 @@ func (v PassportElementErrorReverseSide) PassportElementError() ([]byte, error) 
 // PassportElementErrorSelfie Represents an issue with the selfie with a document. The error is considered resolved when the file with the selfie changes.
 // https://core.telegram.org/bots/api#passportelementerrorselfie
 type PassportElementErrorSelfie struct {
-	// Error source, must be selfie
-	Source string `json:"source,omitempty"`
 	// The section of the user's Telegram Passport which has the issue, one of "passport", "driver_license", "identity_card", "internal_passport"
 	Type string `json:"type,omitempty"`
 	// Base64-encoded hash of the file with the selfie
@@ -2953,8 +2941,6 @@ func (v PassportElementErrorSelfie) PassportElementError() ([]byte, error) {
 // PassportElementErrorTranslationFile Represents an issue with one of the files that constitute the translation of a document. The error is considered resolved when the file changes.
 // https://core.telegram.org/bots/api#passportelementerrortranslationfile
 type PassportElementErrorTranslationFile struct {
-	// Error source, must be translation_file
-	Source string `json:"source,omitempty"`
 	// Type of element of the user's Telegram Passport which has the issue, one of "passport", "driver_license", "identity_card", "internal_passport", "utility_bill", "bank_statement", "rental_agreement", "passport_registration", "temporary_registration"
 	Type string `json:"type,omitempty"`
 	// Base64-encoded file hash
@@ -2994,8 +2980,6 @@ func (v PassportElementErrorTranslationFile) PassportElementError() ([]byte, err
 // PassportElementErrorTranslationFiles Represents an issue with the translated version of a document. The error is considered resolved when a file with the document translation change.
 // https://core.telegram.org/bots/api#passportelementerrortranslationfiles
 type PassportElementErrorTranslationFiles struct {
-	// Error source, must be translation_files
-	Source string `json:"source,omitempty"`
 	// Type of element of the user's Telegram Passport which has the issue, one of "passport", "driver_license", "identity_card", "internal_passport", "utility_bill", "bank_statement", "rental_agreement", "passport_registration", "temporary_registration"
 	Type string `json:"type,omitempty"`
 	// List of base64-encoded file hashes
@@ -3035,8 +3019,6 @@ func (v PassportElementErrorTranslationFiles) PassportElementError() ([]byte, er
 // PassportElementErrorUnspecified Represents an issue in an unspecified place. The error is considered resolved when new data is added.
 // https://core.telegram.org/bots/api#passportelementerrorunspecified
 type PassportElementErrorUnspecified struct {
-	// Error source, must be unspecified
-	Source string `json:"source,omitempty"`
 	// Type of element of the user's Telegram Passport which has the issue
 	Type string `json:"type,omitempty"`
 	// Base64-encoded element hash

--- a/gen_types.go
+++ b/gen_types.go
@@ -5,7 +5,6 @@ package gotgbot
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 )
@@ -428,7 +427,7 @@ func unmarshalChatMember(d json.RawMessage) (ChatMember, error) {
 		}
 		return s, nil
 	}
-	return nil, errors.New("failed to unmarshal: unknown interface with Status " + t.Status)
+	return nil, fmt.Errorf("unknown interface with Status %v", t.Status)
 }
 
 // ChatMemberAdministrator Represents a chat member that has some additional privileges.

--- a/gen_types.go
+++ b/gen_types.go
@@ -426,7 +426,6 @@ func unmarshalChatMember(d json.RawMessage) (ChatMember, error) {
 			return nil, err
 		}
 		return s, nil
-
 	}
 	return nil, errors.New("failed to unmarshal: unknown interface with Status " + t.Status)
 }

--- a/gen_types.go
+++ b/gen_types.go
@@ -68,6 +68,188 @@ type BotCommand struct {
 	Description string `json:"description,omitempty"`
 }
 
+// BotCommandScope This object represents the scope to which bot commands are applied. Currently, the following 7 scopes are supported:
+// - BotCommandScopeDefault
+// - BotCommandScopeAllPrivateChats
+// - BotCommandScopeAllGroupChats
+// - BotCommandScopeAllChatAdministrators
+// - BotCommandScopeChat
+// - BotCommandScopeChatAdministrators
+// - BotCommandScopeChatMember
+// https://core.telegram.org/bots/api#botcommandscope
+type BotCommandScope interface {
+	BotCommandScope() ([]byte, error)
+}
+
+// BotCommandScopeAllChatAdministrators Represents the scope of bot commands, covering all group and supergroup chat administrators.
+// https://core.telegram.org/bots/api#botcommandscopeallchatadministrators
+type BotCommandScopeAllChatAdministrators struct {
+	// Scope type, must be all_chat_administrators
+	Type string `json:"type,omitempty"`
+}
+
+func (v BotCommandScopeAllChatAdministrators) MarshalJSON() ([]byte, error) {
+	type alias BotCommandScopeAllChatAdministrators
+	a := struct {
+		Type string `json:"type"`
+		alias
+	}{
+		Type:  "all_chat_administrators",
+		alias: (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
+func (v BotCommandScopeAllChatAdministrators) BotCommandScope() ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// BotCommandScopeAllGroupChats Represents the scope of bot commands, covering all group and supergroup chats.
+// https://core.telegram.org/bots/api#botcommandscopeallgroupchats
+type BotCommandScopeAllGroupChats struct {
+	// Scope type, must be all_group_chats
+	Type string `json:"type,omitempty"`
+}
+
+func (v BotCommandScopeAllGroupChats) MarshalJSON() ([]byte, error) {
+	type alias BotCommandScopeAllGroupChats
+	a := struct {
+		Type string `json:"type"`
+		alias
+	}{
+		Type:  "all_group_chats",
+		alias: (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
+func (v BotCommandScopeAllGroupChats) BotCommandScope() ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// BotCommandScopeAllPrivateChats Represents the scope of bot commands, covering all private chats.
+// https://core.telegram.org/bots/api#botcommandscopeallprivatechats
+type BotCommandScopeAllPrivateChats struct {
+	// Scope type, must be all_private_chats
+	Type string `json:"type,omitempty"`
+}
+
+func (v BotCommandScopeAllPrivateChats) MarshalJSON() ([]byte, error) {
+	type alias BotCommandScopeAllPrivateChats
+	a := struct {
+		Type string `json:"type"`
+		alias
+	}{
+		Type:  "all_private_chats",
+		alias: (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
+func (v BotCommandScopeAllPrivateChats) BotCommandScope() ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// BotCommandScopeChat Represents the scope of bot commands, covering a specific chat.
+// https://core.telegram.org/bots/api#botcommandscopechat
+type BotCommandScopeChat struct {
+	// Scope type, must be chat
+	Type string `json:"type,omitempty"`
+	// Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+	ChatId int64 `json:"chat_id,omitempty"`
+}
+
+func (v BotCommandScopeChat) MarshalJSON() ([]byte, error) {
+	type alias BotCommandScopeChat
+	a := struct {
+		Type string `json:"type"`
+		alias
+	}{
+		Type:  "chat",
+		alias: (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
+func (v BotCommandScopeChat) BotCommandScope() ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// BotCommandScopeChatAdministrators Represents the scope of bot commands, covering all administrators of a specific group or supergroup chat.
+// https://core.telegram.org/bots/api#botcommandscopechatadministrators
+type BotCommandScopeChatAdministrators struct {
+	// Scope type, must be chat_administrators
+	Type string `json:"type,omitempty"`
+	// Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+	ChatId int64 `json:"chat_id,omitempty"`
+}
+
+func (v BotCommandScopeChatAdministrators) MarshalJSON() ([]byte, error) {
+	type alias BotCommandScopeChatAdministrators
+	a := struct {
+		Type string `json:"type"`
+		alias
+	}{
+		Type:  "chat_administrators",
+		alias: (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
+func (v BotCommandScopeChatAdministrators) BotCommandScope() ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// BotCommandScopeChatMember Represents the scope of bot commands, covering a specific member of a group or supergroup chat.
+// https://core.telegram.org/bots/api#botcommandscopechatmember
+type BotCommandScopeChatMember struct {
+	// Scope type, must be chat_member
+	Type string `json:"type,omitempty"`
+	// Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
+	ChatId int64 `json:"chat_id,omitempty"`
+	// Unique identifier of the target user
+	UserId int64 `json:"user_id,omitempty"`
+}
+
+func (v BotCommandScopeChatMember) MarshalJSON() ([]byte, error) {
+	type alias BotCommandScopeChatMember
+	a := struct {
+		Type string `json:"type"`
+		alias
+	}{
+		Type:  "chat_member",
+		alias: (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
+func (v BotCommandScopeChatMember) BotCommandScope() ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// BotCommandScopeDefault Represents the default scope of bot commands. Default commands are used if no commands with a narrower scope are specified for the user.
+// https://core.telegram.org/bots/api#botcommandscopedefault
+type BotCommandScopeDefault struct {
+	// Scope type, must be default
+	Type string `json:"type,omitempty"`
+}
+
+func (v BotCommandScopeDefault) MarshalJSON() ([]byte, error) {
+	type alias BotCommandScopeDefault
+	a := struct {
+		Type string `json:"type"`
+		alias
+	}{
+		Type:  "default",
+		alias: (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
+func (v BotCommandScopeDefault) BotCommandScope() ([]byte, error) {
+	return json.Marshal(v)
+}
+
 // CallbackGame A placeholder, currently holds no information. Use BotFather to set up your game.
 // https://core.telegram.org/bots/api#callbackgame
 type CallbackGame interface{}
@@ -158,53 +340,218 @@ type ChatLocation struct {
 	Address string `json:"address,omitempty"`
 }
 
-// ChatMember This object contains information about one member of a chat.
+// ChatMember This object contains information about one member of a chat. Currently, the following 6 types of chat members are supported:
+// - ChatMemberOwner
+// - ChatMemberAdministrator
+// - ChatMemberMember
+// - ChatMemberRestricted
+// - ChatMemberLeft
+// - ChatMemberBanned
 // https://core.telegram.org/bots/api#chatmember
-type ChatMember struct {
+type ChatMember interface {
+	ChatMember() ([]byte, error)
+}
+
+// ChatMemberAdministrator Represents a chat member that has some additional privileges.
+// https://core.telegram.org/bots/api#chatmemberadministrator
+type ChatMemberAdministrator struct {
+	// The member's status in the chat, always "administrator"
+	Status string `json:"status,omitempty"`
 	// Information about the user
 	User User `json:"user,omitempty"`
-	// The member's status in the chat. Can be "creator", "administrator", "member", "restricted", "left" or "kicked"
-	Status string `json:"status,omitempty"`
-	// Optional. Owner and administrators only. Custom title for this user
-	CustomTitle string `json:"custom_title,omitempty"`
-	// Optional. Owner and administrators only. True, if the user's presence in the chat is hidden
-	IsAnonymous bool `json:"is_anonymous,omitempty"`
-	// Optional. Administrators only. True, if the bot is allowed to edit administrator privileges of that user
+	// True, if the bot is allowed to edit administrator privileges of that user
 	CanBeEdited bool `json:"can_be_edited,omitempty"`
-	// Optional. Administrators only. True, if the administrator can access the chat event log, chat statistics, message statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode. Implied by any other administrator privilege
+	// Custom title for this user
+	CustomTitle string `json:"custom_title,omitempty"`
+	// True, if the user's presence in the chat is hidden
+	IsAnonymous bool `json:"is_anonymous,omitempty"`
+	// True, if the administrator can access the chat event log, chat statistics, message statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode. Implied by any other administrator privilege
 	CanManageChat bool `json:"can_manage_chat,omitempty"`
-	// Optional. Administrators only. True, if the administrator can post in the channel; channels only
+	// True, if the administrator can post in the channel; channels only
 	CanPostMessages bool `json:"can_post_messages,omitempty"`
-	// Optional. Administrators only. True, if the administrator can edit messages of other users and can pin messages; channels only
+	// True, if the administrator can edit messages of other users and can pin messages; channels only
 	CanEditMessages bool `json:"can_edit_messages,omitempty"`
-	// Optional. Administrators only. True, if the administrator can delete messages of other users
+	// True, if the administrator can delete messages of other users
 	CanDeleteMessages bool `json:"can_delete_messages,omitempty"`
-	// Optional. Administrators only. True, if the administrator can manage voice chats
+	// True, if the administrator can manage voice chats
 	CanManageVoiceChats bool `json:"can_manage_voice_chats,omitempty"`
-	// Optional. Administrators only. True, if the administrator can restrict, ban or unban chat members
+	// True, if the administrator can restrict, ban or unban chat members
 	CanRestrictMembers bool `json:"can_restrict_members,omitempty"`
-	// Optional. Administrators only. True, if the administrator can add new administrators with a subset of their own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by the user)
+	// True, if the administrator can add new administrators with a subset of their own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by the user)
 	CanPromoteMembers bool `json:"can_promote_members,omitempty"`
-	// Optional. Administrators and restricted only. True, if the user is allowed to change the chat title, photo and other settings
+	// True, if the user is allowed to change the chat title, photo and other settings
 	CanChangeInfo bool `json:"can_change_info,omitempty"`
-	// Optional. Administrators and restricted only. True, if the user is allowed to invite new users to the chat
+	// True, if the user is allowed to invite new users to the chat
 	CanInviteUsers bool `json:"can_invite_users,omitempty"`
-	// Optional. Administrators and restricted only. True, if the user is allowed to pin messages; groups and supergroups only
+	// True, if the user is allowed to pin messages; groups and supergroups only
 	CanPinMessages bool `json:"can_pin_messages,omitempty"`
-	// Optional. Restricted only. True, if the user is a member of the chat at the moment of the request
-	IsMember bool `json:"is_member,omitempty"`
-	// Optional. Restricted only. True, if the user is allowed to send text messages, contacts, locations and venues
-	CanSendMessages bool `json:"can_send_messages,omitempty"`
-	// Optional. Restricted only. True, if the user is allowed to send audios, documents, photos, videos, video notes and voice notes
-	CanSendMediaMessages bool `json:"can_send_media_messages,omitempty"`
-	// Optional. Restricted only. True, if the user is allowed to send polls
-	CanSendPolls bool `json:"can_send_polls,omitempty"`
-	// Optional. Restricted only. True, if the user is allowed to send animations, games, stickers and use inline bots
-	CanSendOtherMessages bool `json:"can_send_other_messages,omitempty"`
-	// Optional. Restricted only. True, if the user is allowed to add web page previews to their messages
-	CanAddWebPagePreviews bool `json:"can_add_web_page_previews,omitempty"`
-	// Optional. Restricted and kicked only. Date when restrictions will be lifted for this user; unix time
+}
+
+func (v ChatMemberAdministrator) MarshalJSON() ([]byte, error) {
+	type alias ChatMemberAdministrator
+	a := struct {
+		Type string `json:"type"`
+		alias
+	}{
+		Type:  "administrator",
+		alias: (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
+func (v ChatMemberAdministrator) ChatMember() ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// ChatMemberBanned Represents a chat member that was banned in the chat and can't return to the chat or view chat messages.
+// https://core.telegram.org/bots/api#chatmemberbanned
+type ChatMemberBanned struct {
+	// The member's status in the chat, always "kicked"
+	Status string `json:"status,omitempty"`
+	// Information about the user
+	User User `json:"user,omitempty"`
+	// Date when restrictions will be lifted for this user; unix time
 	UntilDate int64 `json:"until_date,omitempty"`
+}
+
+func (v ChatMemberBanned) MarshalJSON() ([]byte, error) {
+	type alias ChatMemberBanned
+	a := struct {
+		Type string `json:"type"`
+		alias
+	}{
+		Type:  "banned",
+		alias: (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
+func (v ChatMemberBanned) ChatMember() ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// ChatMemberLeft Represents a chat member that isn't currently a member of the chat, but may join it themselves.
+// https://core.telegram.org/bots/api#chatmemberleft
+type ChatMemberLeft struct {
+	// The member's status in the chat, always "left"
+	Status string `json:"status,omitempty"`
+	// Information about the user
+	User User `json:"user,omitempty"`
+}
+
+func (v ChatMemberLeft) MarshalJSON() ([]byte, error) {
+	type alias ChatMemberLeft
+	a := struct {
+		Type string `json:"type"`
+		alias
+	}{
+		Type:  "left",
+		alias: (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
+func (v ChatMemberLeft) ChatMember() ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// ChatMemberMember Represents a chat member that has no additional privileges or restrictions.
+// https://core.telegram.org/bots/api#chatmembermember
+type ChatMemberMember struct {
+	// The member's status in the chat, always "member"
+	Status string `json:"status,omitempty"`
+	// Information about the user
+	User User `json:"user,omitempty"`
+}
+
+func (v ChatMemberMember) MarshalJSON() ([]byte, error) {
+	type alias ChatMemberMember
+	a := struct {
+		Type string `json:"type"`
+		alias
+	}{
+		Type:  "member",
+		alias: (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
+func (v ChatMemberMember) ChatMember() ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// ChatMemberOwner Represents a chat member that owns the chat and has all administrator privileges.
+// https://core.telegram.org/bots/api#chatmemberowner
+type ChatMemberOwner struct {
+	// The member's status in the chat, always "creator"
+	Status string `json:"status,omitempty"`
+	// Information about the user
+	User User `json:"user,omitempty"`
+	// Custom title for this user
+	CustomTitle string `json:"custom_title,omitempty"`
+	// True, if the user's presence in the chat is hidden
+	IsAnonymous bool `json:"is_anonymous,omitempty"`
+}
+
+func (v ChatMemberOwner) MarshalJSON() ([]byte, error) {
+	type alias ChatMemberOwner
+	a := struct {
+		Type string `json:"type"`
+		alias
+	}{
+		Type:  "owner",
+		alias: (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
+func (v ChatMemberOwner) ChatMember() ([]byte, error) {
+	return json.Marshal(v)
+}
+
+// ChatMemberRestricted Represents a chat member that is under certain restrictions in the chat. Supergroups only.
+// https://core.telegram.org/bots/api#chatmemberrestricted
+type ChatMemberRestricted struct {
+	// The member's status in the chat, always "restricted"
+	Status string `json:"status,omitempty"`
+	// Information about the user
+	User User `json:"user,omitempty"`
+	// True, if the user is a member of the chat at the moment of the request
+	IsMember bool `json:"is_member,omitempty"`
+	// True, if the user is allowed to change the chat title, photo and other settings
+	CanChangeInfo bool `json:"can_change_info,omitempty"`
+	// True, if the user is allowed to invite new users to the chat
+	CanInviteUsers bool `json:"can_invite_users,omitempty"`
+	// True, if the user is allowed to pin messages; groups and supergroups only
+	CanPinMessages bool `json:"can_pin_messages,omitempty"`
+	// True, if the user is allowed to send text messages, contacts, locations and venues
+	CanSendMessages bool `json:"can_send_messages,omitempty"`
+	// True, if the user is allowed to send audios, documents, photos, videos, video notes and voice notes
+	CanSendMediaMessages bool `json:"can_send_media_messages,omitempty"`
+	// True, if the user is allowed to send polls
+	CanSendPolls bool `json:"can_send_polls,omitempty"`
+	// True, if the user is allowed to send animations, games, stickers and use inline bots
+	CanSendOtherMessages bool `json:"can_send_other_messages,omitempty"`
+	// True, if the user is allowed to add web page previews to their messages
+	CanAddWebPagePreviews bool `json:"can_add_web_page_previews,omitempty"`
+	// Date when restrictions will be lifted for this user; unix time
+	UntilDate int64 `json:"until_date,omitempty"`
+}
+
+func (v ChatMemberRestricted) MarshalJSON() ([]byte, error) {
+	type alias ChatMemberRestricted
+	a := struct {
+		Type string `json:"type"`
+		alias
+	}{
+		Type:  "restricted",
+		alias: (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
+func (v ChatMemberRestricted) ChatMember() ([]byte, error) {
+	return json.Marshal(v)
 }
 
 // ChatMemberUpdated This object represents changes in the status of a chat member.
@@ -369,6 +716,8 @@ type File struct {
 type ForceReply struct {
 	// Shows reply interface to the user, as if they manually selected the bot's message and tapped 'Reply'
 	ForceReply bool `json:"force_reply,omitempty"`
+	// Optional. The placeholder to be shown in the input field when the reply is active; 1-64 characters
+	InputFieldPlaceholder string `json:"input_field_placeholder,omitempty"`
 	// Optional. Use this parameter if you want to force reply from specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has reply_to_message_id), sender of the original message.
 	Selective bool `json:"selective,omitempty"`
 }
@@ -457,6 +806,26 @@ type InlineQuery struct {
 }
 
 // InlineQueryResult This object represents one result of an inline query. Telegram clients currently support results of the following 20 types:
+// - InlineQueryResultCachedAudio
+// - InlineQueryResultCachedDocument
+// - InlineQueryResultCachedGif
+// - InlineQueryResultCachedMpeg4Gif
+// - InlineQueryResultCachedPhoto
+// - InlineQueryResultCachedSticker
+// - InlineQueryResultCachedVideo
+// - InlineQueryResultCachedVoice
+// - InlineQueryResultArticle
+// - InlineQueryResultAudio
+// - InlineQueryResultContact
+// - InlineQueryResultGame
+// - InlineQueryResultDocument
+// - InlineQueryResultGif
+// - InlineQueryResultLocation
+// - InlineQueryResultMpeg4Gif
+// - InlineQueryResultPhoto
+// - InlineQueryResultVenue
+// - InlineQueryResultVideo
+// - InlineQueryResultVoice
 // Note: All URLs passed in inline query results will be available to end users and therefore must be assumed to be public.
 // https://core.telegram.org/bots/api#inlinequeryresult
 type InlineQueryResult interface {
@@ -1304,10 +1673,6 @@ func (v InputContactMessageContent) InputMessageContent() ([]byte, error) {
 }
 
 // InputFile This object represents the contents of a file to be uploaded. Must be posted using multipart/form-data in the usual way that files are uploaded via the browser.
-// There are three ways to send files (photos, stickers, audio, media, etc.):
-// Sending by file_id
-// Sending by URL
-// Objects and methods used in the inline mode are described in the Inline mode section.
 // https://core.telegram.org/bots/api#inputfile
 type InputFile interface{}
 
@@ -1382,6 +1747,11 @@ func (v InputLocationMessageContent) InputMessageContent() ([]byte, error) {
 }
 
 // InputMedia This object represents the content of a media message to be sent. It should be one of
+// - InputMediaAnimation
+// - InputMediaDocument
+// - InputMediaAudio
+// - InputMediaPhoto
+// - InputMediaVideo
 // https://core.telegram.org/bots/api#inputmedia
 type InputMedia interface {
 	InputMediaParams(string, map[string]NamedReader) ([]byte, error)
@@ -1653,6 +2023,11 @@ func (v InputMediaVideo) InputMediaParams(mediaName string, data map[string]Name
 }
 
 // InputMessageContent This object represents the content of a message to be sent as a result of an inline query. Telegram clients currently support the following 5 types:
+// - InputTextMessageContent
+// - InputLocationMessageContent
+// - InputVenueMessageContent
+// - InputContactMessageContent
+// - InputInvoiceMessageContent
 // https://core.telegram.org/bots/api#inputmessagecontent
 type InputMessageContent interface {
 	InputMessageContent() ([]byte, error)
@@ -1960,6 +2335,15 @@ type PassportData struct {
 }
 
 // PassportElementError This object represents an error in the Telegram Passport element which was submitted that should be resolved by the user. It should be one of:
+// - PassportElementErrorDataField
+// - PassportElementErrorFrontSide
+// - PassportElementErrorReverseSide
+// - PassportElementErrorSelfie
+// - PassportElementErrorFile
+// - PassportElementErrorFiles
+// - PassportElementErrorTranslationFile
+// - PassportElementErrorTranslationFiles
+// - PassportElementErrorUnspecified
 // https://core.telegram.org/bots/api#passportelementerror
 type PassportElementError interface {
 	PassportElementError() ([]byte, error)
@@ -2238,6 +2622,8 @@ type ReplyKeyboardMarkup struct {
 	ResizeKeyboard bool `json:"resize_keyboard,omitempty"`
 	// Optional. Requests clients to hide the keyboard as soon as it's been used. The keyboard will still be available, but clients will automatically display the usual letter-keyboard in the chat – the user can press a special button in the input field to see the custom keyboard again. Defaults to false.
 	OneTimeKeyboard bool `json:"one_time_keyboard,omitempty"`
+	// Optional. The placeholder to be shown in the input field when the keyboard is active; 1-64 characters
+	InputFieldPlaceholder string `json:"input_field_placeholder,omitempty"`
 	// Optional. Use this parameter if you want to show the keyboard to specific users only. Targets: 1) users that are @mentioned in the text of the Message object; 2) if the bot's message is a reply (has reply_to_message_id), sender of the original message.Example: A user requests to change the bot's language, bot replies to the request with a keyboard to select the new language. Other users in the group don't see the keyboard.
 	Selective bool `json:"selective,omitempty"`
 }

--- a/gen_types.go
+++ b/gen_types.go
@@ -2716,7 +2716,7 @@ type PassportElementErrorDataField struct {
 }
 
 func (v PassportElementErrorDataField) GetSource() string {
-	return "data_field"
+	return "data"
 }
 
 func (v PassportElementErrorDataField) GetType() string {
@@ -2733,7 +2733,7 @@ func (v PassportElementErrorDataField) MarshalJSON() ([]byte, error) {
 		Source string `json:"source"`
 		alias
 	}{
-		Source: "data_field",
+		Source: "data",
 		alias:  (alias)(v),
 	}
 	return json.Marshal(a)

--- a/gen_types.go
+++ b/gen_types.go
@@ -80,6 +80,17 @@ type BotCommand struct {
 type BotCommandScope interface {
 	GetType() string
 	BotCommandScope() ([]byte, error)
+	// MergeBotCommandScope returns a MergedBotCommandScope struct to simplify working with complex telegram types in a non-generic world.
+	MergeBotCommandScope() MergedBotCommandScope
+}
+
+type MergedBotCommandScope struct {
+	// Scope type, must be default
+	Type string `json:"type,omitempty"`
+	// Optional. Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername) (Only for chat, chat_administrators, chat_member)
+	ChatId int64 `json:"chat_id,omitempty"`
+	// Optional. Unique identifier of the target user (Only for chat_member)
+	UserId int64 `json:"user_id,omitempty"`
 }
 
 // BotCommandScopeAllChatAdministrators Represents the scope of bot commands, covering all group and supergroup chat administrators.
@@ -88,6 +99,13 @@ type BotCommandScopeAllChatAdministrators struct{}
 
 func (v BotCommandScopeAllChatAdministrators) GetType() string {
 	return "all_chat_administrators"
+}
+
+// BotCommandScopeAllChatAdministrators.MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+func (v BotCommandScopeAllChatAdministrators) MergeBotCommandScope() MergedBotCommandScope {
+	return MergedBotCommandScope{
+		Type: "all_chat_administrators",
+	}
 }
 
 func (v BotCommandScopeAllChatAdministrators) MarshalJSON() ([]byte, error) {
@@ -114,6 +132,13 @@ func (v BotCommandScopeAllGroupChats) GetType() string {
 	return "all_group_chats"
 }
 
+// BotCommandScopeAllGroupChats.MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+func (v BotCommandScopeAllGroupChats) MergeBotCommandScope() MergedBotCommandScope {
+	return MergedBotCommandScope{
+		Type: "all_group_chats",
+	}
+}
+
 func (v BotCommandScopeAllGroupChats) MarshalJSON() ([]byte, error) {
 	type alias BotCommandScopeAllGroupChats
 	a := struct {
@@ -136,6 +161,13 @@ type BotCommandScopeAllPrivateChats struct{}
 
 func (v BotCommandScopeAllPrivateChats) GetType() string {
 	return "all_private_chats"
+}
+
+// BotCommandScopeAllPrivateChats.MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+func (v BotCommandScopeAllPrivateChats) MergeBotCommandScope() MergedBotCommandScope {
+	return MergedBotCommandScope{
+		Type: "all_private_chats",
+	}
 }
 
 func (v BotCommandScopeAllPrivateChats) MarshalJSON() ([]byte, error) {
@@ -165,6 +197,14 @@ func (v BotCommandScopeChat) GetType() string {
 	return "chat"
 }
 
+// BotCommandScopeChat.MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+func (v BotCommandScopeChat) MergeBotCommandScope() MergedBotCommandScope {
+	return MergedBotCommandScope{
+		Type:   "chat",
+		ChatId: v.ChatId,
+	}
+}
+
 func (v BotCommandScopeChat) MarshalJSON() ([]byte, error) {
 	type alias BotCommandScopeChat
 	a := struct {
@@ -190,6 +230,14 @@ type BotCommandScopeChatAdministrators struct {
 
 func (v BotCommandScopeChatAdministrators) GetType() string {
 	return "chat_administrators"
+}
+
+// BotCommandScopeChatAdministrators.MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+func (v BotCommandScopeChatAdministrators) MergeBotCommandScope() MergedBotCommandScope {
+	return MergedBotCommandScope{
+		Type:   "chat_administrators",
+		ChatId: v.ChatId,
+	}
 }
 
 func (v BotCommandScopeChatAdministrators) MarshalJSON() ([]byte, error) {
@@ -221,6 +269,15 @@ func (v BotCommandScopeChatMember) GetType() string {
 	return "chat_member"
 }
 
+// BotCommandScopeChatMember.MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+func (v BotCommandScopeChatMember) MergeBotCommandScope() MergedBotCommandScope {
+	return MergedBotCommandScope{
+		Type:   "chat_member",
+		ChatId: v.ChatId,
+		UserId: v.UserId,
+	}
+}
+
 func (v BotCommandScopeChatMember) MarshalJSON() ([]byte, error) {
 	type alias BotCommandScopeChatMember
 	a := struct {
@@ -243,6 +300,13 @@ type BotCommandScopeDefault struct{}
 
 func (v BotCommandScopeDefault) GetType() string {
 	return "default"
+}
+
+// BotCommandScopeDefault.MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+func (v BotCommandScopeDefault) MergeBotCommandScope() MergedBotCommandScope {
+	return MergedBotCommandScope{
+		Type: "default",
+	}
 }
 
 func (v BotCommandScopeDefault) MarshalJSON() ([]byte, error) {
@@ -363,6 +427,55 @@ type ChatMember interface {
 	GetStatus() string
 	GetUser() User
 	ChatMember() ([]byte, error)
+	// MergeChatMember returns a MergedChatMember struct to simplify working with complex telegram types in a non-generic world.
+	MergeChatMember() MergedChatMember
+}
+
+type MergedChatMember struct {
+	// The member's status in the chat, always "creator"
+	Status string `json:"status,omitempty"`
+	// Information about the user
+	User User `json:"user,omitempty"`
+	// Optional. Custom title for this user (Only for owner, administrator)
+	CustomTitle string `json:"custom_title,omitempty"`
+	// Optional. True, if the user's presence in the chat is hidden (Only for owner, administrator)
+	IsAnonymous bool `json:"is_anonymous,omitempty"`
+	// Optional. True, if the bot is allowed to edit administrator privileges of that user (Only for administrator)
+	CanBeEdited bool `json:"can_be_edited,omitempty"`
+	// Optional. True, if the administrator can access the chat event log, chat statistics, message statistics in channels, see channel members, see anonymous administrators in supergroups and ignore slow mode. Implied by any other administrator privilege (Only for administrator)
+	CanManageChat bool `json:"can_manage_chat,omitempty"`
+	// Optional. True, if the administrator can post in the channel; channels only (Only for administrator)
+	CanPostMessages bool `json:"can_post_messages,omitempty"`
+	// Optional. True, if the administrator can edit messages of other users and can pin messages; channels only (Only for administrator)
+	CanEditMessages bool `json:"can_edit_messages,omitempty"`
+	// Optional. True, if the administrator can delete messages of other users (Only for administrator)
+	CanDeleteMessages bool `json:"can_delete_messages,omitempty"`
+	// Optional. True, if the administrator can manage voice chats (Only for administrator)
+	CanManageVoiceChats bool `json:"can_manage_voice_chats,omitempty"`
+	// Optional. True, if the administrator can restrict, ban or unban chat members (Only for administrator)
+	CanRestrictMembers bool `json:"can_restrict_members,omitempty"`
+	// Optional. True, if the administrator can add new administrators with a subset of their own privileges or demote administrators that he has promoted, directly or indirectly (promoted by administrators that were appointed by the user) (Only for administrator)
+	CanPromoteMembers bool `json:"can_promote_members,omitempty"`
+	// Optional. True, if the user is allowed to change the chat title, photo and other settings (Only for administrator, restricted)
+	CanChangeInfo bool `json:"can_change_info,omitempty"`
+	// Optional. True, if the user is allowed to invite new users to the chat (Only for administrator, restricted)
+	CanInviteUsers bool `json:"can_invite_users,omitempty"`
+	// Optional. True, if the user is allowed to pin messages; groups and supergroups only (Only for administrator, restricted)
+	CanPinMessages bool `json:"can_pin_messages,omitempty"`
+	// Optional. True, if the user is a member of the chat at the moment of the request (Only for restricted)
+	IsMember bool `json:"is_member,omitempty"`
+	// Optional. True, if the user is allowed to send text messages, contacts, locations and venues (Only for restricted)
+	CanSendMessages bool `json:"can_send_messages,omitempty"`
+	// Optional. True, if the user is allowed to send audios, documents, photos, videos, video notes and voice notes (Only for restricted)
+	CanSendMediaMessages bool `json:"can_send_media_messages,omitempty"`
+	// Optional. True, if the user is allowed to send polls (Only for restricted)
+	CanSendPolls bool `json:"can_send_polls,omitempty"`
+	// Optional. True, if the user is allowed to send animations, games, stickers and use inline bots (Only for restricted)
+	CanSendOtherMessages bool `json:"can_send_other_messages,omitempty"`
+	// Optional. True, if the user is allowed to add web page previews to their messages (Only for restricted)
+	CanAddWebPagePreviews bool `json:"can_add_web_page_previews,omitempty"`
+	// Optional. Date when restrictions will be lifted for this user; unix time (Only for restricted, banned)
+	UntilDate int64 `json:"until_date,omitempty"`
 }
 
 func unmarshalChatMember(d json.RawMessage) (ChatMember, error) {
@@ -426,6 +539,7 @@ func unmarshalChatMember(d json.RawMessage) (ChatMember, error) {
 			return nil, err
 		}
 		return s, nil
+
 	}
 	return nil, fmt.Errorf("unknown interface with Status %v", t.Status)
 }
@@ -471,6 +585,27 @@ func (v ChatMemberAdministrator) GetUser() User {
 	return v.User
 }
 
+// ChatMemberAdministrator.MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
+func (v ChatMemberAdministrator) MergeChatMember() MergedChatMember {
+	return MergedChatMember{
+		Status:              "administrator",
+		User:                v.User,
+		CanBeEdited:         v.CanBeEdited,
+		CustomTitle:         v.CustomTitle,
+		IsAnonymous:         v.IsAnonymous,
+		CanManageChat:       v.CanManageChat,
+		CanPostMessages:     v.CanPostMessages,
+		CanEditMessages:     v.CanEditMessages,
+		CanDeleteMessages:   v.CanDeleteMessages,
+		CanManageVoiceChats: v.CanManageVoiceChats,
+		CanRestrictMembers:  v.CanRestrictMembers,
+		CanPromoteMembers:   v.CanPromoteMembers,
+		CanChangeInfo:       v.CanChangeInfo,
+		CanInviteUsers:      v.CanInviteUsers,
+		CanPinMessages:      v.CanPinMessages,
+	}
+}
+
 func (v ChatMemberAdministrator) MarshalJSON() ([]byte, error) {
 	type alias ChatMemberAdministrator
 	a := struct {
@@ -504,6 +639,15 @@ func (v ChatMemberBanned) GetUser() User {
 	return v.User
 }
 
+// ChatMemberBanned.MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
+func (v ChatMemberBanned) MergeChatMember() MergedChatMember {
+	return MergedChatMember{
+		Status:    "banned",
+		User:      v.User,
+		UntilDate: v.UntilDate,
+	}
+}
+
 func (v ChatMemberBanned) MarshalJSON() ([]byte, error) {
 	type alias ChatMemberBanned
 	a := struct {
@@ -535,6 +679,14 @@ func (v ChatMemberLeft) GetUser() User {
 	return v.User
 }
 
+// ChatMemberLeft.MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
+func (v ChatMemberLeft) MergeChatMember() MergedChatMember {
+	return MergedChatMember{
+		Status: "left",
+		User:   v.User,
+	}
+}
+
 func (v ChatMemberLeft) MarshalJSON() ([]byte, error) {
 	type alias ChatMemberLeft
 	a := struct {
@@ -564,6 +716,14 @@ func (v ChatMemberMember) GetStatus() string {
 
 func (v ChatMemberMember) GetUser() User {
 	return v.User
+}
+
+// ChatMemberMember.MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
+func (v ChatMemberMember) MergeChatMember() MergedChatMember {
+	return MergedChatMember{
+		Status: "member",
+		User:   v.User,
+	}
 }
 
 func (v ChatMemberMember) MarshalJSON() ([]byte, error) {
@@ -599,6 +759,16 @@ func (v ChatMemberOwner) GetStatus() string {
 
 func (v ChatMemberOwner) GetUser() User {
 	return v.User
+}
+
+// ChatMemberOwner.MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
+func (v ChatMemberOwner) MergeChatMember() MergedChatMember {
+	return MergedChatMember{
+		Status:      "owner",
+		User:        v.User,
+		CustomTitle: v.CustomTitle,
+		IsAnonymous: v.IsAnonymous,
+	}
 }
 
 func (v ChatMemberOwner) MarshalJSON() ([]byte, error) {
@@ -650,6 +820,24 @@ func (v ChatMemberRestricted) GetStatus() string {
 
 func (v ChatMemberRestricted) GetUser() User {
 	return v.User
+}
+
+// ChatMemberRestricted.MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
+func (v ChatMemberRestricted) MergeChatMember() MergedChatMember {
+	return MergedChatMember{
+		Status:                "restricted",
+		User:                  v.User,
+		IsMember:              v.IsMember,
+		CanChangeInfo:         v.CanChangeInfo,
+		CanInviteUsers:        v.CanInviteUsers,
+		CanPinMessages:        v.CanPinMessages,
+		CanSendMessages:       v.CanSendMessages,
+		CanSendMediaMessages:  v.CanSendMediaMessages,
+		CanSendPolls:          v.CanSendPolls,
+		CanSendOtherMessages:  v.CanSendOtherMessages,
+		CanAddWebPagePreviews: v.CanAddWebPagePreviews,
+		UntilDate:             v.UntilDate,
+	}
 }
 
 func (v ChatMemberRestricted) MarshalJSON() ([]byte, error) {
@@ -978,6 +1166,133 @@ type InlineQueryResult interface {
 	GetType() string
 	GetId() string
 	InlineQueryResult() ([]byte, error)
+	// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with complex telegram types in a non-generic world.
+	MergeInlineQueryResult() MergedInlineQueryResult
+}
+
+type MergedInlineQueryResult struct {
+	// Type of the result, must be audio
+	Type string `json:"type,omitempty"`
+	// Unique identifier for this result, 1-64 bytes
+	Id string `json:"id,omitempty"`
+	// Optional. A valid file identifier for the audio file (Only for audio)
+	AudioFileId string `json:"audio_file_id,omitempty"`
+	// Optional. Caption, 0-1024 characters after entities parsing (Only for audio, document, gif, mpeg4_gif, photo, video, voice, audio, document, gif, mpeg4_gif, photo, video, voice)
+	Caption string `json:"caption,omitempty"`
+	// Optional. Mode for parsing entities in the audio caption. See formatting options for more details. (Only for audio, document, gif, mpeg4_gif, photo, video, voice, audio, document, gif, mpeg4_gif, photo, video, voice)
+	ParseMode string `json:"parse_mode,omitempty"`
+	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode (Only for audio, document, gif, mpeg4_gif, photo, video, voice, audio, document, gif, mpeg4_gif, photo, video, voice)
+	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
+	// Optional. Inline keyboard attached to the message
+	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+	// Optional. Content of the message to be sent instead of the audio (Only for audio, document, gif, mpeg4_gif, photo, sticker, video, voice, article, audio, contact, document, gif, location, mpeg4_gif, photo, venue, video, voice)
+	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
+	// Optional. Title for the result (Only for document, gif, mpeg4_gif, photo, video, voice, article, audio, document, gif, location, mpeg4_gif, photo, venue, video, voice)
+	Title string `json:"title,omitempty"`
+	// Optional. A valid file identifier for the file (Only for document)
+	DocumentFileId string `json:"document_file_id,omitempty"`
+	// Optional. Short description of the result (Only for document, photo, video, article, document, photo, video)
+	Description string `json:"description,omitempty"`
+	// Optional. A valid file identifier for the GIF file (Only for gif)
+	GifFileId string `json:"gif_file_id,omitempty"`
+	// Optional. A valid file identifier for the MP4 file (Only for mpeg4_gif)
+	Mpeg4FileId string `json:"mpeg4_file_id,omitempty"`
+	// Optional. A valid file identifier of the photo (Only for photo)
+	PhotoFileId string `json:"photo_file_id,omitempty"`
+	// Optional. A valid file identifier of the sticker (Only for sticker)
+	StickerFileId string `json:"sticker_file_id,omitempty"`
+	// Optional. A valid file identifier for the video file (Only for video)
+	VideoFileId string `json:"video_file_id,omitempty"`
+	// Optional. A valid file identifier for the voice message (Only for voice)
+	VoiceFileId string `json:"voice_file_id,omitempty"`
+	// Optional. URL of the result (Only for article)
+	Url string `json:"url,omitempty"`
+	// Optional. Pass True, if you don't want the URL to be shown in the message (Only for article)
+	HideUrl bool `json:"hide_url,omitempty"`
+	// Optional. Url of the thumbnail for the result (Only for article, contact, document, gif, location, mpeg4_gif, photo, venue, video)
+	ThumbUrl string `json:"thumb_url,omitempty"`
+	// Optional. Thumbnail width (Only for article, contact, document, location, venue)
+	ThumbWidth int64 `json:"thumb_width,omitempty"`
+	// Optional. Thumbnail height (Only for article, contact, document, location, venue)
+	ThumbHeight int64 `json:"thumb_height,omitempty"`
+	// Optional. A valid URL for the audio file (Only for audio)
+	AudioUrl string `json:"audio_url,omitempty"`
+	// Optional. Performer (Only for audio)
+	Performer string `json:"performer,omitempty"`
+	// Optional. Audio duration in seconds (Only for audio)
+	AudioDuration int64 `json:"audio_duration,omitempty"`
+	// Optional. Contact's phone number (Only for contact)
+	PhoneNumber string `json:"phone_number,omitempty"`
+	// Optional. Contact's first name (Only for contact)
+	FirstName string `json:"first_name,omitempty"`
+	// Optional. Contact's last name (Only for contact)
+	LastName string `json:"last_name,omitempty"`
+	// Optional. Additional data about the contact in the form of a vCard, 0-2048 bytes (Only for contact)
+	Vcard string `json:"vcard,omitempty"`
+	// Optional. Short name of the game (Only for game)
+	GameShortName string `json:"game_short_name,omitempty"`
+	// Optional. A valid URL for the file (Only for document)
+	DocumentUrl string `json:"document_url,omitempty"`
+	// Optional. Mime type of the content of the file, either "application/pdf" or "application/zip" (Only for document, video)
+	MimeType string `json:"mime_type,omitempty"`
+	// Optional. A valid URL for the GIF file. File size must not exceed 1MB (Only for gif)
+	GifUrl string `json:"gif_url,omitempty"`
+	// Optional. Width of the GIF (Only for gif)
+	GifWidth int64 `json:"gif_width,omitempty"`
+	// Optional. Height of the GIF (Only for gif)
+	GifHeight int64 `json:"gif_height,omitempty"`
+	// Optional. Duration of the GIF (Only for gif)
+	GifDuration int64 `json:"gif_duration,omitempty"`
+	// Optional. MIME type of the thumbnail, must be one of "image/jpeg", "image/gif", or "video/mp4". Defaults to "image/jpeg" (Only for gif, mpeg4_gif)
+	ThumbMimeType string `json:"thumb_mime_type,omitempty"`
+	// Optional. Location latitude in degrees (Only for location, venue)
+	Latitude float64 `json:"latitude,omitempty"`
+	// Optional. Location longitude in degrees (Only for location, venue)
+	Longitude float64 `json:"longitude,omitempty"`
+	// Optional. The radius of uncertainty for the location, measured in meters; 0-1500 (Only for location)
+	HorizontalAccuracy float64 `json:"horizontal_accuracy,omitempty"`
+	// Optional. Period in seconds for which the location can be updated, should be between 60 and 86400. (Only for location)
+	LivePeriod int64 `json:"live_period,omitempty"`
+	// Optional. For live locations, a direction in which the user is moving, in degrees. Must be between 1 and 360 if specified. (Only for location)
+	Heading int64 `json:"heading,omitempty"`
+	// Optional. For live locations, a maximum distance for proximity alerts about approaching another chat member, in meters. Must be between 1 and 100000 if specified. (Only for location)
+	ProximityAlertRadius int64 `json:"proximity_alert_radius,omitempty"`
+	// Optional. A valid URL for the MP4 file. File size must not exceed 1MB (Only for mpeg4_gif)
+	Mpeg4Url string `json:"mpeg4_url,omitempty"`
+	// Optional. Video width (Only for mpeg4_gif)
+	Mpeg4Width int64 `json:"mpeg4_width,omitempty"`
+	// Optional. Video height (Only for mpeg4_gif)
+	Mpeg4Height int64 `json:"mpeg4_height,omitempty"`
+	// Optional. Video duration (Only for mpeg4_gif)
+	Mpeg4Duration int64 `json:"mpeg4_duration,omitempty"`
+	// Optional. A valid URL of the photo. Photo must be in jpeg format. Photo size must not exceed 5MB (Only for photo)
+	PhotoUrl string `json:"photo_url,omitempty"`
+	// Optional. Width of the photo (Only for photo)
+	PhotoWidth int64 `json:"photo_width,omitempty"`
+	// Optional. Height of the photo (Only for photo)
+	PhotoHeight int64 `json:"photo_height,omitempty"`
+	// Optional. Address of the venue (Only for venue)
+	Address string `json:"address,omitempty"`
+	// Optional. Foursquare identifier of the venue if known (Only for venue)
+	FoursquareId string `json:"foursquare_id,omitempty"`
+	// Optional. Foursquare type of the venue, if known. (For example, "arts_entertainment/default", "arts_entertainment/aquarium" or "food/icecream".) (Only for venue)
+	FoursquareType string `json:"foursquare_type,omitempty"`
+	// Optional. Google Places identifier of the venue (Only for venue)
+	GooglePlaceId string `json:"google_place_id,omitempty"`
+	// Optional. Google Places type of the venue. (See supported types.) (Only for venue)
+	GooglePlaceType string `json:"google_place_type,omitempty"`
+	// Optional. A valid URL for the embedded video player or video file (Only for video)
+	VideoUrl string `json:"video_url,omitempty"`
+	// Optional. Video width (Only for video)
+	VideoWidth int64 `json:"video_width,omitempty"`
+	// Optional. Video height (Only for video)
+	VideoHeight int64 `json:"video_height,omitempty"`
+	// Optional. Video duration in seconds (Only for video)
+	VideoDuration int64 `json:"video_duration,omitempty"`
+	// Optional. A valid URL for the voice recording (Only for voice)
+	VoiceUrl string `json:"voice_url,omitempty"`
+	// Optional. Recording duration in seconds (Only for voice)
+	VoiceDuration int64 `json:"voice_duration,omitempty"`
 }
 
 // InlineQueryResultArticle Represents a link to an article or web page.
@@ -1011,6 +1326,23 @@ func (v InlineQueryResultArticle) GetType() string {
 
 func (v InlineQueryResultArticle) GetId() string {
 	return v.Id
+}
+
+// InlineQueryResultArticle.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultArticle) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:                "article",
+		Id:                  v.Id,
+		Title:               v.Title,
+		InputMessageContent: &v.InputMessageContent,
+		ReplyMarkup:         v.ReplyMarkup,
+		Url:                 v.Url,
+		HideUrl:             v.HideUrl,
+		Description:         v.Description,
+		ThumbUrl:            v.ThumbUrl,
+		ThumbWidth:          v.ThumbWidth,
+		ThumbHeight:         v.ThumbHeight,
+	}
 }
 
 func (v InlineQueryResultArticle) MarshalJSON() ([]byte, error) {
@@ -1063,6 +1395,23 @@ func (v InlineQueryResultAudio) GetId() string {
 	return v.Id
 }
 
+// InlineQueryResultAudio.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultAudio) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:                "audio",
+		Id:                  v.Id,
+		AudioUrl:            v.AudioUrl,
+		Title:               v.Title,
+		Caption:             v.Caption,
+		ParseMode:           v.ParseMode,
+		CaptionEntities:     v.CaptionEntities,
+		Performer:           v.Performer,
+		AudioDuration:       v.AudioDuration,
+		ReplyMarkup:         v.ReplyMarkup,
+		InputMessageContent: v.InputMessageContent,
+	}
+}
+
 func (v InlineQueryResultAudio) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultAudio
 	a := struct {
@@ -1105,6 +1454,20 @@ func (v InlineQueryResultCachedAudio) GetType() string {
 
 func (v InlineQueryResultCachedAudio) GetId() string {
 	return v.Id
+}
+
+// InlineQueryResultCachedAudio.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultCachedAudio) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:                "audio",
+		Id:                  v.Id,
+		AudioFileId:         v.AudioFileId,
+		Caption:             v.Caption,
+		ParseMode:           v.ParseMode,
+		CaptionEntities:     v.CaptionEntities,
+		ReplyMarkup:         v.ReplyMarkup,
+		InputMessageContent: v.InputMessageContent,
+	}
 }
 
 func (v InlineQueryResultCachedAudio) MarshalJSON() ([]byte, error) {
@@ -1155,6 +1518,22 @@ func (v InlineQueryResultCachedDocument) GetId() string {
 	return v.Id
 }
 
+// InlineQueryResultCachedDocument.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultCachedDocument) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:                "document",
+		Id:                  v.Id,
+		Title:               v.Title,
+		DocumentFileId:      v.DocumentFileId,
+		Description:         v.Description,
+		Caption:             v.Caption,
+		ParseMode:           v.ParseMode,
+		CaptionEntities:     v.CaptionEntities,
+		ReplyMarkup:         v.ReplyMarkup,
+		InputMessageContent: v.InputMessageContent,
+	}
+}
+
 func (v InlineQueryResultCachedDocument) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultCachedDocument
 	a := struct {
@@ -1200,6 +1579,21 @@ func (v InlineQueryResultCachedGif) GetId() string {
 	return v.Id
 }
 
+// InlineQueryResultCachedGif.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultCachedGif) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:                "gif",
+		Id:                  v.Id,
+		GifFileId:           v.GifFileId,
+		Title:               v.Title,
+		Caption:             v.Caption,
+		ParseMode:           v.ParseMode,
+		CaptionEntities:     v.CaptionEntities,
+		ReplyMarkup:         v.ReplyMarkup,
+		InputMessageContent: v.InputMessageContent,
+	}
+}
+
 func (v InlineQueryResultCachedGif) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultCachedGif
 	a := struct {
@@ -1243,6 +1637,21 @@ func (v InlineQueryResultCachedMpeg4Gif) GetType() string {
 
 func (v InlineQueryResultCachedMpeg4Gif) GetId() string {
 	return v.Id
+}
+
+// InlineQueryResultCachedMpeg4Gif.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultCachedMpeg4Gif) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:                "mpeg4_gif",
+		Id:                  v.Id,
+		Mpeg4FileId:         v.Mpeg4FileId,
+		Title:               v.Title,
+		Caption:             v.Caption,
+		ParseMode:           v.ParseMode,
+		CaptionEntities:     v.CaptionEntities,
+		ReplyMarkup:         v.ReplyMarkup,
+		InputMessageContent: v.InputMessageContent,
+	}
 }
 
 func (v InlineQueryResultCachedMpeg4Gif) MarshalJSON() ([]byte, error) {
@@ -1292,6 +1701,22 @@ func (v InlineQueryResultCachedPhoto) GetId() string {
 	return v.Id
 }
 
+// InlineQueryResultCachedPhoto.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultCachedPhoto) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:                "photo",
+		Id:                  v.Id,
+		PhotoFileId:         v.PhotoFileId,
+		Title:               v.Title,
+		Description:         v.Description,
+		Caption:             v.Caption,
+		ParseMode:           v.ParseMode,
+		CaptionEntities:     v.CaptionEntities,
+		ReplyMarkup:         v.ReplyMarkup,
+		InputMessageContent: v.InputMessageContent,
+	}
+}
+
 func (v InlineQueryResultCachedPhoto) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultCachedPhoto
 	a := struct {
@@ -1328,6 +1753,17 @@ func (v InlineQueryResultCachedSticker) GetType() string {
 
 func (v InlineQueryResultCachedSticker) GetId() string {
 	return v.Id
+}
+
+// InlineQueryResultCachedSticker.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultCachedSticker) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:                "sticker",
+		Id:                  v.Id,
+		StickerFileId:       v.StickerFileId,
+		ReplyMarkup:         v.ReplyMarkup,
+		InputMessageContent: v.InputMessageContent,
+	}
 }
 
 func (v InlineQueryResultCachedSticker) MarshalJSON() ([]byte, error) {
@@ -1377,6 +1813,22 @@ func (v InlineQueryResultCachedVideo) GetId() string {
 	return v.Id
 }
 
+// InlineQueryResultCachedVideo.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultCachedVideo) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:                "video",
+		Id:                  v.Id,
+		VideoFileId:         v.VideoFileId,
+		Title:               v.Title,
+		Description:         v.Description,
+		Caption:             v.Caption,
+		ParseMode:           v.ParseMode,
+		CaptionEntities:     v.CaptionEntities,
+		ReplyMarkup:         v.ReplyMarkup,
+		InputMessageContent: v.InputMessageContent,
+	}
+}
+
 func (v InlineQueryResultCachedVideo) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultCachedVideo
 	a := struct {
@@ -1421,6 +1873,21 @@ func (v InlineQueryResultCachedVoice) GetType() string {
 
 func (v InlineQueryResultCachedVoice) GetId() string {
 	return v.Id
+}
+
+// InlineQueryResultCachedVoice.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultCachedVoice) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:                "voice",
+		Id:                  v.Id,
+		VoiceFileId:         v.VoiceFileId,
+		Title:               v.Title,
+		Caption:             v.Caption,
+		ParseMode:           v.ParseMode,
+		CaptionEntities:     v.CaptionEntities,
+		ReplyMarkup:         v.ReplyMarkup,
+		InputMessageContent: v.InputMessageContent,
+	}
 }
 
 func (v InlineQueryResultCachedVoice) MarshalJSON() ([]byte, error) {
@@ -1471,6 +1938,23 @@ func (v InlineQueryResultContact) GetType() string {
 
 func (v InlineQueryResultContact) GetId() string {
 	return v.Id
+}
+
+// InlineQueryResultContact.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultContact) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:                "contact",
+		Id:                  v.Id,
+		PhoneNumber:         v.PhoneNumber,
+		FirstName:           v.FirstName,
+		LastName:            v.LastName,
+		Vcard:               v.Vcard,
+		ReplyMarkup:         v.ReplyMarkup,
+		InputMessageContent: v.InputMessageContent,
+		ThumbUrl:            v.ThumbUrl,
+		ThumbWidth:          v.ThumbWidth,
+		ThumbHeight:         v.ThumbHeight,
+	}
 }
 
 func (v InlineQueryResultContact) MarshalJSON() ([]byte, error) {
@@ -1529,6 +2013,26 @@ func (v InlineQueryResultDocument) GetId() string {
 	return v.Id
 }
 
+// InlineQueryResultDocument.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultDocument) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:                "document",
+		Id:                  v.Id,
+		Title:               v.Title,
+		Caption:             v.Caption,
+		ParseMode:           v.ParseMode,
+		CaptionEntities:     v.CaptionEntities,
+		DocumentUrl:         v.DocumentUrl,
+		MimeType:            v.MimeType,
+		Description:         v.Description,
+		ReplyMarkup:         v.ReplyMarkup,
+		InputMessageContent: v.InputMessageContent,
+		ThumbUrl:            v.ThumbUrl,
+		ThumbWidth:          v.ThumbWidth,
+		ThumbHeight:         v.ThumbHeight,
+	}
+}
+
 func (v InlineQueryResultDocument) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultDocument
 	a := struct {
@@ -1563,6 +2067,16 @@ func (v InlineQueryResultGame) GetType() string {
 
 func (v InlineQueryResultGame) GetId() string {
 	return v.Id
+}
+
+// InlineQueryResultGame.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultGame) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:          "game",
+		Id:            v.Id,
+		GameShortName: v.GameShortName,
+		ReplyMarkup:   v.ReplyMarkup,
+	}
 }
 
 func (v InlineQueryResultGame) MarshalJSON() ([]byte, error) {
@@ -1618,6 +2132,26 @@ func (v InlineQueryResultGif) GetType() string {
 
 func (v InlineQueryResultGif) GetId() string {
 	return v.Id
+}
+
+// InlineQueryResultGif.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultGif) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:                "gif",
+		Id:                  v.Id,
+		GifUrl:              v.GifUrl,
+		GifWidth:            v.GifWidth,
+		GifHeight:           v.GifHeight,
+		GifDuration:         v.GifDuration,
+		ThumbUrl:            v.ThumbUrl,
+		ThumbMimeType:       v.ThumbMimeType,
+		Title:               v.Title,
+		Caption:             v.Caption,
+		ParseMode:           v.ParseMode,
+		CaptionEntities:     v.CaptionEntities,
+		ReplyMarkup:         v.ReplyMarkup,
+		InputMessageContent: v.InputMessageContent,
+	}
 }
 
 func (v InlineQueryResultGif) MarshalJSON() ([]byte, error) {
@@ -1676,6 +2210,26 @@ func (v InlineQueryResultLocation) GetId() string {
 	return v.Id
 }
 
+// InlineQueryResultLocation.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultLocation) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:                 "location",
+		Id:                   v.Id,
+		Latitude:             v.Latitude,
+		Longitude:            v.Longitude,
+		Title:                v.Title,
+		HorizontalAccuracy:   v.HorizontalAccuracy,
+		LivePeriod:           v.LivePeriod,
+		Heading:              v.Heading,
+		ProximityAlertRadius: v.ProximityAlertRadius,
+		ReplyMarkup:          v.ReplyMarkup,
+		InputMessageContent:  v.InputMessageContent,
+		ThumbUrl:             v.ThumbUrl,
+		ThumbWidth:           v.ThumbWidth,
+		ThumbHeight:          v.ThumbHeight,
+	}
+}
+
 func (v InlineQueryResultLocation) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultLocation
 	a := struct {
@@ -1731,6 +2285,26 @@ func (v InlineQueryResultMpeg4Gif) GetId() string {
 	return v.Id
 }
 
+// InlineQueryResultMpeg4Gif.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultMpeg4Gif) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:                "mpeg4_gif",
+		Id:                  v.Id,
+		Mpeg4Url:            v.Mpeg4Url,
+		Mpeg4Width:          v.Mpeg4Width,
+		Mpeg4Height:         v.Mpeg4Height,
+		Mpeg4Duration:       v.Mpeg4Duration,
+		ThumbUrl:            v.ThumbUrl,
+		ThumbMimeType:       v.ThumbMimeType,
+		Title:               v.Title,
+		Caption:             v.Caption,
+		ParseMode:           v.ParseMode,
+		CaptionEntities:     v.CaptionEntities,
+		ReplyMarkup:         v.ReplyMarkup,
+		InputMessageContent: v.InputMessageContent,
+	}
+}
+
 func (v InlineQueryResultMpeg4Gif) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultMpeg4Gif
 	a := struct {
@@ -1782,6 +2356,25 @@ func (v InlineQueryResultPhoto) GetType() string {
 
 func (v InlineQueryResultPhoto) GetId() string {
 	return v.Id
+}
+
+// InlineQueryResultPhoto.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultPhoto) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:                "photo",
+		Id:                  v.Id,
+		PhotoUrl:            v.PhotoUrl,
+		ThumbUrl:            v.ThumbUrl,
+		PhotoWidth:          v.PhotoWidth,
+		PhotoHeight:         v.PhotoHeight,
+		Title:               v.Title,
+		Description:         v.Description,
+		Caption:             v.Caption,
+		ParseMode:           v.ParseMode,
+		CaptionEntities:     v.CaptionEntities,
+		ReplyMarkup:         v.ReplyMarkup,
+		InputMessageContent: v.InputMessageContent,
+	}
 }
 
 func (v InlineQueryResultPhoto) MarshalJSON() ([]byte, error) {
@@ -1842,6 +2435,27 @@ func (v InlineQueryResultVenue) GetId() string {
 	return v.Id
 }
 
+// InlineQueryResultVenue.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultVenue) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:                "venue",
+		Id:                  v.Id,
+		Latitude:            v.Latitude,
+		Longitude:           v.Longitude,
+		Title:               v.Title,
+		Address:             v.Address,
+		FoursquareId:        v.FoursquareId,
+		FoursquareType:      v.FoursquareType,
+		GooglePlaceId:       v.GooglePlaceId,
+		GooglePlaceType:     v.GooglePlaceType,
+		ReplyMarkup:         v.ReplyMarkup,
+		InputMessageContent: v.InputMessageContent,
+		ThumbUrl:            v.ThumbUrl,
+		ThumbWidth:          v.ThumbWidth,
+		ThumbHeight:         v.ThumbHeight,
+	}
+}
+
 func (v InlineQueryResultVenue) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultVenue
 	a := struct {
@@ -1899,6 +2513,27 @@ func (v InlineQueryResultVideo) GetId() string {
 	return v.Id
 }
 
+// InlineQueryResultVideo.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultVideo) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:                "video",
+		Id:                  v.Id,
+		VideoUrl:            v.VideoUrl,
+		MimeType:            v.MimeType,
+		ThumbUrl:            v.ThumbUrl,
+		Title:               v.Title,
+		Caption:             v.Caption,
+		ParseMode:           v.ParseMode,
+		CaptionEntities:     v.CaptionEntities,
+		VideoWidth:          v.VideoWidth,
+		VideoHeight:         v.VideoHeight,
+		VideoDuration:       v.VideoDuration,
+		Description:         v.Description,
+		ReplyMarkup:         v.ReplyMarkup,
+		InputMessageContent: v.InputMessageContent,
+	}
+}
+
 func (v InlineQueryResultVideo) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultVideo
 	a := struct {
@@ -1945,6 +2580,22 @@ func (v InlineQueryResultVoice) GetType() string {
 
 func (v InlineQueryResultVoice) GetId() string {
 	return v.Id
+}
+
+// InlineQueryResultVoice.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+func (v InlineQueryResultVoice) MergeInlineQueryResult() MergedInlineQueryResult {
+	return MergedInlineQueryResult{
+		Type:                "voice",
+		Id:                  v.Id,
+		VoiceUrl:            v.VoiceUrl,
+		Title:               v.Title,
+		Caption:             v.Caption,
+		ParseMode:           v.ParseMode,
+		CaptionEntities:     v.CaptionEntities,
+		VoiceDuration:       v.VoiceDuration,
+		ReplyMarkup:         v.ReplyMarkup,
+		InputMessageContent: v.InputMessageContent,
+	}
 }
 
 func (v InlineQueryResultVoice) MarshalJSON() ([]byte, error) {
@@ -2062,8 +2713,42 @@ func (v InputLocationMessageContent) InputMessageContent() ([]byte, error) {
 // - InputMediaVideo
 // https://core.telegram.org/bots/api#inputmedia
 type InputMedia interface {
-	Type() string
+	GetType() string
+	GetMedia() InputFile
+	InputMedia() ([]byte, error)
+	// InputMediaParams allows for uploading InputMedia files with attachments.
 	InputMediaParams(string, map[string]NamedReader) ([]byte, error)
+	// MergeInputMedia returns a MergedInputMedia struct to simplify working with complex telegram types in a non-generic world.
+	MergeInputMedia() MergedInputMedia
+}
+
+type MergedInputMedia struct {
+	// Type of the result, must be animation
+	Type string `json:"type,omitempty"`
+	// File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass "attach://<file_attach_name>" to upload a new one using multipart/form-data under <file_attach_name> name. More info on Sending Files »
+	Media InputFile `json:"media,omitempty"`
+	// Optional. Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass "attach://<file_attach_name>" if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files » (Only for animation, document, audio, video)
+	Thumb *InputFile `json:"thumb,omitempty"`
+	// Optional. Caption of the animation to be sent, 0-1024 characters after entities parsing
+	Caption string `json:"caption,omitempty"`
+	// Optional. Mode for parsing entities in the animation caption. See formatting options for more details.
+	ParseMode string `json:"parse_mode,omitempty"`
+	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
+	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
+	// Optional. Animation width (Only for animation, video)
+	Width int64 `json:"width,omitempty"`
+	// Optional. Animation height (Only for animation, video)
+	Height int64 `json:"height,omitempty"`
+	// Optional. Animation duration (Only for animation, audio, video)
+	Duration int64 `json:"duration,omitempty"`
+	// Optional. Disables automatic server-side content type detection for files uploaded using multipart/form-data. Always true, if the document is sent as part of an album. (Only for document)
+	DisableContentTypeDetection bool `json:"disable_content_type_detection,omitempty"`
+	// Optional. Performer of the audio (Only for audio)
+	Performer string `json:"performer,omitempty"`
+	// Optional. Title of the audio (Only for audio)
+	Title string `json:"title,omitempty"`
+	// Optional. Pass True, if the uploaded video is suitable for streaming (Only for video)
+	SupportsStreaming bool `json:"supports_streaming,omitempty"`
 }
 
 // InputMediaAnimation Represents an animation file (GIF or H.264/MPEG-4 AVC video without sound) to be sent.
@@ -2085,26 +2770,6 @@ type InputMediaAnimation struct {
 	Height int64 `json:"height,omitempty"`
 	// Optional. Animation duration
 	Duration int64 `json:"duration,omitempty"`
-}
-
-func (v InputMediaAnimation) GetType() string {
-	return "animation"
-}
-
-func (v InputMediaAnimation) GetMedia() InputFile {
-	return v.Media
-}
-
-func (v InputMediaAnimation) MarshalJSON() ([]byte, error) {
-	type alias InputMediaAnimation
-	a := struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type:  "animation",
-		alias: (alias)(v),
-	}
-	return json.Marshal(a)
 }
 
 func (v InputMediaAnimation) InputMediaParams(mediaName string, data map[string]NamedReader) ([]byte, error) {
@@ -2129,6 +2794,45 @@ func (v InputMediaAnimation) InputMediaParams(mediaName string, data map[string]
 	return json.Marshal(v)
 }
 
+func (v InputMediaAnimation) GetType() string {
+	return "animation"
+}
+
+func (v InputMediaAnimation) GetMedia() InputFile {
+	return v.Media
+}
+
+// InputMediaAnimation.MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
+func (v InputMediaAnimation) MergeInputMedia() MergedInputMedia {
+	return MergedInputMedia{
+		Type:            "animation",
+		Media:           v.Media,
+		Thumb:           v.Thumb,
+		Caption:         v.Caption,
+		ParseMode:       v.ParseMode,
+		CaptionEntities: v.CaptionEntities,
+		Width:           v.Width,
+		Height:          v.Height,
+		Duration:        v.Duration,
+	}
+}
+
+func (v InputMediaAnimation) MarshalJSON() ([]byte, error) {
+	type alias InputMediaAnimation
+	a := struct {
+		Type string `json:"type"`
+		alias
+	}{
+		Type:  "animation",
+		alias: (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
+func (v InputMediaAnimation) InputMedia() ([]byte, error) {
+	return json.Marshal(v)
+}
+
 // InputMediaAudio Represents an audio file to be treated as music to be sent.
 // https://core.telegram.org/bots/api#inputmediaaudio
 type InputMediaAudio struct {
@@ -2148,26 +2852,6 @@ type InputMediaAudio struct {
 	Performer string `json:"performer,omitempty"`
 	// Optional. Title of the audio
 	Title string `json:"title,omitempty"`
-}
-
-func (v InputMediaAudio) GetType() string {
-	return "audio"
-}
-
-func (v InputMediaAudio) GetMedia() InputFile {
-	return v.Media
-}
-
-func (v InputMediaAudio) MarshalJSON() ([]byte, error) {
-	type alias InputMediaAudio
-	a := struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type:  "audio",
-		alias: (alias)(v),
-	}
-	return json.Marshal(a)
 }
 
 func (v InputMediaAudio) InputMediaParams(mediaName string, data map[string]NamedReader) ([]byte, error) {
@@ -2192,6 +2876,45 @@ func (v InputMediaAudio) InputMediaParams(mediaName string, data map[string]Name
 	return json.Marshal(v)
 }
 
+func (v InputMediaAudio) GetType() string {
+	return "audio"
+}
+
+func (v InputMediaAudio) GetMedia() InputFile {
+	return v.Media
+}
+
+// InputMediaAudio.MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
+func (v InputMediaAudio) MergeInputMedia() MergedInputMedia {
+	return MergedInputMedia{
+		Type:            "audio",
+		Media:           v.Media,
+		Thumb:           v.Thumb,
+		Caption:         v.Caption,
+		ParseMode:       v.ParseMode,
+		CaptionEntities: v.CaptionEntities,
+		Duration:        v.Duration,
+		Performer:       v.Performer,
+		Title:           v.Title,
+	}
+}
+
+func (v InputMediaAudio) MarshalJSON() ([]byte, error) {
+	type alias InputMediaAudio
+	a := struct {
+		Type string `json:"type"`
+		alias
+	}{
+		Type:  "audio",
+		alias: (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
+func (v InputMediaAudio) InputMedia() ([]byte, error) {
+	return json.Marshal(v)
+}
+
 // InputMediaDocument Represents a general file to be sent.
 // https://core.telegram.org/bots/api#inputmediadocument
 type InputMediaDocument struct {
@@ -2207,26 +2930,6 @@ type InputMediaDocument struct {
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Disables automatic server-side content type detection for files uploaded using multipart/form-data. Always true, if the document is sent as part of an album.
 	DisableContentTypeDetection bool `json:"disable_content_type_detection,omitempty"`
-}
-
-func (v InputMediaDocument) GetType() string {
-	return "document"
-}
-
-func (v InputMediaDocument) GetMedia() InputFile {
-	return v.Media
-}
-
-func (v InputMediaDocument) MarshalJSON() ([]byte, error) {
-	type alias InputMediaDocument
-	a := struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type:  "document",
-		alias: (alias)(v),
-	}
-	return json.Marshal(a)
 }
 
 func (v InputMediaDocument) InputMediaParams(mediaName string, data map[string]NamedReader) ([]byte, error) {
@@ -2251,6 +2954,43 @@ func (v InputMediaDocument) InputMediaParams(mediaName string, data map[string]N
 	return json.Marshal(v)
 }
 
+func (v InputMediaDocument) GetType() string {
+	return "document"
+}
+
+func (v InputMediaDocument) GetMedia() InputFile {
+	return v.Media
+}
+
+// InputMediaDocument.MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
+func (v InputMediaDocument) MergeInputMedia() MergedInputMedia {
+	return MergedInputMedia{
+		Type:                        "document",
+		Media:                       v.Media,
+		Thumb:                       v.Thumb,
+		Caption:                     v.Caption,
+		ParseMode:                   v.ParseMode,
+		CaptionEntities:             v.CaptionEntities,
+		DisableContentTypeDetection: v.DisableContentTypeDetection,
+	}
+}
+
+func (v InputMediaDocument) MarshalJSON() ([]byte, error) {
+	type alias InputMediaDocument
+	a := struct {
+		Type string `json:"type"`
+		alias
+	}{
+		Type:  "document",
+		alias: (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
+func (v InputMediaDocument) InputMedia() ([]byte, error) {
+	return json.Marshal(v)
+}
+
 // InputMediaPhoto Represents a photo to be sent.
 // https://core.telegram.org/bots/api#inputmediaphoto
 type InputMediaPhoto struct {
@@ -2262,26 +3002,6 @@ type InputMediaPhoto struct {
 	ParseMode string `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
-}
-
-func (v InputMediaPhoto) GetType() string {
-	return "photo"
-}
-
-func (v InputMediaPhoto) GetMedia() InputFile {
-	return v.Media
-}
-
-func (v InputMediaPhoto) MarshalJSON() ([]byte, error) {
-	type alias InputMediaPhoto
-	a := struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type:  "photo",
-		alias: (alias)(v),
-	}
-	return json.Marshal(a)
 }
 
 func (v InputMediaPhoto) InputMediaParams(mediaName string, data map[string]NamedReader) ([]byte, error) {
@@ -2303,6 +3023,41 @@ func (v InputMediaPhoto) InputMediaParams(mediaName string, data map[string]Name
 		}
 	}
 
+	return json.Marshal(v)
+}
+
+func (v InputMediaPhoto) GetType() string {
+	return "photo"
+}
+
+func (v InputMediaPhoto) GetMedia() InputFile {
+	return v.Media
+}
+
+// InputMediaPhoto.MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
+func (v InputMediaPhoto) MergeInputMedia() MergedInputMedia {
+	return MergedInputMedia{
+		Type:            "photo",
+		Media:           v.Media,
+		Caption:         v.Caption,
+		ParseMode:       v.ParseMode,
+		CaptionEntities: v.CaptionEntities,
+	}
+}
+
+func (v InputMediaPhoto) MarshalJSON() ([]byte, error) {
+	type alias InputMediaPhoto
+	a := struct {
+		Type string `json:"type"`
+		alias
+	}{
+		Type:  "photo",
+		alias: (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
+func (v InputMediaPhoto) InputMedia() ([]byte, error) {
 	return json.Marshal(v)
 }
 
@@ -2329,26 +3084,6 @@ type InputMediaVideo struct {
 	SupportsStreaming bool `json:"supports_streaming,omitempty"`
 }
 
-func (v InputMediaVideo) GetType() string {
-	return "video"
-}
-
-func (v InputMediaVideo) GetMedia() InputFile {
-	return v.Media
-}
-
-func (v InputMediaVideo) MarshalJSON() ([]byte, error) {
-	type alias InputMediaVideo
-	a := struct {
-		Type string `json:"type"`
-		alias
-	}{
-		Type:  "video",
-		alias: (alias)(v),
-	}
-	return json.Marshal(a)
-}
-
 func (v InputMediaVideo) InputMediaParams(mediaName string, data map[string]NamedReader) ([]byte, error) {
 	if v.Media != nil {
 		switch m := v.Media.(type) {
@@ -2368,6 +3103,46 @@ func (v InputMediaVideo) InputMediaParams(mediaName string, data map[string]Name
 		}
 	}
 
+	return json.Marshal(v)
+}
+
+func (v InputMediaVideo) GetType() string {
+	return "video"
+}
+
+func (v InputMediaVideo) GetMedia() InputFile {
+	return v.Media
+}
+
+// InputMediaVideo.MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
+func (v InputMediaVideo) MergeInputMedia() MergedInputMedia {
+	return MergedInputMedia{
+		Type:              "video",
+		Media:             v.Media,
+		Thumb:             v.Thumb,
+		Caption:           v.Caption,
+		ParseMode:         v.ParseMode,
+		CaptionEntities:   v.CaptionEntities,
+		Width:             v.Width,
+		Height:            v.Height,
+		Duration:          v.Duration,
+		SupportsStreaming: v.SupportsStreaming,
+	}
+}
+
+func (v InputMediaVideo) MarshalJSON() ([]byte, error) {
+	type alias InputMediaVideo
+	a := struct {
+		Type string `json:"type"`
+		alias
+	}{
+		Type:  "video",
+		alias: (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
+func (v InputMediaVideo) InputMedia() ([]byte, error) {
 	return json.Marshal(v)
 }
 
@@ -2699,6 +3474,27 @@ type PassportElementError interface {
 	GetType() string
 	GetMessage() string
 	PassportElementError() ([]byte, error)
+	// MergePassportElementError returns a MergedPassportElementError struct to simplify working with complex telegram types in a non-generic world.
+	MergePassportElementError() MergedPassportElementError
+}
+
+type MergedPassportElementError struct {
+	// Error source, must be data
+	Source string `json:"source,omitempty"`
+	// The section of the user's Telegram Passport which has the error, one of "personal_details", "passport", "driver_license", "identity_card", "internal_passport", "address"
+	Type string `json:"type,omitempty"`
+	// Optional. Name of the data field which has the error (Only for data)
+	FieldName string `json:"field_name,omitempty"`
+	// Optional. Base64-encoded data hash (Only for data)
+	DataHash string `json:"data_hash,omitempty"`
+	// Error message
+	Message string `json:"message,omitempty"`
+	// Optional. Base64-encoded hash of the file with the front side of the document (Only for front_side, reverse_side, selfie, file, translation_file)
+	FileHash string `json:"file_hash,omitempty"`
+	// Optional. List of base64-encoded file hashes (Only for files, translation_files)
+	FileHashes []string `json:"file_hashes,omitempty"`
+	// Optional. Base64-encoded element hash (Only for unspecified)
+	ElementHash string `json:"element_hash,omitempty"`
 }
 
 // PassportElementErrorDataField Represents an issue in one of the data fields that was provided by the user. The error is considered resolved when the field's value changes.
@@ -2724,6 +3520,17 @@ func (v PassportElementErrorDataField) GetType() string {
 
 func (v PassportElementErrorDataField) GetMessage() string {
 	return v.Message
+}
+
+// PassportElementErrorDataField.MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+func (v PassportElementErrorDataField) MergePassportElementError() MergedPassportElementError {
+	return MergedPassportElementError{
+		Source:    "data",
+		Type:      v.Type,
+		FieldName: v.FieldName,
+		DataHash:  v.DataHash,
+		Message:   v.Message,
+	}
 }
 
 func (v PassportElementErrorDataField) MarshalJSON() ([]byte, error) {
@@ -2765,6 +3572,16 @@ func (v PassportElementErrorFile) GetMessage() string {
 	return v.Message
 }
 
+// PassportElementErrorFile.MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+func (v PassportElementErrorFile) MergePassportElementError() MergedPassportElementError {
+	return MergedPassportElementError{
+		Source:   "file",
+		Type:     v.Type,
+		FileHash: v.FileHash,
+		Message:  v.Message,
+	}
+}
+
 func (v PassportElementErrorFile) MarshalJSON() ([]byte, error) {
 	type alias PassportElementErrorFile
 	a := struct {
@@ -2802,6 +3619,16 @@ func (v PassportElementErrorFiles) GetType() string {
 
 func (v PassportElementErrorFiles) GetMessage() string {
 	return v.Message
+}
+
+// PassportElementErrorFiles.MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+func (v PassportElementErrorFiles) MergePassportElementError() MergedPassportElementError {
+	return MergedPassportElementError{
+		Source:     "files",
+		Type:       v.Type,
+		FileHashes: v.FileHashes,
+		Message:    v.Message,
+	}
 }
 
 func (v PassportElementErrorFiles) MarshalJSON() ([]byte, error) {
@@ -2843,6 +3670,16 @@ func (v PassportElementErrorFrontSide) GetMessage() string {
 	return v.Message
 }
 
+// PassportElementErrorFrontSide.MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+func (v PassportElementErrorFrontSide) MergePassportElementError() MergedPassportElementError {
+	return MergedPassportElementError{
+		Source:   "front_side",
+		Type:     v.Type,
+		FileHash: v.FileHash,
+		Message:  v.Message,
+	}
+}
+
 func (v PassportElementErrorFrontSide) MarshalJSON() ([]byte, error) {
 	type alias PassportElementErrorFrontSide
 	a := struct {
@@ -2880,6 +3717,16 @@ func (v PassportElementErrorReverseSide) GetType() string {
 
 func (v PassportElementErrorReverseSide) GetMessage() string {
 	return v.Message
+}
+
+// PassportElementErrorReverseSide.MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+func (v PassportElementErrorReverseSide) MergePassportElementError() MergedPassportElementError {
+	return MergedPassportElementError{
+		Source:   "reverse_side",
+		Type:     v.Type,
+		FileHash: v.FileHash,
+		Message:  v.Message,
+	}
 }
 
 func (v PassportElementErrorReverseSide) MarshalJSON() ([]byte, error) {
@@ -2921,6 +3768,16 @@ func (v PassportElementErrorSelfie) GetMessage() string {
 	return v.Message
 }
 
+// PassportElementErrorSelfie.MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+func (v PassportElementErrorSelfie) MergePassportElementError() MergedPassportElementError {
+	return MergedPassportElementError{
+		Source:   "selfie",
+		Type:     v.Type,
+		FileHash: v.FileHash,
+		Message:  v.Message,
+	}
+}
+
 func (v PassportElementErrorSelfie) MarshalJSON() ([]byte, error) {
 	type alias PassportElementErrorSelfie
 	a := struct {
@@ -2958,6 +3815,16 @@ func (v PassportElementErrorTranslationFile) GetType() string {
 
 func (v PassportElementErrorTranslationFile) GetMessage() string {
 	return v.Message
+}
+
+// PassportElementErrorTranslationFile.MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+func (v PassportElementErrorTranslationFile) MergePassportElementError() MergedPassportElementError {
+	return MergedPassportElementError{
+		Source:   "translation_file",
+		Type:     v.Type,
+		FileHash: v.FileHash,
+		Message:  v.Message,
+	}
 }
 
 func (v PassportElementErrorTranslationFile) MarshalJSON() ([]byte, error) {
@@ -2999,6 +3866,16 @@ func (v PassportElementErrorTranslationFiles) GetMessage() string {
 	return v.Message
 }
 
+// PassportElementErrorTranslationFiles.MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+func (v PassportElementErrorTranslationFiles) MergePassportElementError() MergedPassportElementError {
+	return MergedPassportElementError{
+		Source:     "translation_files",
+		Type:       v.Type,
+		FileHashes: v.FileHashes,
+		Message:    v.Message,
+	}
+}
+
 func (v PassportElementErrorTranslationFiles) MarshalJSON() ([]byte, error) {
 	type alias PassportElementErrorTranslationFiles
 	a := struct {
@@ -3036,6 +3913,16 @@ func (v PassportElementErrorUnspecified) GetType() string {
 
 func (v PassportElementErrorUnspecified) GetMessage() string {
 	return v.Message
+}
+
+// PassportElementErrorUnspecified.MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+func (v PassportElementErrorUnspecified) MergePassportElementError() MergedPassportElementError {
+	return MergedPassportElementError{
+		Source:      "unspecified",
+		Type:        v.Type,
+		ElementHash: v.ElementHash,
+		Message:     v.Message,
+	}
 }
 
 func (v PassportElementErrorUnspecified) MarshalJSON() ([]byte, error) {

--- a/gen_types.go
+++ b/gen_types.go
@@ -78,14 +78,16 @@ type BotCommand struct {
 // - BotCommandScopeChatMember
 // https://core.telegram.org/bots/api#botcommandscope
 type BotCommandScope interface {
+	Type() string
 	BotCommandScope() ([]byte, error)
 }
 
 // BotCommandScopeAllChatAdministrators Represents the scope of bot commands, covering all group and supergroup chat administrators.
 // https://core.telegram.org/bots/api#botcommandscopeallchatadministrators
-type BotCommandScopeAllChatAdministrators struct {
-	// Scope type, must be all_chat_administrators
-	Type string `json:"type,omitempty"`
+type BotCommandScopeAllChatAdministrators struct{}
+
+func (v BotCommandScopeAllChatAdministrators) Type() string {
+	return "all_chat_administrators"
 }
 
 func (v BotCommandScopeAllChatAdministrators) MarshalJSON() ([]byte, error) {
@@ -106,9 +108,10 @@ func (v BotCommandScopeAllChatAdministrators) BotCommandScope() ([]byte, error) 
 
 // BotCommandScopeAllGroupChats Represents the scope of bot commands, covering all group and supergroup chats.
 // https://core.telegram.org/bots/api#botcommandscopeallgroupchats
-type BotCommandScopeAllGroupChats struct {
-	// Scope type, must be all_group_chats
-	Type string `json:"type,omitempty"`
+type BotCommandScopeAllGroupChats struct{}
+
+func (v BotCommandScopeAllGroupChats) Type() string {
+	return "all_group_chats"
 }
 
 func (v BotCommandScopeAllGroupChats) MarshalJSON() ([]byte, error) {
@@ -129,9 +132,10 @@ func (v BotCommandScopeAllGroupChats) BotCommandScope() ([]byte, error) {
 
 // BotCommandScopeAllPrivateChats Represents the scope of bot commands, covering all private chats.
 // https://core.telegram.org/bots/api#botcommandscopeallprivatechats
-type BotCommandScopeAllPrivateChats struct {
-	// Scope type, must be all_private_chats
-	Type string `json:"type,omitempty"`
+type BotCommandScopeAllPrivateChats struct{}
+
+func (v BotCommandScopeAllPrivateChats) Type() string {
+	return "all_private_chats"
 }
 
 func (v BotCommandScopeAllPrivateChats) MarshalJSON() ([]byte, error) {
@@ -153,10 +157,12 @@ func (v BotCommandScopeAllPrivateChats) BotCommandScope() ([]byte, error) {
 // BotCommandScopeChat Represents the scope of bot commands, covering a specific chat.
 // https://core.telegram.org/bots/api#botcommandscopechat
 type BotCommandScopeChat struct {
-	// Scope type, must be chat
-	Type string `json:"type,omitempty"`
 	// Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
 	ChatId int64 `json:"chat_id,omitempty"`
+}
+
+func (v BotCommandScopeChat) Type() string {
+	return "chat"
 }
 
 func (v BotCommandScopeChat) MarshalJSON() ([]byte, error) {
@@ -178,10 +184,12 @@ func (v BotCommandScopeChat) BotCommandScope() ([]byte, error) {
 // BotCommandScopeChatAdministrators Represents the scope of bot commands, covering all administrators of a specific group or supergroup chat.
 // https://core.telegram.org/bots/api#botcommandscopechatadministrators
 type BotCommandScopeChatAdministrators struct {
-	// Scope type, must be chat_administrators
-	Type string `json:"type,omitempty"`
 	// Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
 	ChatId int64 `json:"chat_id,omitempty"`
+}
+
+func (v BotCommandScopeChatAdministrators) Type() string {
+	return "chat_administrators"
 }
 
 func (v BotCommandScopeChatAdministrators) MarshalJSON() ([]byte, error) {
@@ -203,12 +211,14 @@ func (v BotCommandScopeChatAdministrators) BotCommandScope() ([]byte, error) {
 // BotCommandScopeChatMember Represents the scope of bot commands, covering a specific member of a group or supergroup chat.
 // https://core.telegram.org/bots/api#botcommandscopechatmember
 type BotCommandScopeChatMember struct {
-	// Scope type, must be chat_member
-	Type string `json:"type,omitempty"`
 	// Unique identifier for the target chat or username of the target supergroup (in the format @supergroupusername)
 	ChatId int64 `json:"chat_id,omitempty"`
 	// Unique identifier of the target user
 	UserId int64 `json:"user_id,omitempty"`
+}
+
+func (v BotCommandScopeChatMember) Type() string {
+	return "chat_member"
 }
 
 func (v BotCommandScopeChatMember) MarshalJSON() ([]byte, error) {
@@ -229,9 +239,10 @@ func (v BotCommandScopeChatMember) BotCommandScope() ([]byte, error) {
 
 // BotCommandScopeDefault Represents the default scope of bot commands. Default commands are used if no commands with a narrower scope are specified for the user.
 // https://core.telegram.org/bots/api#botcommandscopedefault
-type BotCommandScopeDefault struct {
-	// Scope type, must be default
-	Type string `json:"type,omitempty"`
+type BotCommandScopeDefault struct{}
+
+func (v BotCommandScopeDefault) Type() string {
+	return "default"
 }
 
 func (v BotCommandScopeDefault) MarshalJSON() ([]byte, error) {
@@ -349,14 +360,13 @@ type ChatLocation struct {
 // - ChatMemberBanned
 // https://core.telegram.org/bots/api#chatmember
 type ChatMember interface {
+	Status() string
 	ChatMember() ([]byte, error)
 }
 
 // ChatMemberAdministrator Represents a chat member that has some additional privileges.
 // https://core.telegram.org/bots/api#chatmemberadministrator
 type ChatMemberAdministrator struct {
-	// The member's status in the chat, always "administrator"
-	Status string `json:"status,omitempty"`
 	// Information about the user
 	User User `json:"user,omitempty"`
 	// True, if the bot is allowed to edit administrator privileges of that user
@@ -387,6 +397,10 @@ type ChatMemberAdministrator struct {
 	CanPinMessages bool `json:"can_pin_messages,omitempty"`
 }
 
+func (v ChatMemberAdministrator) Status() string {
+	return "administrator"
+}
+
 func (v ChatMemberAdministrator) MarshalJSON() ([]byte, error) {
 	type alias ChatMemberAdministrator
 	a := struct {
@@ -406,12 +420,14 @@ func (v ChatMemberAdministrator) ChatMember() ([]byte, error) {
 // ChatMemberBanned Represents a chat member that was banned in the chat and can't return to the chat or view chat messages.
 // https://core.telegram.org/bots/api#chatmemberbanned
 type ChatMemberBanned struct {
-	// The member's status in the chat, always "kicked"
-	Status string `json:"status,omitempty"`
 	// Information about the user
 	User User `json:"user,omitempty"`
 	// Date when restrictions will be lifted for this user; unix time
 	UntilDate int64 `json:"until_date,omitempty"`
+}
+
+func (v ChatMemberBanned) Status() string {
+	return "banned"
 }
 
 func (v ChatMemberBanned) MarshalJSON() ([]byte, error) {
@@ -433,10 +449,12 @@ func (v ChatMemberBanned) ChatMember() ([]byte, error) {
 // ChatMemberLeft Represents a chat member that isn't currently a member of the chat, but may join it themselves.
 // https://core.telegram.org/bots/api#chatmemberleft
 type ChatMemberLeft struct {
-	// The member's status in the chat, always "left"
-	Status string `json:"status,omitempty"`
 	// Information about the user
 	User User `json:"user,omitempty"`
+}
+
+func (v ChatMemberLeft) Status() string {
+	return "left"
 }
 
 func (v ChatMemberLeft) MarshalJSON() ([]byte, error) {
@@ -458,10 +476,12 @@ func (v ChatMemberLeft) ChatMember() ([]byte, error) {
 // ChatMemberMember Represents a chat member that has no additional privileges or restrictions.
 // https://core.telegram.org/bots/api#chatmembermember
 type ChatMemberMember struct {
-	// The member's status in the chat, always "member"
-	Status string `json:"status,omitempty"`
 	// Information about the user
 	User User `json:"user,omitempty"`
+}
+
+func (v ChatMemberMember) Status() string {
+	return "member"
 }
 
 func (v ChatMemberMember) MarshalJSON() ([]byte, error) {
@@ -483,14 +503,16 @@ func (v ChatMemberMember) ChatMember() ([]byte, error) {
 // ChatMemberOwner Represents a chat member that owns the chat and has all administrator privileges.
 // https://core.telegram.org/bots/api#chatmemberowner
 type ChatMemberOwner struct {
-	// The member's status in the chat, always "creator"
-	Status string `json:"status,omitempty"`
 	// Information about the user
 	User User `json:"user,omitempty"`
 	// Custom title for this user
 	CustomTitle string `json:"custom_title,omitempty"`
 	// True, if the user's presence in the chat is hidden
 	IsAnonymous bool `json:"is_anonymous,omitempty"`
+}
+
+func (v ChatMemberOwner) Status() string {
+	return "owner"
 }
 
 func (v ChatMemberOwner) MarshalJSON() ([]byte, error) {
@@ -512,8 +534,6 @@ func (v ChatMemberOwner) ChatMember() ([]byte, error) {
 // ChatMemberRestricted Represents a chat member that is under certain restrictions in the chat. Supergroups only.
 // https://core.telegram.org/bots/api#chatmemberrestricted
 type ChatMemberRestricted struct {
-	// The member's status in the chat, always "restricted"
-	Status string `json:"status,omitempty"`
 	// Information about the user
 	User User `json:"user,omitempty"`
 	// True, if the user is a member of the chat at the moment of the request
@@ -536,6 +556,10 @@ type ChatMemberRestricted struct {
 	CanAddWebPagePreviews bool `json:"can_add_web_page_previews,omitempty"`
 	// Date when restrictions will be lifted for this user; unix time
 	UntilDate int64 `json:"until_date,omitempty"`
+}
+
+func (v ChatMemberRestricted) Status() string {
+	return "restricted"
 }
 
 func (v ChatMemberRestricted) MarshalJSON() ([]byte, error) {
@@ -857,6 +881,10 @@ type InlineQueryResultArticle struct {
 	ThumbHeight int64 `json:"thumb_height,omitempty"`
 }
 
+func (v InlineQueryResultArticle) Type() string {
+	return "article"
+}
+
 func (v InlineQueryResultArticle) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultArticle
 	a := struct {
@@ -899,6 +927,10 @@ type InlineQueryResultAudio struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+func (v InlineQueryResultAudio) Type() string {
+	return "audio"
+}
+
 func (v InlineQueryResultAudio) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultAudio
 	a := struct {
@@ -933,6 +965,10 @@ type InlineQueryResultCachedAudio struct {
 	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
 	// Optional. Content of the message to be sent instead of the audio
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
+}
+
+func (v InlineQueryResultCachedAudio) Type() string {
+	return "audio"
 }
 
 func (v InlineQueryResultCachedAudio) MarshalJSON() ([]byte, error) {
@@ -975,6 +1011,10 @@ type InlineQueryResultCachedDocument struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+func (v InlineQueryResultCachedDocument) Type() string {
+	return "document"
+}
+
 func (v InlineQueryResultCachedDocument) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultCachedDocument
 	a := struct {
@@ -1012,6 +1052,10 @@ type InlineQueryResultCachedGif struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+func (v InlineQueryResultCachedGif) Type() string {
+	return "gif"
+}
+
 func (v InlineQueryResultCachedGif) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultCachedGif
 	a := struct {
@@ -1047,6 +1091,10 @@ type InlineQueryResultCachedMpeg4Gif struct {
 	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
 	// Optional. Content of the message to be sent instead of the video animation
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
+}
+
+func (v InlineQueryResultCachedMpeg4Gif) Type() string {
+	return "mpeg4_gif"
 }
 
 func (v InlineQueryResultCachedMpeg4Gif) MarshalJSON() ([]byte, error) {
@@ -1088,6 +1136,10 @@ type InlineQueryResultCachedPhoto struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+func (v InlineQueryResultCachedPhoto) Type() string {
+	return "photo"
+}
+
 func (v InlineQueryResultCachedPhoto) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultCachedPhoto
 	a := struct {
@@ -1116,6 +1168,10 @@ type InlineQueryResultCachedSticker struct {
 	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
 	// Optional. Content of the message to be sent instead of the sticker
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
+}
+
+func (v InlineQueryResultCachedSticker) Type() string {
+	return "sticker"
 }
 
 func (v InlineQueryResultCachedSticker) MarshalJSON() ([]byte, error) {
@@ -1157,6 +1213,10 @@ type InlineQueryResultCachedVideo struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+func (v InlineQueryResultCachedVideo) Type() string {
+	return "video"
+}
+
 func (v InlineQueryResultCachedVideo) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultCachedVideo
 	a := struct {
@@ -1193,6 +1253,10 @@ type InlineQueryResultCachedVoice struct {
 	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
 	// Optional. Content of the message to be sent instead of the voice message
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
+}
+
+func (v InlineQueryResultCachedVoice) Type() string {
+	return "voice"
 }
 
 func (v InlineQueryResultCachedVoice) MarshalJSON() ([]byte, error) {
@@ -1235,6 +1299,10 @@ type InlineQueryResultContact struct {
 	ThumbWidth int64 `json:"thumb_width,omitempty"`
 	// Optional. Thumbnail height
 	ThumbHeight int64 `json:"thumb_height,omitempty"`
+}
+
+func (v InlineQueryResultContact) Type() string {
+	return "contact"
 }
 
 func (v InlineQueryResultContact) MarshalJSON() ([]byte, error) {
@@ -1285,6 +1353,10 @@ type InlineQueryResultDocument struct {
 	ThumbHeight int64 `json:"thumb_height,omitempty"`
 }
 
+func (v InlineQueryResultDocument) Type() string {
+	return "document"
+}
+
 func (v InlineQueryResultDocument) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultDocument
 	a := struct {
@@ -1311,6 +1383,10 @@ type InlineQueryResultGame struct {
 	GameShortName string `json:"game_short_name,omitempty"`
 	// Optional. Inline keyboard attached to the message
 	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
+}
+
+func (v InlineQueryResultGame) Type() string {
+	return "game"
 }
 
 func (v InlineQueryResultGame) MarshalJSON() ([]byte, error) {
@@ -1358,6 +1434,10 @@ type InlineQueryResultGif struct {
 	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
 	// Optional. Content of the message to be sent instead of the GIF animation
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
+}
+
+func (v InlineQueryResultGif) Type() string {
+	return "gif"
 }
 
 func (v InlineQueryResultGif) MarshalJSON() ([]byte, error) {
@@ -1408,6 +1488,10 @@ type InlineQueryResultLocation struct {
 	ThumbHeight int64 `json:"thumb_height,omitempty"`
 }
 
+func (v InlineQueryResultLocation) Type() string {
+	return "location"
+}
+
 func (v InlineQueryResultLocation) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultLocation
 	a := struct {
@@ -1455,6 +1539,10 @@ type InlineQueryResultMpeg4Gif struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+func (v InlineQueryResultMpeg4Gif) Type() string {
+	return "mpeg4_gif"
+}
+
 func (v InlineQueryResultMpeg4Gif) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultMpeg4Gif
 	a := struct {
@@ -1498,6 +1586,10 @@ type InlineQueryResultPhoto struct {
 	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
 	// Optional. Content of the message to be sent instead of the photo
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
+}
+
+func (v InlineQueryResultPhoto) Type() string {
+	return "photo"
 }
 
 func (v InlineQueryResultPhoto) MarshalJSON() ([]byte, error) {
@@ -1550,6 +1642,10 @@ type InlineQueryResultVenue struct {
 	ThumbHeight int64 `json:"thumb_height,omitempty"`
 }
 
+func (v InlineQueryResultVenue) Type() string {
+	return "venue"
+}
+
 func (v InlineQueryResultVenue) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultVenue
 	a := struct {
@@ -1599,6 +1695,10 @@ type InlineQueryResultVideo struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+func (v InlineQueryResultVideo) Type() string {
+	return "video"
+}
+
 func (v InlineQueryResultVideo) MarshalJSON() ([]byte, error) {
 	type alias InlineQueryResultVideo
 	a := struct {
@@ -1637,6 +1737,10 @@ type InlineQueryResultVoice struct {
 	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
 	// Optional. Content of the message to be sent instead of the voice recording
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
+}
+
+func (v InlineQueryResultVoice) Type() string {
+	return "voice"
 }
 
 func (v InlineQueryResultVoice) MarshalJSON() ([]byte, error) {
@@ -1754,6 +1858,7 @@ func (v InputLocationMessageContent) InputMessageContent() ([]byte, error) {
 // - InputMediaVideo
 // https://core.telegram.org/bots/api#inputmedia
 type InputMedia interface {
+	Type() string
 	InputMediaParams(string, map[string]NamedReader) ([]byte, error)
 }
 
@@ -1776,6 +1881,10 @@ type InputMediaAnimation struct {
 	Height int64 `json:"height,omitempty"`
 	// Optional. Animation duration
 	Duration int64 `json:"duration,omitempty"`
+}
+
+func (v InputMediaAnimation) Type() string {
+	return "animation"
 }
 
 func (v InputMediaAnimation) MarshalJSON() ([]byte, error) {
@@ -1833,6 +1942,10 @@ type InputMediaAudio struct {
 	Title string `json:"title,omitempty"`
 }
 
+func (v InputMediaAudio) Type() string {
+	return "audio"
+}
+
 func (v InputMediaAudio) MarshalJSON() ([]byte, error) {
 	type alias InputMediaAudio
 	a := struct {
@@ -1884,6 +1997,10 @@ type InputMediaDocument struct {
 	DisableContentTypeDetection bool `json:"disable_content_type_detection,omitempty"`
 }
 
+func (v InputMediaDocument) Type() string {
+	return "document"
+}
+
 func (v InputMediaDocument) MarshalJSON() ([]byte, error) {
 	type alias InputMediaDocument
 	a := struct {
@@ -1929,6 +2046,10 @@ type InputMediaPhoto struct {
 	ParseMode string `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
+}
+
+func (v InputMediaPhoto) Type() string {
+	return "photo"
 }
 
 func (v InputMediaPhoto) MarshalJSON() ([]byte, error) {
@@ -1986,6 +2107,10 @@ type InputMediaVideo struct {
 	Duration int64 `json:"duration,omitempty"`
 	// Optional. Pass True, if the uploaded video is suitable for streaming
 	SupportsStreaming bool `json:"supports_streaming,omitempty"`
+}
+
+func (v InputMediaVideo) Type() string {
+	return "video"
 }
 
 func (v InputMediaVideo) MarshalJSON() ([]byte, error) {

--- a/gen_types.go
+++ b/gen_types.go
@@ -390,11 +390,11 @@ type ChatMemberAdministrator struct {
 func (v ChatMemberAdministrator) MarshalJSON() ([]byte, error) {
 	type alias ChatMemberAdministrator
 	a := struct {
-		Type string `json:"type"`
+		Status string `json:"status"`
 		alias
 	}{
-		Type:  "administrator",
-		alias: (alias)(v),
+		Status: "administrator",
+		alias:  (alias)(v),
 	}
 	return json.Marshal(a)
 }
@@ -417,11 +417,11 @@ type ChatMemberBanned struct {
 func (v ChatMemberBanned) MarshalJSON() ([]byte, error) {
 	type alias ChatMemberBanned
 	a := struct {
-		Type string `json:"type"`
+		Status string `json:"status"`
 		alias
 	}{
-		Type:  "banned",
-		alias: (alias)(v),
+		Status: "banned",
+		alias:  (alias)(v),
 	}
 	return json.Marshal(a)
 }
@@ -442,11 +442,11 @@ type ChatMemberLeft struct {
 func (v ChatMemberLeft) MarshalJSON() ([]byte, error) {
 	type alias ChatMemberLeft
 	a := struct {
-		Type string `json:"type"`
+		Status string `json:"status"`
 		alias
 	}{
-		Type:  "left",
-		alias: (alias)(v),
+		Status: "left",
+		alias:  (alias)(v),
 	}
 	return json.Marshal(a)
 }
@@ -467,11 +467,11 @@ type ChatMemberMember struct {
 func (v ChatMemberMember) MarshalJSON() ([]byte, error) {
 	type alias ChatMemberMember
 	a := struct {
-		Type string `json:"type"`
+		Status string `json:"status"`
 		alias
 	}{
-		Type:  "member",
-		alias: (alias)(v),
+		Status: "member",
+		alias:  (alias)(v),
 	}
 	return json.Marshal(a)
 }
@@ -496,11 +496,11 @@ type ChatMemberOwner struct {
 func (v ChatMemberOwner) MarshalJSON() ([]byte, error) {
 	type alias ChatMemberOwner
 	a := struct {
-		Type string `json:"type"`
+		Status string `json:"status"`
 		alias
 	}{
-		Type:  "owner",
-		alias: (alias)(v),
+		Status: "owner",
+		alias:  (alias)(v),
 	}
 	return json.Marshal(a)
 }
@@ -541,11 +541,11 @@ type ChatMemberRestricted struct {
 func (v ChatMemberRestricted) MarshalJSON() ([]byte, error) {
 	type alias ChatMemberRestricted
 	a := struct {
-		Type string `json:"type"`
+		Status string `json:"status"`
 		alias
 	}{
-		Type:  "restricted",
-		alias: (alias)(v),
+		Status: "restricted",
+		alias:  (alias)(v),
 	}
 	return json.Marshal(a)
 }

--- a/gen_types.go
+++ b/gen_types.go
@@ -93,6 +93,7 @@ type MergedBotCommandScope struct {
 	UserId int64 `json:"user_id,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v MergedBotCommandScope) GetType() string {
 	return v.Type
 }
@@ -108,11 +109,12 @@ func (v MergedBotCommandScope) MergeBotCommandScope() MergedBotCommandScope {
 // https://core.telegram.org/bots/api#botcommandscopeallchatadministrators
 type BotCommandScopeAllChatAdministrators struct{}
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v BotCommandScopeAllChatAdministrators) GetType() string {
 	return "all_chat_administrators"
 }
 
-// BotCommandScopeAllChatAdministrators.MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+// MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
 func (v BotCommandScopeAllChatAdministrators) MergeBotCommandScope() MergedBotCommandScope {
 	return MergedBotCommandScope{
 		Type: "all_chat_administrators",
@@ -138,11 +140,12 @@ func (v BotCommandScopeAllChatAdministrators) botCommandScope() {}
 // https://core.telegram.org/bots/api#botcommandscopeallgroupchats
 type BotCommandScopeAllGroupChats struct{}
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v BotCommandScopeAllGroupChats) GetType() string {
 	return "all_group_chats"
 }
 
-// BotCommandScopeAllGroupChats.MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+// MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
 func (v BotCommandScopeAllGroupChats) MergeBotCommandScope() MergedBotCommandScope {
 	return MergedBotCommandScope{
 		Type: "all_group_chats",
@@ -168,11 +171,12 @@ func (v BotCommandScopeAllGroupChats) botCommandScope() {}
 // https://core.telegram.org/bots/api#botcommandscopeallprivatechats
 type BotCommandScopeAllPrivateChats struct{}
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v BotCommandScopeAllPrivateChats) GetType() string {
 	return "all_private_chats"
 }
 
-// BotCommandScopeAllPrivateChats.MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+// MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
 func (v BotCommandScopeAllPrivateChats) MergeBotCommandScope() MergedBotCommandScope {
 	return MergedBotCommandScope{
 		Type: "all_private_chats",
@@ -201,11 +205,12 @@ type BotCommandScopeChat struct {
 	ChatId int64 `json:"chat_id,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v BotCommandScopeChat) GetType() string {
 	return "chat"
 }
 
-// BotCommandScopeChat.MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+// MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
 func (v BotCommandScopeChat) MergeBotCommandScope() MergedBotCommandScope {
 	return MergedBotCommandScope{
 		Type:   "chat",
@@ -235,11 +240,12 @@ type BotCommandScopeChatAdministrators struct {
 	ChatId int64 `json:"chat_id,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v BotCommandScopeChatAdministrators) GetType() string {
 	return "chat_administrators"
 }
 
-// BotCommandScopeChatAdministrators.MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+// MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
 func (v BotCommandScopeChatAdministrators) MergeBotCommandScope() MergedBotCommandScope {
 	return MergedBotCommandScope{
 		Type:   "chat_administrators",
@@ -271,11 +277,12 @@ type BotCommandScopeChatMember struct {
 	UserId int64 `json:"user_id,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v BotCommandScopeChatMember) GetType() string {
 	return "chat_member"
 }
 
-// BotCommandScopeChatMember.MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+// MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
 func (v BotCommandScopeChatMember) MergeBotCommandScope() MergedBotCommandScope {
 	return MergedBotCommandScope{
 		Type:   "chat_member",
@@ -303,11 +310,12 @@ func (v BotCommandScopeChatMember) botCommandScope() {}
 // https://core.telegram.org/bots/api#botcommandscopedefault
 type BotCommandScopeDefault struct{}
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v BotCommandScopeDefault) GetType() string {
 	return "default"
 }
 
-// BotCommandScopeDefault.MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
+// MergeBotCommandScope returns a MergedBotCommandScope struct to simply working with types in a non-generic world.
 func (v BotCommandScopeDefault) MergeBotCommandScope() MergedBotCommandScope {
 	return MergedBotCommandScope{
 		Type: "default",
@@ -482,10 +490,12 @@ type MergedChatMember struct {
 	UntilDate int64 `json:"until_date,omitempty"`
 }
 
+// GetStatus is a helper method to easily access the common fields of an interface.
 func (v MergedChatMember) GetStatus() string {
 	return v.Status
 }
 
+// GetUser is a helper method to easily access the common fields of an interface.
 func (v MergedChatMember) GetUser() User {
 	return v.User
 }
@@ -596,15 +606,17 @@ type ChatMemberAdministrator struct {
 	CanPinMessages bool `json:"can_pin_messages,omitempty"`
 }
 
+// GetStatus is a helper method to easily access the common fields of an interface.
 func (v ChatMemberAdministrator) GetStatus() string {
 	return "administrator"
 }
 
+// GetUser is a helper method to easily access the common fields of an interface.
 func (v ChatMemberAdministrator) GetUser() User {
 	return v.User
 }
 
-// ChatMemberAdministrator.MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
+// MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
 func (v ChatMemberAdministrator) MergeChatMember() MergedChatMember {
 	return MergedChatMember{
 		Status:              "administrator",
@@ -649,15 +661,17 @@ type ChatMemberBanned struct {
 	UntilDate int64 `json:"until_date,omitempty"`
 }
 
+// GetStatus is a helper method to easily access the common fields of an interface.
 func (v ChatMemberBanned) GetStatus() string {
 	return "banned"
 }
 
+// GetUser is a helper method to easily access the common fields of an interface.
 func (v ChatMemberBanned) GetUser() User {
 	return v.User
 }
 
-// ChatMemberBanned.MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
+// MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
 func (v ChatMemberBanned) MergeChatMember() MergedChatMember {
 	return MergedChatMember{
 		Status:    "banned",
@@ -688,15 +702,17 @@ type ChatMemberLeft struct {
 	User User `json:"user,omitempty"`
 }
 
+// GetStatus is a helper method to easily access the common fields of an interface.
 func (v ChatMemberLeft) GetStatus() string {
 	return "left"
 }
 
+// GetUser is a helper method to easily access the common fields of an interface.
 func (v ChatMemberLeft) GetUser() User {
 	return v.User
 }
 
-// ChatMemberLeft.MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
+// MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
 func (v ChatMemberLeft) MergeChatMember() MergedChatMember {
 	return MergedChatMember{
 		Status: "left",
@@ -726,15 +742,17 @@ type ChatMemberMember struct {
 	User User `json:"user,omitempty"`
 }
 
+// GetStatus is a helper method to easily access the common fields of an interface.
 func (v ChatMemberMember) GetStatus() string {
 	return "member"
 }
 
+// GetUser is a helper method to easily access the common fields of an interface.
 func (v ChatMemberMember) GetUser() User {
 	return v.User
 }
 
-// ChatMemberMember.MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
+// MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
 func (v ChatMemberMember) MergeChatMember() MergedChatMember {
 	return MergedChatMember{
 		Status: "member",
@@ -768,15 +786,17 @@ type ChatMemberOwner struct {
 	IsAnonymous bool `json:"is_anonymous,omitempty"`
 }
 
+// GetStatus is a helper method to easily access the common fields of an interface.
 func (v ChatMemberOwner) GetStatus() string {
 	return "owner"
 }
 
+// GetUser is a helper method to easily access the common fields of an interface.
 func (v ChatMemberOwner) GetUser() User {
 	return v.User
 }
 
-// ChatMemberOwner.MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
+// MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
 func (v ChatMemberOwner) MergeChatMember() MergedChatMember {
 	return MergedChatMember{
 		Status:      "owner",
@@ -828,15 +848,17 @@ type ChatMemberRestricted struct {
 	UntilDate int64 `json:"until_date,omitempty"`
 }
 
+// GetStatus is a helper method to easily access the common fields of an interface.
 func (v ChatMemberRestricted) GetStatus() string {
 	return "restricted"
 }
 
+// GetUser is a helper method to easily access the common fields of an interface.
 func (v ChatMemberRestricted) GetUser() User {
 	return v.User
 }
 
-// ChatMemberRestricted.MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
+// MergeChatMember returns a MergedChatMember struct to simply working with types in a non-generic world.
 func (v ChatMemberRestricted) MergeChatMember() MergedChatMember {
 	return MergedChatMember{
 		Status:                "restricted",
@@ -1306,10 +1328,12 @@ type MergedInlineQueryResult struct {
 	VoiceDuration int64 `json:"voice_duration,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v MergedInlineQueryResult) GetType() string {
 	return v.Type
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v MergedInlineQueryResult) GetId() string {
 	return v.Id
 }
@@ -1346,15 +1370,17 @@ type InlineQueryResultArticle struct {
 	ThumbHeight int64 `json:"thumb_height,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultArticle) GetType() string {
 	return "article"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultArticle) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultArticle.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultArticle) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "article",
@@ -1412,15 +1438,17 @@ type InlineQueryResultAudio struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultAudio) GetType() string {
 	return "audio"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultAudio) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultAudio.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultAudio) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "audio",
@@ -1472,15 +1500,17 @@ type InlineQueryResultCachedAudio struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultCachedAudio) GetType() string {
 	return "audio"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultCachedAudio) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultCachedAudio.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultCachedAudio) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "audio",
@@ -1533,15 +1563,17 @@ type InlineQueryResultCachedDocument struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultCachedDocument) GetType() string {
 	return "document"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultCachedDocument) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultCachedDocument.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultCachedDocument) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "document",
@@ -1593,15 +1625,17 @@ type InlineQueryResultCachedGif struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultCachedGif) GetType() string {
 	return "gif"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultCachedGif) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultCachedGif.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultCachedGif) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "gif",
@@ -1652,15 +1686,17 @@ type InlineQueryResultCachedMpeg4Gif struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultCachedMpeg4Gif) GetType() string {
 	return "mpeg4_gif"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultCachedMpeg4Gif) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultCachedMpeg4Gif.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultCachedMpeg4Gif) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "mpeg4_gif",
@@ -1713,15 +1749,17 @@ type InlineQueryResultCachedPhoto struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultCachedPhoto) GetType() string {
 	return "photo"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultCachedPhoto) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultCachedPhoto.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultCachedPhoto) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "photo",
@@ -1766,15 +1804,17 @@ type InlineQueryResultCachedSticker struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultCachedSticker) GetType() string {
 	return "sticker"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultCachedSticker) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultCachedSticker.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultCachedSticker) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "sticker",
@@ -1823,15 +1863,17 @@ type InlineQueryResultCachedVideo struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultCachedVideo) GetType() string {
 	return "video"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultCachedVideo) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultCachedVideo.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultCachedVideo) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "video",
@@ -1884,15 +1926,17 @@ type InlineQueryResultCachedVoice struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultCachedVoice) GetType() string {
 	return "voice"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultCachedVoice) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultCachedVoice.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultCachedVoice) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "voice",
@@ -1948,15 +1992,17 @@ type InlineQueryResultContact struct {
 	ThumbHeight int64 `json:"thumb_height,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultContact) GetType() string {
 	return "contact"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultContact) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultContact.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultContact) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "contact",
@@ -2020,15 +2066,17 @@ type InlineQueryResultDocument struct {
 	ThumbHeight int64 `json:"thumb_height,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultDocument) GetType() string {
 	return "document"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultDocument) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultDocument.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultDocument) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "document",
@@ -2075,15 +2123,17 @@ type InlineQueryResultGame struct {
 	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultGame) GetType() string {
 	return "game"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultGame) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultGame.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultGame) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:          "game",
@@ -2139,15 +2189,17 @@ type InlineQueryResultGif struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultGif) GetType() string {
 	return "gif"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultGif) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultGif.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultGif) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "gif",
@@ -2214,15 +2266,17 @@ type InlineQueryResultLocation struct {
 	ThumbHeight int64 `json:"thumb_height,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultLocation) GetType() string {
 	return "location"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultLocation) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultLocation.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultLocation) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                 "location",
@@ -2288,15 +2342,17 @@ type InlineQueryResultMpeg4Gif struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultMpeg4Gif) GetType() string {
 	return "mpeg4_gif"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultMpeg4Gif) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultMpeg4Gif.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultMpeg4Gif) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "mpeg4_gif",
@@ -2360,15 +2416,17 @@ type InlineQueryResultPhoto struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultPhoto) GetType() string {
 	return "photo"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultPhoto) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultPhoto.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultPhoto) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "photo",
@@ -2436,15 +2494,17 @@ type InlineQueryResultVenue struct {
 	ThumbHeight int64 `json:"thumb_height,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultVenue) GetType() string {
 	return "venue"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultVenue) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultVenue.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultVenue) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "venue",
@@ -2513,15 +2573,17 @@ type InlineQueryResultVideo struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultVideo) GetType() string {
 	return "video"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultVideo) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultVideo.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultVideo) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "video",
@@ -2581,15 +2643,17 @@ type InlineQueryResultVoice struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultVoice) GetType() string {
 	return "voice"
 }
 
+// GetId is a helper method to easily access the common fields of an interface.
 func (v InlineQueryResultVoice) GetId() string {
 	return v.Id
 }
 
-// InlineQueryResultVoice.MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
+// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simply working with types in a non-generic world.
 func (v InlineQueryResultVoice) MergeInlineQueryResult() MergedInlineQueryResult {
 	return MergedInlineQueryResult{
 		Type:                "voice",
@@ -2754,10 +2818,12 @@ type MergedInputMedia struct {
 	SupportsStreaming bool `json:"supports_streaming,omitempty"`
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v MergedInputMedia) GetType() string {
 	return v.Type
 }
 
+// GetMedia is a helper method to easily access the common fields of an interface.
 func (v MergedInputMedia) GetMedia() InputFile {
 	return v.Media
 }
@@ -2812,15 +2878,17 @@ func (v InputMediaAnimation) InputMediaParams(mediaName string, data map[string]
 	return json.Marshal(v)
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InputMediaAnimation) GetType() string {
 	return "animation"
 }
 
+// GetMedia is a helper method to easily access the common fields of an interface.
 func (v InputMediaAnimation) GetMedia() InputFile {
 	return v.Media
 }
 
-// InputMediaAnimation.MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
+// MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
 func (v InputMediaAnimation) MergeInputMedia() MergedInputMedia {
 	return MergedInputMedia{
 		Type:            "animation",
@@ -2893,15 +2961,17 @@ func (v InputMediaAudio) InputMediaParams(mediaName string, data map[string]Name
 	return json.Marshal(v)
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InputMediaAudio) GetType() string {
 	return "audio"
 }
 
+// GetMedia is a helper method to easily access the common fields of an interface.
 func (v InputMediaAudio) GetMedia() InputFile {
 	return v.Media
 }
 
-// InputMediaAudio.MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
+// MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
 func (v InputMediaAudio) MergeInputMedia() MergedInputMedia {
 	return MergedInputMedia{
 		Type:            "audio",
@@ -2970,15 +3040,17 @@ func (v InputMediaDocument) InputMediaParams(mediaName string, data map[string]N
 	return json.Marshal(v)
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InputMediaDocument) GetType() string {
 	return "document"
 }
 
+// GetMedia is a helper method to easily access the common fields of an interface.
 func (v InputMediaDocument) GetMedia() InputFile {
 	return v.Media
 }
 
-// InputMediaDocument.MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
+// MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
 func (v InputMediaDocument) MergeInputMedia() MergedInputMedia {
 	return MergedInputMedia{
 		Type:                        "document",
@@ -3041,15 +3113,17 @@ func (v InputMediaPhoto) InputMediaParams(mediaName string, data map[string]Name
 	return json.Marshal(v)
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InputMediaPhoto) GetType() string {
 	return "photo"
 }
 
+// GetMedia is a helper method to easily access the common fields of an interface.
 func (v InputMediaPhoto) GetMedia() InputFile {
 	return v.Media
 }
 
-// InputMediaPhoto.MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
+// MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
 func (v InputMediaPhoto) MergeInputMedia() MergedInputMedia {
 	return MergedInputMedia{
 		Type:            "photo",
@@ -3120,15 +3194,17 @@ func (v InputMediaVideo) InputMediaParams(mediaName string, data map[string]Name
 	return json.Marshal(v)
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v InputMediaVideo) GetType() string {
 	return "video"
 }
 
+// GetMedia is a helper method to easily access the common fields of an interface.
 func (v InputMediaVideo) GetMedia() InputFile {
 	return v.Media
 }
 
-// InputMediaVideo.MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
+// MergeInputMedia returns a MergedInputMedia struct to simply working with types in a non-generic world.
 func (v InputMediaVideo) MergeInputMedia() MergedInputMedia {
 	return MergedInputMedia{
 		Type:              "video",
@@ -3508,14 +3584,17 @@ type MergedPassportElementError struct {
 	ElementHash string `json:"element_hash,omitempty"`
 }
 
+// GetSource is a helper method to easily access the common fields of an interface.
 func (v MergedPassportElementError) GetSource() string {
 	return v.Source
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v MergedPassportElementError) GetType() string {
 	return v.Type
 }
 
+// GetMessage is a helper method to easily access the common fields of an interface.
 func (v MergedPassportElementError) GetMessage() string {
 	return v.Message
 }
@@ -3540,19 +3619,22 @@ type PassportElementErrorDataField struct {
 	Message string `json:"message,omitempty"`
 }
 
+// GetSource is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorDataField) GetSource() string {
 	return "data"
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorDataField) GetType() string {
 	return v.Type
 }
 
+// GetMessage is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorDataField) GetMessage() string {
 	return v.Message
 }
 
-// PassportElementErrorDataField.MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+// MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
 func (v PassportElementErrorDataField) MergePassportElementError() MergedPassportElementError {
 	return MergedPassportElementError{
 		Source:    "data",
@@ -3589,19 +3671,22 @@ type PassportElementErrorFile struct {
 	Message string `json:"message,omitempty"`
 }
 
+// GetSource is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorFile) GetSource() string {
 	return "file"
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorFile) GetType() string {
 	return v.Type
 }
 
+// GetMessage is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorFile) GetMessage() string {
 	return v.Message
 }
 
-// PassportElementErrorFile.MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+// MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
 func (v PassportElementErrorFile) MergePassportElementError() MergedPassportElementError {
 	return MergedPassportElementError{
 		Source:   "file",
@@ -3637,19 +3722,22 @@ type PassportElementErrorFiles struct {
 	Message string `json:"message,omitempty"`
 }
 
+// GetSource is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorFiles) GetSource() string {
 	return "files"
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorFiles) GetType() string {
 	return v.Type
 }
 
+// GetMessage is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorFiles) GetMessage() string {
 	return v.Message
 }
 
-// PassportElementErrorFiles.MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+// MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
 func (v PassportElementErrorFiles) MergePassportElementError() MergedPassportElementError {
 	return MergedPassportElementError{
 		Source:     "files",
@@ -3685,19 +3773,22 @@ type PassportElementErrorFrontSide struct {
 	Message string `json:"message,omitempty"`
 }
 
+// GetSource is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorFrontSide) GetSource() string {
 	return "front_side"
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorFrontSide) GetType() string {
 	return v.Type
 }
 
+// GetMessage is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorFrontSide) GetMessage() string {
 	return v.Message
 }
 
-// PassportElementErrorFrontSide.MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+// MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
 func (v PassportElementErrorFrontSide) MergePassportElementError() MergedPassportElementError {
 	return MergedPassportElementError{
 		Source:   "front_side",
@@ -3733,19 +3824,22 @@ type PassportElementErrorReverseSide struct {
 	Message string `json:"message,omitempty"`
 }
 
+// GetSource is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorReverseSide) GetSource() string {
 	return "reverse_side"
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorReverseSide) GetType() string {
 	return v.Type
 }
 
+// GetMessage is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorReverseSide) GetMessage() string {
 	return v.Message
 }
 
-// PassportElementErrorReverseSide.MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+// MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
 func (v PassportElementErrorReverseSide) MergePassportElementError() MergedPassportElementError {
 	return MergedPassportElementError{
 		Source:   "reverse_side",
@@ -3781,19 +3875,22 @@ type PassportElementErrorSelfie struct {
 	Message string `json:"message,omitempty"`
 }
 
+// GetSource is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorSelfie) GetSource() string {
 	return "selfie"
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorSelfie) GetType() string {
 	return v.Type
 }
 
+// GetMessage is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorSelfie) GetMessage() string {
 	return v.Message
 }
 
-// PassportElementErrorSelfie.MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+// MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
 func (v PassportElementErrorSelfie) MergePassportElementError() MergedPassportElementError {
 	return MergedPassportElementError{
 		Source:   "selfie",
@@ -3829,19 +3926,22 @@ type PassportElementErrorTranslationFile struct {
 	Message string `json:"message,omitempty"`
 }
 
+// GetSource is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorTranslationFile) GetSource() string {
 	return "translation_file"
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorTranslationFile) GetType() string {
 	return v.Type
 }
 
+// GetMessage is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorTranslationFile) GetMessage() string {
 	return v.Message
 }
 
-// PassportElementErrorTranslationFile.MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+// MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
 func (v PassportElementErrorTranslationFile) MergePassportElementError() MergedPassportElementError {
 	return MergedPassportElementError{
 		Source:   "translation_file",
@@ -3877,19 +3977,22 @@ type PassportElementErrorTranslationFiles struct {
 	Message string `json:"message,omitempty"`
 }
 
+// GetSource is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorTranslationFiles) GetSource() string {
 	return "translation_files"
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorTranslationFiles) GetType() string {
 	return v.Type
 }
 
+// GetMessage is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorTranslationFiles) GetMessage() string {
 	return v.Message
 }
 
-// PassportElementErrorTranslationFiles.MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+// MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
 func (v PassportElementErrorTranslationFiles) MergePassportElementError() MergedPassportElementError {
 	return MergedPassportElementError{
 		Source:     "translation_files",
@@ -3925,19 +4028,22 @@ type PassportElementErrorUnspecified struct {
 	Message string `json:"message,omitempty"`
 }
 
+// GetSource is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorUnspecified) GetSource() string {
 	return "unspecified"
 }
 
+// GetType is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorUnspecified) GetType() string {
 	return v.Type
 }
 
+// GetMessage is a helper method to easily access the common fields of an interface.
 func (v PassportElementErrorUnspecified) GetMessage() string {
 	return v.Message
 }
 
-// PassportElementErrorUnspecified.MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
+// MergePassportElementError returns a MergedPassportElementError struct to simply working with types in a non-generic world.
 func (v PassportElementErrorUnspecified) MergePassportElementError() MergedPassportElementError {
 	return MergedPassportElementError{
 		Source:      "unspecified",

--- a/gen_types.go
+++ b/gen_types.go
@@ -10,7 +10,7 @@ import (
 )
 
 type ReplyMarkup interface {
-	ReplyMarkup() ([]byte, error)
+	replyMarkup()
 }
 
 // Animation This object represents an animation file (GIF or H.264/MPEG-4 AVC video without sound).
@@ -79,7 +79,7 @@ type BotCommand struct {
 // https://core.telegram.org/bots/api#botcommandscope
 type BotCommandScope interface {
 	GetType() string
-	BotCommandScope() ([]byte, error)
+	botCommandScope()
 	// MergeBotCommandScope returns a MergedBotCommandScope struct to simplify working with complex telegram types in a non-generic world.
 	MergeBotCommandScope() MergedBotCommandScope
 }
@@ -91,6 +91,17 @@ type MergedBotCommandScope struct {
 	ChatId int64 `json:"chat_id,omitempty"`
 	// Optional. Unique identifier of the target user (Only for chat_member)
 	UserId int64 `json:"user_id,omitempty"`
+}
+
+func (v MergedBotCommandScope) GetType() string {
+	return v.Type
+}
+
+// MergedBotCommandScope.botCommandScope is a dummy method to avoid interface implementation.
+func (v MergedBotCommandScope) botCommandScope() {}
+
+func (v MergedBotCommandScope) MergeBotCommandScope() MergedBotCommandScope {
+	return v
 }
 
 // BotCommandScopeAllChatAdministrators Represents the scope of bot commands, covering all group and supergroup chat administrators.
@@ -120,9 +131,8 @@ func (v BotCommandScopeAllChatAdministrators) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v BotCommandScopeAllChatAdministrators) BotCommandScope() ([]byte, error) {
-	return json.Marshal(v)
-}
+// BotCommandScopeAllChatAdministrators.botCommandScope is a dummy method to avoid interface implementation.
+func (v BotCommandScopeAllChatAdministrators) botCommandScope() {}
 
 // BotCommandScopeAllGroupChats Represents the scope of bot commands, covering all group and supergroup chats.
 // https://core.telegram.org/bots/api#botcommandscopeallgroupchats
@@ -151,9 +161,8 @@ func (v BotCommandScopeAllGroupChats) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v BotCommandScopeAllGroupChats) BotCommandScope() ([]byte, error) {
-	return json.Marshal(v)
-}
+// BotCommandScopeAllGroupChats.botCommandScope is a dummy method to avoid interface implementation.
+func (v BotCommandScopeAllGroupChats) botCommandScope() {}
 
 // BotCommandScopeAllPrivateChats Represents the scope of bot commands, covering all private chats.
 // https://core.telegram.org/bots/api#botcommandscopeallprivatechats
@@ -182,9 +191,8 @@ func (v BotCommandScopeAllPrivateChats) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v BotCommandScopeAllPrivateChats) BotCommandScope() ([]byte, error) {
-	return json.Marshal(v)
-}
+// BotCommandScopeAllPrivateChats.botCommandScope is a dummy method to avoid interface implementation.
+func (v BotCommandScopeAllPrivateChats) botCommandScope() {}
 
 // BotCommandScopeChat Represents the scope of bot commands, covering a specific chat.
 // https://core.telegram.org/bots/api#botcommandscopechat
@@ -217,9 +225,8 @@ func (v BotCommandScopeChat) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v BotCommandScopeChat) BotCommandScope() ([]byte, error) {
-	return json.Marshal(v)
-}
+// BotCommandScopeChat.botCommandScope is a dummy method to avoid interface implementation.
+func (v BotCommandScopeChat) botCommandScope() {}
 
 // BotCommandScopeChatAdministrators Represents the scope of bot commands, covering all administrators of a specific group or supergroup chat.
 // https://core.telegram.org/bots/api#botcommandscopechatadministrators
@@ -252,9 +259,8 @@ func (v BotCommandScopeChatAdministrators) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v BotCommandScopeChatAdministrators) BotCommandScope() ([]byte, error) {
-	return json.Marshal(v)
-}
+// BotCommandScopeChatAdministrators.botCommandScope is a dummy method to avoid interface implementation.
+func (v BotCommandScopeChatAdministrators) botCommandScope() {}
 
 // BotCommandScopeChatMember Represents the scope of bot commands, covering a specific member of a group or supergroup chat.
 // https://core.telegram.org/bots/api#botcommandscopechatmember
@@ -290,9 +296,8 @@ func (v BotCommandScopeChatMember) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v BotCommandScopeChatMember) BotCommandScope() ([]byte, error) {
-	return json.Marshal(v)
-}
+// BotCommandScopeChatMember.botCommandScope is a dummy method to avoid interface implementation.
+func (v BotCommandScopeChatMember) botCommandScope() {}
 
 // BotCommandScopeDefault Represents the default scope of bot commands. Default commands are used if no commands with a narrower scope are specified for the user.
 // https://core.telegram.org/bots/api#botcommandscopedefault
@@ -321,13 +326,12 @@ func (v BotCommandScopeDefault) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v BotCommandScopeDefault) BotCommandScope() ([]byte, error) {
-	return json.Marshal(v)
-}
+// BotCommandScopeDefault.botCommandScope is a dummy method to avoid interface implementation.
+func (v BotCommandScopeDefault) botCommandScope() {}
 
 // CallbackGame A placeholder, currently holds no information. Use BotFather to set up your game.
 // https://core.telegram.org/bots/api#callbackgame
-type CallbackGame interface{}
+type CallbackGame struct{}
 
 // CallbackQuery This object represents an incoming callback query from a callback button in an inline keyboard. If the button that originated the query was attached to a message sent by the bot, the field message will be present. If the button was attached to a message sent via the bot (in inline mode), the field inline_message_id will be present. Exactly one of the fields data or game_short_name will be present.
 // https://core.telegram.org/bots/api#callbackquery
@@ -426,7 +430,7 @@ type ChatLocation struct {
 type ChatMember interface {
 	GetStatus() string
 	GetUser() User
-	ChatMember() ([]byte, error)
+	chatMember()
 	// MergeChatMember returns a MergedChatMember struct to simplify working with complex telegram types in a non-generic world.
 	MergeChatMember() MergedChatMember
 }
@@ -476,6 +480,21 @@ type MergedChatMember struct {
 	CanAddWebPagePreviews bool `json:"can_add_web_page_previews,omitempty"`
 	// Optional. Date when restrictions will be lifted for this user; unix time (Only for restricted, banned)
 	UntilDate int64 `json:"until_date,omitempty"`
+}
+
+func (v MergedChatMember) GetStatus() string {
+	return v.Status
+}
+
+func (v MergedChatMember) GetUser() User {
+	return v.User
+}
+
+// MergedChatMember.chatMember is a dummy method to avoid interface implementation.
+func (v MergedChatMember) chatMember() {}
+
+func (v MergedChatMember) MergeChatMember() MergedChatMember {
+	return v
 }
 
 func unmarshalChatMember(d json.RawMessage) (ChatMember, error) {
@@ -618,9 +637,8 @@ func (v ChatMemberAdministrator) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v ChatMemberAdministrator) ChatMember() ([]byte, error) {
-	return json.Marshal(v)
-}
+// ChatMemberAdministrator.chatMember is a dummy method to avoid interface implementation.
+func (v ChatMemberAdministrator) chatMember() {}
 
 // ChatMemberBanned Represents a chat member that was banned in the chat and can't return to the chat or view chat messages.
 // https://core.telegram.org/bots/api#chatmemberbanned
@@ -660,9 +678,8 @@ func (v ChatMemberBanned) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v ChatMemberBanned) ChatMember() ([]byte, error) {
-	return json.Marshal(v)
-}
+// ChatMemberBanned.chatMember is a dummy method to avoid interface implementation.
+func (v ChatMemberBanned) chatMember() {}
 
 // ChatMemberLeft Represents a chat member that isn't currently a member of the chat, but may join it themselves.
 // https://core.telegram.org/bots/api#chatmemberleft
@@ -699,9 +716,8 @@ func (v ChatMemberLeft) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v ChatMemberLeft) ChatMember() ([]byte, error) {
-	return json.Marshal(v)
-}
+// ChatMemberLeft.chatMember is a dummy method to avoid interface implementation.
+func (v ChatMemberLeft) chatMember() {}
 
 // ChatMemberMember Represents a chat member that has no additional privileges or restrictions.
 // https://core.telegram.org/bots/api#chatmembermember
@@ -738,9 +754,8 @@ func (v ChatMemberMember) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v ChatMemberMember) ChatMember() ([]byte, error) {
-	return json.Marshal(v)
-}
+// ChatMemberMember.chatMember is a dummy method to avoid interface implementation.
+func (v ChatMemberMember) chatMember() {}
 
 // ChatMemberOwner Represents a chat member that owns the chat and has all administrator privileges.
 // https://core.telegram.org/bots/api#chatmemberowner
@@ -783,9 +798,8 @@ func (v ChatMemberOwner) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v ChatMemberOwner) ChatMember() ([]byte, error) {
-	return json.Marshal(v)
-}
+// ChatMemberOwner.chatMember is a dummy method to avoid interface implementation.
+func (v ChatMemberOwner) chatMember() {}
 
 // ChatMemberRestricted Represents a chat member that is under certain restrictions in the chat. Supergroups only.
 // https://core.telegram.org/bots/api#chatmemberrestricted
@@ -852,9 +866,8 @@ func (v ChatMemberRestricted) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v ChatMemberRestricted) ChatMember() ([]byte, error) {
-	return json.Marshal(v)
-}
+// ChatMemberRestricted.chatMember is a dummy method to avoid interface implementation.
+func (v ChatMemberRestricted) chatMember() {}
 
 // ChatMemberUpdated This object represents changes in the status of a chat member.
 // https://core.telegram.org/bots/api#chatmemberupdated
@@ -1056,9 +1069,8 @@ type ForceReply struct {
 	Selective bool `json:"selective,omitempty"`
 }
 
-func (v ForceReply) ReplyMarkup() ([]byte, error) {
-	return json.Marshal(v)
-}
+// ForceReply.replyMarkup is a dummy method to avoid interface implementation.
+func (v ForceReply) replyMarkup() {}
 
 // Game This object represents a game. Use BotFather to create and edit games, their short names will act as unique identifiers.
 // https://core.telegram.org/bots/api#game
@@ -1118,9 +1130,8 @@ type InlineKeyboardMarkup struct {
 	InlineKeyboard [][]InlineKeyboardButton `json:"inline_keyboard,omitempty"`
 }
 
-func (v InlineKeyboardMarkup) ReplyMarkup() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineKeyboardMarkup.replyMarkup is a dummy method to avoid interface implementation.
+func (v InlineKeyboardMarkup) replyMarkup() {}
 
 // InlineQuery This object represents an incoming inline query. When the user sends an empty query, your bot could return some default or trending results.
 // https://core.telegram.org/bots/api#inlinequery
@@ -1165,7 +1176,7 @@ type InlineQuery struct {
 type InlineQueryResult interface {
 	GetType() string
 	GetId() string
-	InlineQueryResult() ([]byte, error)
+	inlineQueryResult()
 	// MergeInlineQueryResult returns a MergedInlineQueryResult struct to simplify working with complex telegram types in a non-generic world.
 	MergeInlineQueryResult() MergedInlineQueryResult
 }
@@ -1295,6 +1306,21 @@ type MergedInlineQueryResult struct {
 	VoiceDuration int64 `json:"voice_duration,omitempty"`
 }
 
+func (v MergedInlineQueryResult) GetType() string {
+	return v.Type
+}
+
+func (v MergedInlineQueryResult) GetId() string {
+	return v.Id
+}
+
+// MergedInlineQueryResult.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v MergedInlineQueryResult) inlineQueryResult() {}
+
+func (v MergedInlineQueryResult) MergeInlineQueryResult() MergedInlineQueryResult {
+	return v
+}
+
 // InlineQueryResultArticle Represents a link to an article or web page.
 // https://core.telegram.org/bots/api#inlinequeryresultarticle
 type InlineQueryResultArticle struct {
@@ -1357,9 +1383,8 @@ func (v InlineQueryResultArticle) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultArticle) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultArticle.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultArticle) inlineQueryResult() {}
 
 // InlineQueryResultAudio Represents a link to an MP3 audio file. By default, this audio file will be sent by the user. Alternatively, you can use input_message_content to send a message with the specified content instead of the audio.
 // Note: This will only work in Telegram versions released after 9 April, 2016. Older clients will ignore them.
@@ -1424,9 +1449,8 @@ func (v InlineQueryResultAudio) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultAudio) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultAudio.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultAudio) inlineQueryResult() {}
 
 // InlineQueryResultCachedAudio Represents a link to an MP3 audio file stored on the Telegram servers. By default, this audio file will be sent by the user. Alternatively, you can use input_message_content to send a message with the specified content instead of the audio.
 // Note: This will only work in Telegram versions released after 9 April, 2016. Older clients will ignore them.
@@ -1482,9 +1506,8 @@ func (v InlineQueryResultCachedAudio) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultCachedAudio) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultCachedAudio.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultCachedAudio) inlineQueryResult() {}
 
 // InlineQueryResultCachedDocument Represents a link to a file stored on the Telegram servers. By default, this file will be sent by the user with an optional caption. Alternatively, you can use input_message_content to send a message with the specified content instead of the file.
 // Note: This will only work in Telegram versions released after 9 April, 2016. Older clients will ignore them.
@@ -1546,9 +1569,8 @@ func (v InlineQueryResultCachedDocument) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultCachedDocument) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultCachedDocument.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultCachedDocument) inlineQueryResult() {}
 
 // InlineQueryResultCachedGif Represents a link to an animated GIF file stored on the Telegram servers. By default, this animated GIF file will be sent by the user with an optional caption. Alternatively, you can use input_message_content to send a message with specified content instead of the animation.
 // https://core.telegram.org/bots/api#inlinequeryresultcachedgif
@@ -1606,9 +1628,8 @@ func (v InlineQueryResultCachedGif) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultCachedGif) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultCachedGif.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultCachedGif) inlineQueryResult() {}
 
 // InlineQueryResultCachedMpeg4Gif Represents a link to a video animation (H.264/MPEG-4 AVC video without sound) stored on the Telegram servers. By default, this animated MPEG-4 file will be sent by the user with an optional caption. Alternatively, you can use input_message_content to send a message with the specified content instead of the animation.
 // https://core.telegram.org/bots/api#inlinequeryresultcachedmpeg4gif
@@ -1666,9 +1687,8 @@ func (v InlineQueryResultCachedMpeg4Gif) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultCachedMpeg4Gif) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultCachedMpeg4Gif.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultCachedMpeg4Gif) inlineQueryResult() {}
 
 // InlineQueryResultCachedPhoto Represents a link to a photo stored on the Telegram servers. By default, this photo will be sent by the user with an optional caption. Alternatively, you can use input_message_content to send a message with the specified content instead of the photo.
 // https://core.telegram.org/bots/api#inlinequeryresultcachedphoto
@@ -1729,9 +1749,8 @@ func (v InlineQueryResultCachedPhoto) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultCachedPhoto) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultCachedPhoto.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultCachedPhoto) inlineQueryResult() {}
 
 // InlineQueryResultCachedSticker Represents a link to a sticker stored on the Telegram servers. By default, this sticker will be sent by the user. Alternatively, you can use input_message_content to send a message with the specified content instead of the sticker.
 // Note: This will only work in Telegram versions released after 9 April, 2016 for static stickers and after 06 July, 2019 for animated stickers. Older clients will ignore them.
@@ -1778,9 +1797,8 @@ func (v InlineQueryResultCachedSticker) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultCachedSticker) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultCachedSticker.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultCachedSticker) inlineQueryResult() {}
 
 // InlineQueryResultCachedVideo Represents a link to a video file stored on the Telegram servers. By default, this video file will be sent by the user with an optional caption. Alternatively, you can use input_message_content to send a message with the specified content instead of the video.
 // https://core.telegram.org/bots/api#inlinequeryresultcachedvideo
@@ -1841,9 +1859,8 @@ func (v InlineQueryResultCachedVideo) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultCachedVideo) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultCachedVideo.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultCachedVideo) inlineQueryResult() {}
 
 // InlineQueryResultCachedVoice Represents a link to a voice message stored on the Telegram servers. By default, this voice message will be sent by the user. Alternatively, you can use input_message_content to send a message with the specified content instead of the voice message.
 // Note: This will only work in Telegram versions released after 9 April, 2016. Older clients will ignore them.
@@ -1902,9 +1919,8 @@ func (v InlineQueryResultCachedVoice) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultCachedVoice) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultCachedVoice.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultCachedVoice) inlineQueryResult() {}
 
 // InlineQueryResultContact Represents a contact with a phone number. By default, this contact will be sent by the user. Alternatively, you can use input_message_content to send a message with the specified content instead of the contact.
 // Note: This will only work in Telegram versions released after 9 April, 2016. Older clients will ignore them.
@@ -1969,9 +1985,8 @@ func (v InlineQueryResultContact) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultContact) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultContact.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultContact) inlineQueryResult() {}
 
 // InlineQueryResultDocument Represents a link to a file. By default, this file will be sent by the user with an optional caption. Alternatively, you can use input_message_content to send a message with the specified content instead of the file. Currently, only .PDF and .ZIP files can be sent using this method.
 // Note: This will only work in Telegram versions released after 9 April, 2016. Older clients will ignore them.
@@ -2045,9 +2060,8 @@ func (v InlineQueryResultDocument) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultDocument) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultDocument.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultDocument) inlineQueryResult() {}
 
 // InlineQueryResultGame Represents a Game.
 // Note: This will only work in Telegram versions released after October 1, 2016. Older clients will not display any inline results if a game result is among them.
@@ -2091,9 +2105,8 @@ func (v InlineQueryResultGame) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultGame) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultGame.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultGame) inlineQueryResult() {}
 
 // InlineQueryResultGif Represents a link to an animated GIF file. By default, this animated GIF file will be sent by the user with optional caption. Alternatively, you can use input_message_content to send a message with the specified content instead of the animation.
 // https://core.telegram.org/bots/api#inlinequeryresultgif
@@ -2166,9 +2179,8 @@ func (v InlineQueryResultGif) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultGif) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultGif.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultGif) inlineQueryResult() {}
 
 // InlineQueryResultLocation Represents a location on a map. By default, the location will be sent by the user. Alternatively, you can use input_message_content to send a message with the specified content instead of the location.
 // Note: This will only work in Telegram versions released after 9 April, 2016. Older clients will ignore them.
@@ -2242,9 +2254,8 @@ func (v InlineQueryResultLocation) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultLocation) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultLocation.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultLocation) inlineQueryResult() {}
 
 // InlineQueryResultMpeg4Gif Represents a link to a video animation (H.264/MPEG-4 AVC video without sound). By default, this animated MPEG-4 file will be sent by the user with optional caption. Alternatively, you can use input_message_content to send a message with the specified content instead of the animation.
 // https://core.telegram.org/bots/api#inlinequeryresultmpeg4gif
@@ -2317,9 +2328,8 @@ func (v InlineQueryResultMpeg4Gif) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultMpeg4Gif) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultMpeg4Gif.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultMpeg4Gif) inlineQueryResult() {}
 
 // InlineQueryResultPhoto Represents a link to a photo. By default, this photo will be sent by the user with optional caption. Alternatively, you can use input_message_content to send a message with the specified content instead of the photo.
 // https://core.telegram.org/bots/api#inlinequeryresultphoto
@@ -2389,9 +2399,8 @@ func (v InlineQueryResultPhoto) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultPhoto) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultPhoto.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultPhoto) inlineQueryResult() {}
 
 // InlineQueryResultVenue Represents a venue. By default, the venue will be sent by the user. Alternatively, you can use input_message_content to send a message with the specified content instead of the venue.
 // Note: This will only work in Telegram versions released after 9 April, 2016. Older clients will ignore them.
@@ -2468,9 +2477,8 @@ func (v InlineQueryResultVenue) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultVenue) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultVenue.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultVenue) inlineQueryResult() {}
 
 // InlineQueryResultVideo Represents a link to a page containing an embedded video player or a video file. By default, this video file will be sent by the user with an optional caption. Alternatively, you can use input_message_content to send a message with the specified content instead of the video.
 // https://core.telegram.org/bots/api#inlinequeryresultvideo
@@ -2546,9 +2554,8 @@ func (v InlineQueryResultVideo) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultVideo) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultVideo.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultVideo) inlineQueryResult() {}
 
 // InlineQueryResultVoice Represents a link to a voice recording in an .OGG container encoded with OPUS. By default, this voice recording will be sent by the user. Alternatively, you can use input_message_content to send a message with the specified content instead of the the voice message.
 // Note: This will only work in Telegram versions released after 9 April, 2016. Older clients will ignore them.
@@ -2610,9 +2617,8 @@ func (v InlineQueryResultVoice) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InlineQueryResultVoice) InlineQueryResult() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InlineQueryResultVoice.inlineQueryResult is a dummy method to avoid interface implementation.
+func (v InlineQueryResultVoice) inlineQueryResult() {}
 
 // InputContactMessageContent Represents the content of a contact message to be sent as the result of an inline query.
 // https://core.telegram.org/bots/api#inputcontactmessagecontent
@@ -2627,9 +2633,8 @@ type InputContactMessageContent struct {
 	Vcard string `json:"vcard,omitempty"`
 }
 
-func (v InputContactMessageContent) InputMessageContent() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InputContactMessageContent.inputMessageContent is a dummy method to avoid interface implementation.
+func (v InputContactMessageContent) inputMessageContent() {}
 
 // InputFile This object represents the contents of a file to be uploaded. Must be posted using multipart/form-data in the usual way that files are uploaded via the browser.
 // https://core.telegram.org/bots/api#inputfile
@@ -2680,9 +2685,8 @@ type InputInvoiceMessageContent struct {
 	IsFlexible bool `json:"is_flexible,omitempty"`
 }
 
-func (v InputInvoiceMessageContent) InputMessageContent() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InputInvoiceMessageContent.inputMessageContent is a dummy method to avoid interface implementation.
+func (v InputInvoiceMessageContent) inputMessageContent() {}
 
 // InputLocationMessageContent Represents the content of a location message to be sent as the result of an inline query.
 // https://core.telegram.org/bots/api#inputlocationmessagecontent
@@ -2701,9 +2705,8 @@ type InputLocationMessageContent struct {
 	ProximityAlertRadius int64 `json:"proximity_alert_radius,omitempty"`
 }
 
-func (v InputLocationMessageContent) InputMessageContent() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InputLocationMessageContent.inputMessageContent is a dummy method to avoid interface implementation.
+func (v InputLocationMessageContent) inputMessageContent() {}
 
 // InputMedia This object represents the content of a media message to be sent. It should be one of
 // - InputMediaAnimation
@@ -2715,7 +2718,7 @@ func (v InputLocationMessageContent) InputMessageContent() ([]byte, error) {
 type InputMedia interface {
 	GetType() string
 	GetMedia() InputFile
-	InputMedia() ([]byte, error)
+	inputMedia()
 	// InputMediaParams allows for uploading InputMedia files with attachments.
 	InputMediaParams(string, map[string]NamedReader) ([]byte, error)
 	// MergeInputMedia returns a MergedInputMedia struct to simplify working with complex telegram types in a non-generic world.
@@ -2749,6 +2752,21 @@ type MergedInputMedia struct {
 	Title string `json:"title,omitempty"`
 	// Optional. Pass True, if the uploaded video is suitable for streaming (Only for video)
 	SupportsStreaming bool `json:"supports_streaming,omitempty"`
+}
+
+func (v MergedInputMedia) GetType() string {
+	return v.Type
+}
+
+func (v MergedInputMedia) GetMedia() InputFile {
+	return v.Media
+}
+
+// MergedInputMedia.inputMedia is a dummy method to avoid interface implementation.
+func (v MergedInputMedia) inputMedia() {}
+
+func (v MergedInputMedia) MergeInputMedia() MergedInputMedia {
+	return v
 }
 
 // InputMediaAnimation Represents an animation file (GIF or H.264/MPEG-4 AVC video without sound) to be sent.
@@ -2829,9 +2847,8 @@ func (v InputMediaAnimation) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InputMediaAnimation) InputMedia() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InputMediaAnimation.inputMedia is a dummy method to avoid interface implementation.
+func (v InputMediaAnimation) inputMedia() {}
 
 // InputMediaAudio Represents an audio file to be treated as music to be sent.
 // https://core.telegram.org/bots/api#inputmediaaudio
@@ -2911,9 +2928,8 @@ func (v InputMediaAudio) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InputMediaAudio) InputMedia() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InputMediaAudio.inputMedia is a dummy method to avoid interface implementation.
+func (v InputMediaAudio) inputMedia() {}
 
 // InputMediaDocument Represents a general file to be sent.
 // https://core.telegram.org/bots/api#inputmediadocument
@@ -2987,9 +3003,8 @@ func (v InputMediaDocument) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InputMediaDocument) InputMedia() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InputMediaDocument.inputMedia is a dummy method to avoid interface implementation.
+func (v InputMediaDocument) inputMedia() {}
 
 // InputMediaPhoto Represents a photo to be sent.
 // https://core.telegram.org/bots/api#inputmediaphoto
@@ -3057,9 +3072,8 @@ func (v InputMediaPhoto) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InputMediaPhoto) InputMedia() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InputMediaPhoto.inputMedia is a dummy method to avoid interface implementation.
+func (v InputMediaPhoto) inputMedia() {}
 
 // InputMediaVideo Represents a video to be sent.
 // https://core.telegram.org/bots/api#inputmediavideo
@@ -3142,9 +3156,8 @@ func (v InputMediaVideo) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v InputMediaVideo) InputMedia() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InputMediaVideo.inputMedia is a dummy method to avoid interface implementation.
+func (v InputMediaVideo) inputMedia() {}
 
 // InputMessageContent This object represents the content of a message to be sent as a result of an inline query. Telegram clients currently support the following 5 types:
 // - InputTextMessageContent
@@ -3154,7 +3167,7 @@ func (v InputMediaVideo) InputMedia() ([]byte, error) {
 // - InputInvoiceMessageContent
 // https://core.telegram.org/bots/api#inputmessagecontent
 type InputMessageContent interface {
-	InputMessageContent() ([]byte, error)
+	inputMessageContent()
 }
 
 // InputTextMessageContent Represents the content of a text message to be sent as the result of an inline query.
@@ -3170,9 +3183,8 @@ type InputTextMessageContent struct {
 	DisableWebPagePreview bool `json:"disable_web_page_preview,omitempty"`
 }
 
-func (v InputTextMessageContent) InputMessageContent() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InputTextMessageContent.inputMessageContent is a dummy method to avoid interface implementation.
+func (v InputTextMessageContent) inputMessageContent() {}
 
 // InputVenueMessageContent Represents the content of a venue message to be sent as the result of an inline query.
 // https://core.telegram.org/bots/api#inputvenuemessagecontent
@@ -3195,9 +3207,8 @@ type InputVenueMessageContent struct {
 	GooglePlaceType string `json:"google_place_type,omitempty"`
 }
 
-func (v InputVenueMessageContent) InputMessageContent() ([]byte, error) {
-	return json.Marshal(v)
-}
+// InputVenueMessageContent.inputMessageContent is a dummy method to avoid interface implementation.
+func (v InputVenueMessageContent) inputMessageContent() {}
 
 // Invoice This object contains basic information about an invoice.
 // https://core.telegram.org/bots/api#invoice
@@ -3473,7 +3484,7 @@ type PassportElementError interface {
 	GetSource() string
 	GetType() string
 	GetMessage() string
-	PassportElementError() ([]byte, error)
+	passportElementError()
 	// MergePassportElementError returns a MergedPassportElementError struct to simplify working with complex telegram types in a non-generic world.
 	MergePassportElementError() MergedPassportElementError
 }
@@ -3495,6 +3506,25 @@ type MergedPassportElementError struct {
 	FileHashes []string `json:"file_hashes,omitempty"`
 	// Optional. Base64-encoded element hash (Only for unspecified)
 	ElementHash string `json:"element_hash,omitempty"`
+}
+
+func (v MergedPassportElementError) GetSource() string {
+	return v.Source
+}
+
+func (v MergedPassportElementError) GetType() string {
+	return v.Type
+}
+
+func (v MergedPassportElementError) GetMessage() string {
+	return v.Message
+}
+
+// MergedPassportElementError.passportElementError is a dummy method to avoid interface implementation.
+func (v MergedPassportElementError) passportElementError() {}
+
+func (v MergedPassportElementError) MergePassportElementError() MergedPassportElementError {
+	return v
 }
 
 // PassportElementErrorDataField Represents an issue in one of the data fields that was provided by the user. The error is considered resolved when the field's value changes.
@@ -3545,9 +3575,8 @@ func (v PassportElementErrorDataField) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v PassportElementErrorDataField) PassportElementError() ([]byte, error) {
-	return json.Marshal(v)
-}
+// PassportElementErrorDataField.passportElementError is a dummy method to avoid interface implementation.
+func (v PassportElementErrorDataField) passportElementError() {}
 
 // PassportElementErrorFile Represents an issue with a document scan. The error is considered resolved when the file with the document scan changes.
 // https://core.telegram.org/bots/api#passportelementerrorfile
@@ -3594,9 +3623,8 @@ func (v PassportElementErrorFile) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v PassportElementErrorFile) PassportElementError() ([]byte, error) {
-	return json.Marshal(v)
-}
+// PassportElementErrorFile.passportElementError is a dummy method to avoid interface implementation.
+func (v PassportElementErrorFile) passportElementError() {}
 
 // PassportElementErrorFiles Represents an issue with a list of scans. The error is considered resolved when the list of files containing the scans changes.
 // https://core.telegram.org/bots/api#passportelementerrorfiles
@@ -3643,9 +3671,8 @@ func (v PassportElementErrorFiles) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v PassportElementErrorFiles) PassportElementError() ([]byte, error) {
-	return json.Marshal(v)
-}
+// PassportElementErrorFiles.passportElementError is a dummy method to avoid interface implementation.
+func (v PassportElementErrorFiles) passportElementError() {}
 
 // PassportElementErrorFrontSide Represents an issue with the front side of a document. The error is considered resolved when the file with the front side of the document changes.
 // https://core.telegram.org/bots/api#passportelementerrorfrontside
@@ -3692,9 +3719,8 @@ func (v PassportElementErrorFrontSide) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v PassportElementErrorFrontSide) PassportElementError() ([]byte, error) {
-	return json.Marshal(v)
-}
+// PassportElementErrorFrontSide.passportElementError is a dummy method to avoid interface implementation.
+func (v PassportElementErrorFrontSide) passportElementError() {}
 
 // PassportElementErrorReverseSide Represents an issue with the reverse side of a document. The error is considered resolved when the file with reverse side of the document changes.
 // https://core.telegram.org/bots/api#passportelementerrorreverseside
@@ -3741,9 +3767,8 @@ func (v PassportElementErrorReverseSide) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v PassportElementErrorReverseSide) PassportElementError() ([]byte, error) {
-	return json.Marshal(v)
-}
+// PassportElementErrorReverseSide.passportElementError is a dummy method to avoid interface implementation.
+func (v PassportElementErrorReverseSide) passportElementError() {}
 
 // PassportElementErrorSelfie Represents an issue with the selfie with a document. The error is considered resolved when the file with the selfie changes.
 // https://core.telegram.org/bots/api#passportelementerrorselfie
@@ -3790,9 +3815,8 @@ func (v PassportElementErrorSelfie) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v PassportElementErrorSelfie) PassportElementError() ([]byte, error) {
-	return json.Marshal(v)
-}
+// PassportElementErrorSelfie.passportElementError is a dummy method to avoid interface implementation.
+func (v PassportElementErrorSelfie) passportElementError() {}
 
 // PassportElementErrorTranslationFile Represents an issue with one of the files that constitute the translation of a document. The error is considered resolved when the file changes.
 // https://core.telegram.org/bots/api#passportelementerrortranslationfile
@@ -3839,9 +3863,8 @@ func (v PassportElementErrorTranslationFile) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v PassportElementErrorTranslationFile) PassportElementError() ([]byte, error) {
-	return json.Marshal(v)
-}
+// PassportElementErrorTranslationFile.passportElementError is a dummy method to avoid interface implementation.
+func (v PassportElementErrorTranslationFile) passportElementError() {}
 
 // PassportElementErrorTranslationFiles Represents an issue with the translated version of a document. The error is considered resolved when a file with the document translation change.
 // https://core.telegram.org/bots/api#passportelementerrortranslationfiles
@@ -3888,9 +3911,8 @@ func (v PassportElementErrorTranslationFiles) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v PassportElementErrorTranslationFiles) PassportElementError() ([]byte, error) {
-	return json.Marshal(v)
-}
+// PassportElementErrorTranslationFiles.passportElementError is a dummy method to avoid interface implementation.
+func (v PassportElementErrorTranslationFiles) passportElementError() {}
 
 // PassportElementErrorUnspecified Represents an issue in an unspecified place. The error is considered resolved when new data is added.
 // https://core.telegram.org/bots/api#passportelementerrorunspecified
@@ -3937,9 +3959,8 @@ func (v PassportElementErrorUnspecified) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a)
 }
 
-func (v PassportElementErrorUnspecified) PassportElementError() ([]byte, error) {
-	return json.Marshal(v)
-}
+// PassportElementErrorUnspecified.passportElementError is a dummy method to avoid interface implementation.
+func (v PassportElementErrorUnspecified) passportElementError() {}
 
 // PassportFile This object represents a file uploaded to Telegram Passport. Currently all Telegram Passport files are in JPEG format when decrypted and don't exceed 10MB.
 // https://core.telegram.org/bots/api#passportfile
@@ -4065,9 +4086,8 @@ type ReplyKeyboardMarkup struct {
 	Selective bool `json:"selective,omitempty"`
 }
 
-func (v ReplyKeyboardMarkup) ReplyMarkup() ([]byte, error) {
-	return json.Marshal(v)
-}
+// ReplyKeyboardMarkup.replyMarkup is a dummy method to avoid interface implementation.
+func (v ReplyKeyboardMarkup) replyMarkup() {}
 
 // ReplyKeyboardRemove Upon receiving a message with this object, Telegram clients will remove the current custom keyboard and display the default letter-keyboard. By default, custom keyboards are displayed until a new keyboard is sent by a bot. An exception is made for one-time keyboards that are hidden immediately after the user presses a button (see ReplyKeyboardMarkup).
 // https://core.telegram.org/bots/api#replykeyboardremove
@@ -4078,9 +4098,8 @@ type ReplyKeyboardRemove struct {
 	Selective bool `json:"selective,omitempty"`
 }
 
-func (v ReplyKeyboardRemove) ReplyMarkup() ([]byte, error) {
-	return json.Marshal(v)
-}
+// ReplyKeyboardRemove.replyMarkup is a dummy method to avoid interface implementation.
+func (v ReplyKeyboardRemove) replyMarkup() {}
 
 // ResponseParameters Contains information about why a request was unsuccessful.
 // https://core.telegram.org/bots/api#responseparameters

--- a/gen_types.go
+++ b/gen_types.go
@@ -79,7 +79,7 @@ type BotCommand struct {
 // - BotCommandScopeChatMember
 // https://core.telegram.org/bots/api#botcommandscope
 type BotCommandScope interface {
-	Type() string
+	GetType() string
 	BotCommandScope() ([]byte, error)
 }
 
@@ -87,7 +87,7 @@ type BotCommandScope interface {
 // https://core.telegram.org/bots/api#botcommandscopeallchatadministrators
 type BotCommandScopeAllChatAdministrators struct{}
 
-func (v BotCommandScopeAllChatAdministrators) Type() string {
+func (v BotCommandScopeAllChatAdministrators) GetType() string {
 	return "all_chat_administrators"
 }
 
@@ -111,7 +111,7 @@ func (v BotCommandScopeAllChatAdministrators) BotCommandScope() ([]byte, error) 
 // https://core.telegram.org/bots/api#botcommandscopeallgroupchats
 type BotCommandScopeAllGroupChats struct{}
 
-func (v BotCommandScopeAllGroupChats) Type() string {
+func (v BotCommandScopeAllGroupChats) GetType() string {
 	return "all_group_chats"
 }
 
@@ -135,7 +135,7 @@ func (v BotCommandScopeAllGroupChats) BotCommandScope() ([]byte, error) {
 // https://core.telegram.org/bots/api#botcommandscopeallprivatechats
 type BotCommandScopeAllPrivateChats struct{}
 
-func (v BotCommandScopeAllPrivateChats) Type() string {
+func (v BotCommandScopeAllPrivateChats) GetType() string {
 	return "all_private_chats"
 }
 
@@ -162,7 +162,7 @@ type BotCommandScopeChat struct {
 	ChatId int64 `json:"chat_id,omitempty"`
 }
 
-func (v BotCommandScopeChat) Type() string {
+func (v BotCommandScopeChat) GetType() string {
 	return "chat"
 }
 
@@ -189,7 +189,7 @@ type BotCommandScopeChatAdministrators struct {
 	ChatId int64 `json:"chat_id,omitempty"`
 }
 
-func (v BotCommandScopeChatAdministrators) Type() string {
+func (v BotCommandScopeChatAdministrators) GetType() string {
 	return "chat_administrators"
 }
 
@@ -218,7 +218,7 @@ type BotCommandScopeChatMember struct {
 	UserId int64 `json:"user_id,omitempty"`
 }
 
-func (v BotCommandScopeChatMember) Type() string {
+func (v BotCommandScopeChatMember) GetType() string {
 	return "chat_member"
 }
 
@@ -242,7 +242,7 @@ func (v BotCommandScopeChatMember) BotCommandScope() ([]byte, error) {
 // https://core.telegram.org/bots/api#botcommandscopedefault
 type BotCommandScopeDefault struct{}
 
-func (v BotCommandScopeDefault) Type() string {
+func (v BotCommandScopeDefault) GetType() string {
 	return "default"
 }
 
@@ -361,7 +361,8 @@ type ChatLocation struct {
 // - ChatMemberBanned
 // https://core.telegram.org/bots/api#chatmember
 type ChatMember interface {
-	Status() string
+	GetStatus() string
+	GetUser() User
 	ChatMember() ([]byte, error)
 }
 
@@ -463,8 +464,12 @@ type ChatMemberAdministrator struct {
 	CanPinMessages bool `json:"can_pin_messages,omitempty"`
 }
 
-func (v ChatMemberAdministrator) Status() string {
+func (v ChatMemberAdministrator) GetStatus() string {
 	return "administrator"
+}
+
+func (v ChatMemberAdministrator) GetUser() User {
+	return v.User
 }
 
 func (v ChatMemberAdministrator) MarshalJSON() ([]byte, error) {
@@ -492,8 +497,12 @@ type ChatMemberBanned struct {
 	UntilDate int64 `json:"until_date,omitempty"`
 }
 
-func (v ChatMemberBanned) Status() string {
+func (v ChatMemberBanned) GetStatus() string {
 	return "banned"
+}
+
+func (v ChatMemberBanned) GetUser() User {
+	return v.User
 }
 
 func (v ChatMemberBanned) MarshalJSON() ([]byte, error) {
@@ -519,8 +528,12 @@ type ChatMemberLeft struct {
 	User User `json:"user,omitempty"`
 }
 
-func (v ChatMemberLeft) Status() string {
+func (v ChatMemberLeft) GetStatus() string {
 	return "left"
+}
+
+func (v ChatMemberLeft) GetUser() User {
+	return v.User
 }
 
 func (v ChatMemberLeft) MarshalJSON() ([]byte, error) {
@@ -546,8 +559,12 @@ type ChatMemberMember struct {
 	User User `json:"user,omitempty"`
 }
 
-func (v ChatMemberMember) Status() string {
+func (v ChatMemberMember) GetStatus() string {
 	return "member"
+}
+
+func (v ChatMemberMember) GetUser() User {
+	return v.User
 }
 
 func (v ChatMemberMember) MarshalJSON() ([]byte, error) {
@@ -577,8 +594,12 @@ type ChatMemberOwner struct {
 	IsAnonymous bool `json:"is_anonymous,omitempty"`
 }
 
-func (v ChatMemberOwner) Status() string {
+func (v ChatMemberOwner) GetStatus() string {
 	return "owner"
+}
+
+func (v ChatMemberOwner) GetUser() User {
+	return v.User
 }
 
 func (v ChatMemberOwner) MarshalJSON() ([]byte, error) {
@@ -624,8 +645,12 @@ type ChatMemberRestricted struct {
 	UntilDate int64 `json:"until_date,omitempty"`
 }
 
-func (v ChatMemberRestricted) Status() string {
+func (v ChatMemberRestricted) GetStatus() string {
 	return "restricted"
+}
+
+func (v ChatMemberRestricted) GetUser() User {
+	return v.User
 }
 
 func (v ChatMemberRestricted) MarshalJSON() ([]byte, error) {
@@ -951,6 +976,8 @@ type InlineQuery struct {
 // Note: All URLs passed in inline query results will be available to end users and therefore must be assumed to be public.
 // https://core.telegram.org/bots/api#inlinequeryresult
 type InlineQueryResult interface {
+	GetType() string
+	GetId() string
 	InlineQueryResult() ([]byte, error)
 }
 
@@ -979,8 +1006,12 @@ type InlineQueryResultArticle struct {
 	ThumbHeight int64 `json:"thumb_height,omitempty"`
 }
 
-func (v InlineQueryResultArticle) Type() string {
+func (v InlineQueryResultArticle) GetType() string {
 	return "article"
+}
+
+func (v InlineQueryResultArticle) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultArticle) MarshalJSON() ([]byte, error) {
@@ -1025,8 +1056,12 @@ type InlineQueryResultAudio struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
-func (v InlineQueryResultAudio) Type() string {
+func (v InlineQueryResultAudio) GetType() string {
 	return "audio"
+}
+
+func (v InlineQueryResultAudio) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultAudio) MarshalJSON() ([]byte, error) {
@@ -1065,8 +1100,12 @@ type InlineQueryResultCachedAudio struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
-func (v InlineQueryResultCachedAudio) Type() string {
+func (v InlineQueryResultCachedAudio) GetType() string {
 	return "audio"
+}
+
+func (v InlineQueryResultCachedAudio) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultCachedAudio) MarshalJSON() ([]byte, error) {
@@ -1109,8 +1148,12 @@ type InlineQueryResultCachedDocument struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
-func (v InlineQueryResultCachedDocument) Type() string {
+func (v InlineQueryResultCachedDocument) GetType() string {
 	return "document"
+}
+
+func (v InlineQueryResultCachedDocument) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultCachedDocument) MarshalJSON() ([]byte, error) {
@@ -1150,8 +1193,12 @@ type InlineQueryResultCachedGif struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
-func (v InlineQueryResultCachedGif) Type() string {
+func (v InlineQueryResultCachedGif) GetType() string {
 	return "gif"
+}
+
+func (v InlineQueryResultCachedGif) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultCachedGif) MarshalJSON() ([]byte, error) {
@@ -1191,8 +1238,12 @@ type InlineQueryResultCachedMpeg4Gif struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
-func (v InlineQueryResultCachedMpeg4Gif) Type() string {
+func (v InlineQueryResultCachedMpeg4Gif) GetType() string {
 	return "mpeg4_gif"
+}
+
+func (v InlineQueryResultCachedMpeg4Gif) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultCachedMpeg4Gif) MarshalJSON() ([]byte, error) {
@@ -1234,8 +1285,12 @@ type InlineQueryResultCachedPhoto struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
-func (v InlineQueryResultCachedPhoto) Type() string {
+func (v InlineQueryResultCachedPhoto) GetType() string {
 	return "photo"
+}
+
+func (v InlineQueryResultCachedPhoto) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultCachedPhoto) MarshalJSON() ([]byte, error) {
@@ -1268,8 +1323,12 @@ type InlineQueryResultCachedSticker struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
-func (v InlineQueryResultCachedSticker) Type() string {
+func (v InlineQueryResultCachedSticker) GetType() string {
 	return "sticker"
+}
+
+func (v InlineQueryResultCachedSticker) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultCachedSticker) MarshalJSON() ([]byte, error) {
@@ -1311,8 +1370,12 @@ type InlineQueryResultCachedVideo struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
-func (v InlineQueryResultCachedVideo) Type() string {
+func (v InlineQueryResultCachedVideo) GetType() string {
 	return "video"
+}
+
+func (v InlineQueryResultCachedVideo) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultCachedVideo) MarshalJSON() ([]byte, error) {
@@ -1353,8 +1416,12 @@ type InlineQueryResultCachedVoice struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
-func (v InlineQueryResultCachedVoice) Type() string {
+func (v InlineQueryResultCachedVoice) GetType() string {
 	return "voice"
+}
+
+func (v InlineQueryResultCachedVoice) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultCachedVoice) MarshalJSON() ([]byte, error) {
@@ -1399,8 +1466,12 @@ type InlineQueryResultContact struct {
 	ThumbHeight int64 `json:"thumb_height,omitempty"`
 }
 
-func (v InlineQueryResultContact) Type() string {
+func (v InlineQueryResultContact) GetType() string {
 	return "contact"
+}
+
+func (v InlineQueryResultContact) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultContact) MarshalJSON() ([]byte, error) {
@@ -1451,8 +1522,12 @@ type InlineQueryResultDocument struct {
 	ThumbHeight int64 `json:"thumb_height,omitempty"`
 }
 
-func (v InlineQueryResultDocument) Type() string {
+func (v InlineQueryResultDocument) GetType() string {
 	return "document"
+}
+
+func (v InlineQueryResultDocument) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultDocument) MarshalJSON() ([]byte, error) {
@@ -1483,8 +1558,12 @@ type InlineQueryResultGame struct {
 	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
 }
 
-func (v InlineQueryResultGame) Type() string {
+func (v InlineQueryResultGame) GetType() string {
 	return "game"
+}
+
+func (v InlineQueryResultGame) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultGame) MarshalJSON() ([]byte, error) {
@@ -1534,8 +1613,12 @@ type InlineQueryResultGif struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
-func (v InlineQueryResultGif) Type() string {
+func (v InlineQueryResultGif) GetType() string {
 	return "gif"
+}
+
+func (v InlineQueryResultGif) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultGif) MarshalJSON() ([]byte, error) {
@@ -1586,8 +1669,12 @@ type InlineQueryResultLocation struct {
 	ThumbHeight int64 `json:"thumb_height,omitempty"`
 }
 
-func (v InlineQueryResultLocation) Type() string {
+func (v InlineQueryResultLocation) GetType() string {
 	return "location"
+}
+
+func (v InlineQueryResultLocation) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultLocation) MarshalJSON() ([]byte, error) {
@@ -1637,8 +1724,12 @@ type InlineQueryResultMpeg4Gif struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
-func (v InlineQueryResultMpeg4Gif) Type() string {
+func (v InlineQueryResultMpeg4Gif) GetType() string {
 	return "mpeg4_gif"
+}
+
+func (v InlineQueryResultMpeg4Gif) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultMpeg4Gif) MarshalJSON() ([]byte, error) {
@@ -1686,8 +1777,12 @@ type InlineQueryResultPhoto struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
-func (v InlineQueryResultPhoto) Type() string {
+func (v InlineQueryResultPhoto) GetType() string {
 	return "photo"
+}
+
+func (v InlineQueryResultPhoto) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultPhoto) MarshalJSON() ([]byte, error) {
@@ -1740,8 +1835,12 @@ type InlineQueryResultVenue struct {
 	ThumbHeight int64 `json:"thumb_height,omitempty"`
 }
 
-func (v InlineQueryResultVenue) Type() string {
+func (v InlineQueryResultVenue) GetType() string {
 	return "venue"
+}
+
+func (v InlineQueryResultVenue) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultVenue) MarshalJSON() ([]byte, error) {
@@ -1793,8 +1892,12 @@ type InlineQueryResultVideo struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
-func (v InlineQueryResultVideo) Type() string {
+func (v InlineQueryResultVideo) GetType() string {
 	return "video"
+}
+
+func (v InlineQueryResultVideo) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultVideo) MarshalJSON() ([]byte, error) {
@@ -1837,8 +1940,12 @@ type InlineQueryResultVoice struct {
 	InputMessageContent *InputMessageContent `json:"input_message_content,omitempty"`
 }
 
-func (v InlineQueryResultVoice) Type() string {
+func (v InlineQueryResultVoice) GetType() string {
 	return "voice"
+}
+
+func (v InlineQueryResultVoice) GetId() string {
+	return v.Id
 }
 
 func (v InlineQueryResultVoice) MarshalJSON() ([]byte, error) {
@@ -1981,8 +2088,12 @@ type InputMediaAnimation struct {
 	Duration int64 `json:"duration,omitempty"`
 }
 
-func (v InputMediaAnimation) Type() string {
+func (v InputMediaAnimation) GetType() string {
 	return "animation"
+}
+
+func (v InputMediaAnimation) GetMedia() InputFile {
+	return v.Media
 }
 
 func (v InputMediaAnimation) MarshalJSON() ([]byte, error) {
@@ -2040,8 +2151,12 @@ type InputMediaAudio struct {
 	Title string `json:"title,omitempty"`
 }
 
-func (v InputMediaAudio) Type() string {
+func (v InputMediaAudio) GetType() string {
 	return "audio"
+}
+
+func (v InputMediaAudio) GetMedia() InputFile {
+	return v.Media
 }
 
 func (v InputMediaAudio) MarshalJSON() ([]byte, error) {
@@ -2095,8 +2210,12 @@ type InputMediaDocument struct {
 	DisableContentTypeDetection bool `json:"disable_content_type_detection,omitempty"`
 }
 
-func (v InputMediaDocument) Type() string {
+func (v InputMediaDocument) GetType() string {
 	return "document"
+}
+
+func (v InputMediaDocument) GetMedia() InputFile {
+	return v.Media
 }
 
 func (v InputMediaDocument) MarshalJSON() ([]byte, error) {
@@ -2146,8 +2265,12 @@ type InputMediaPhoto struct {
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 }
 
-func (v InputMediaPhoto) Type() string {
+func (v InputMediaPhoto) GetType() string {
 	return "photo"
+}
+
+func (v InputMediaPhoto) GetMedia() InputFile {
+	return v.Media
 }
 
 func (v InputMediaPhoto) MarshalJSON() ([]byte, error) {
@@ -2207,8 +2330,12 @@ type InputMediaVideo struct {
 	SupportsStreaming bool `json:"supports_streaming,omitempty"`
 }
 
-func (v InputMediaVideo) Type() string {
+func (v InputMediaVideo) GetType() string {
 	return "video"
+}
+
+func (v InputMediaVideo) GetMedia() InputFile {
+	return v.Media
 }
 
 func (v InputMediaVideo) MarshalJSON() ([]byte, error) {
@@ -2569,6 +2696,9 @@ type PassportData struct {
 // - PassportElementErrorUnspecified
 // https://core.telegram.org/bots/api#passportelementerror
 type PassportElementError interface {
+	GetSource() string
+	GetType() string
+	GetMessage() string
 	PassportElementError() ([]byte, error)
 }
 
@@ -2585,6 +2715,30 @@ type PassportElementErrorDataField struct {
 	DataHash string `json:"data_hash,omitempty"`
 	// Error message
 	Message string `json:"message,omitempty"`
+}
+
+func (v PassportElementErrorDataField) GetSource() string {
+	return "data_field"
+}
+
+func (v PassportElementErrorDataField) GetType() string {
+	return v.Type
+}
+
+func (v PassportElementErrorDataField) GetMessage() string {
+	return v.Message
+}
+
+func (v PassportElementErrorDataField) MarshalJSON() ([]byte, error) {
+	type alias PassportElementErrorDataField
+	a := struct {
+		Source string `json:"source"`
+		alias
+	}{
+		Source: "data_field",
+		alias:  (alias)(v),
+	}
+	return json.Marshal(a)
 }
 
 func (v PassportElementErrorDataField) PassportElementError() ([]byte, error) {
@@ -2604,6 +2758,30 @@ type PassportElementErrorFile struct {
 	Message string `json:"message,omitempty"`
 }
 
+func (v PassportElementErrorFile) GetSource() string {
+	return "file"
+}
+
+func (v PassportElementErrorFile) GetType() string {
+	return v.Type
+}
+
+func (v PassportElementErrorFile) GetMessage() string {
+	return v.Message
+}
+
+func (v PassportElementErrorFile) MarshalJSON() ([]byte, error) {
+	type alias PassportElementErrorFile
+	a := struct {
+		Source string `json:"source"`
+		alias
+	}{
+		Source: "file",
+		alias:  (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
 func (v PassportElementErrorFile) PassportElementError() ([]byte, error) {
 	return json.Marshal(v)
 }
@@ -2619,6 +2797,30 @@ type PassportElementErrorFiles struct {
 	FileHashes []string `json:"file_hashes,omitempty"`
 	// Error message
 	Message string `json:"message,omitempty"`
+}
+
+func (v PassportElementErrorFiles) GetSource() string {
+	return "files"
+}
+
+func (v PassportElementErrorFiles) GetType() string {
+	return v.Type
+}
+
+func (v PassportElementErrorFiles) GetMessage() string {
+	return v.Message
+}
+
+func (v PassportElementErrorFiles) MarshalJSON() ([]byte, error) {
+	type alias PassportElementErrorFiles
+	a := struct {
+		Source string `json:"source"`
+		alias
+	}{
+		Source: "files",
+		alias:  (alias)(v),
+	}
+	return json.Marshal(a)
 }
 
 func (v PassportElementErrorFiles) PassportElementError() ([]byte, error) {
@@ -2638,6 +2840,30 @@ type PassportElementErrorFrontSide struct {
 	Message string `json:"message,omitempty"`
 }
 
+func (v PassportElementErrorFrontSide) GetSource() string {
+	return "front_side"
+}
+
+func (v PassportElementErrorFrontSide) GetType() string {
+	return v.Type
+}
+
+func (v PassportElementErrorFrontSide) GetMessage() string {
+	return v.Message
+}
+
+func (v PassportElementErrorFrontSide) MarshalJSON() ([]byte, error) {
+	type alias PassportElementErrorFrontSide
+	a := struct {
+		Source string `json:"source"`
+		alias
+	}{
+		Source: "front_side",
+		alias:  (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
 func (v PassportElementErrorFrontSide) PassportElementError() ([]byte, error) {
 	return json.Marshal(v)
 }
@@ -2653,6 +2879,30 @@ type PassportElementErrorReverseSide struct {
 	FileHash string `json:"file_hash,omitempty"`
 	// Error message
 	Message string `json:"message,omitempty"`
+}
+
+func (v PassportElementErrorReverseSide) GetSource() string {
+	return "reverse_side"
+}
+
+func (v PassportElementErrorReverseSide) GetType() string {
+	return v.Type
+}
+
+func (v PassportElementErrorReverseSide) GetMessage() string {
+	return v.Message
+}
+
+func (v PassportElementErrorReverseSide) MarshalJSON() ([]byte, error) {
+	type alias PassportElementErrorReverseSide
+	a := struct {
+		Source string `json:"source"`
+		alias
+	}{
+		Source: "reverse_side",
+		alias:  (alias)(v),
+	}
+	return json.Marshal(a)
 }
 
 func (v PassportElementErrorReverseSide) PassportElementError() ([]byte, error) {
@@ -2672,6 +2922,30 @@ type PassportElementErrorSelfie struct {
 	Message string `json:"message,omitempty"`
 }
 
+func (v PassportElementErrorSelfie) GetSource() string {
+	return "selfie"
+}
+
+func (v PassportElementErrorSelfie) GetType() string {
+	return v.Type
+}
+
+func (v PassportElementErrorSelfie) GetMessage() string {
+	return v.Message
+}
+
+func (v PassportElementErrorSelfie) MarshalJSON() ([]byte, error) {
+	type alias PassportElementErrorSelfie
+	a := struct {
+		Source string `json:"source"`
+		alias
+	}{
+		Source: "selfie",
+		alias:  (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
 func (v PassportElementErrorSelfie) PassportElementError() ([]byte, error) {
 	return json.Marshal(v)
 }
@@ -2687,6 +2961,30 @@ type PassportElementErrorTranslationFile struct {
 	FileHash string `json:"file_hash,omitempty"`
 	// Error message
 	Message string `json:"message,omitempty"`
+}
+
+func (v PassportElementErrorTranslationFile) GetSource() string {
+	return "translation_file"
+}
+
+func (v PassportElementErrorTranslationFile) GetType() string {
+	return v.Type
+}
+
+func (v PassportElementErrorTranslationFile) GetMessage() string {
+	return v.Message
+}
+
+func (v PassportElementErrorTranslationFile) MarshalJSON() ([]byte, error) {
+	type alias PassportElementErrorTranslationFile
+	a := struct {
+		Source string `json:"source"`
+		alias
+	}{
+		Source: "translation_file",
+		alias:  (alias)(v),
+	}
+	return json.Marshal(a)
 }
 
 func (v PassportElementErrorTranslationFile) PassportElementError() ([]byte, error) {
@@ -2706,6 +3004,30 @@ type PassportElementErrorTranslationFiles struct {
 	Message string `json:"message,omitempty"`
 }
 
+func (v PassportElementErrorTranslationFiles) GetSource() string {
+	return "translation_files"
+}
+
+func (v PassportElementErrorTranslationFiles) GetType() string {
+	return v.Type
+}
+
+func (v PassportElementErrorTranslationFiles) GetMessage() string {
+	return v.Message
+}
+
+func (v PassportElementErrorTranslationFiles) MarshalJSON() ([]byte, error) {
+	type alias PassportElementErrorTranslationFiles
+	a := struct {
+		Source string `json:"source"`
+		alias
+	}{
+		Source: "translation_files",
+		alias:  (alias)(v),
+	}
+	return json.Marshal(a)
+}
+
 func (v PassportElementErrorTranslationFiles) PassportElementError() ([]byte, error) {
 	return json.Marshal(v)
 }
@@ -2721,6 +3043,30 @@ type PassportElementErrorUnspecified struct {
 	ElementHash string `json:"element_hash,omitempty"`
 	// Error message
 	Message string `json:"message,omitempty"`
+}
+
+func (v PassportElementErrorUnspecified) GetSource() string {
+	return "unspecified"
+}
+
+func (v PassportElementErrorUnspecified) GetType() string {
+	return v.Type
+}
+
+func (v PassportElementErrorUnspecified) GetMessage() string {
+	return v.Message
+}
+
+func (v PassportElementErrorUnspecified) MarshalJSON() ([]byte, error) {
+	type alias PassportElementErrorUnspecified
+	a := struct {
+		Source string `json:"source"`
+		alias
+	}{
+		Source: "unspecified",
+		alias:  (alias)(v),
+	}
+	return json.Marshal(a)
 }
 
 func (v PassportElementErrorUnspecified) PassportElementError() ([]byte, error) {

--- a/gen_types.go
+++ b/gen_types.go
@@ -458,9 +458,9 @@ type MergedChatMember struct {
 	Status string `json:"status,omitempty"`
 	// Information about the user
 	User User `json:"user,omitempty"`
-	// Optional. Custom title for this user (Only for owner, administrator)
+	// Optional. Custom title for this user (Only for creator, administrator)
 	CustomTitle string `json:"custom_title,omitempty"`
-	// Optional. True, if the user's presence in the chat is hidden (Only for owner, administrator)
+	// Optional. True, if the user's presence in the chat is hidden (Only for creator, administrator)
 	IsAnonymous bool `json:"is_anonymous,omitempty"`
 	// Optional. True, if the bot is allowed to edit administrator privileges of that user (Only for administrator)
 	CanBeEdited bool `json:"can_be_edited,omitempty"`
@@ -534,7 +534,7 @@ func unmarshalChatMember(d json.RawMessage) (ChatMember, error) {
 	}
 
 	switch t.Status {
-	case "owner":
+	case "creator":
 		s := ChatMemberOwner{}
 		err := json.Unmarshal(d, &s)
 		if err != nil {
@@ -805,7 +805,7 @@ type ChatMemberOwner struct {
 
 // GetStatus is a helper method to easily access the common fields of an interface.
 func (v ChatMemberOwner) GetStatus() string {
-	return "owner"
+	return "creator"
 }
 
 // GetUser is a helper method to easily access the common fields of an interface.
@@ -816,7 +816,7 @@ func (v ChatMemberOwner) GetUser() User {
 // MergeChatMember returns a MergedChatMember struct to simplify working with types in a non-generic world.
 func (v ChatMemberOwner) MergeChatMember() MergedChatMember {
 	return MergedChatMember{
-		Status:      "owner",
+		Status:      "creator",
 		User:        v.User,
 		CustomTitle: v.CustomTitle,
 		IsAnonymous: v.IsAnonymous,
@@ -830,7 +830,7 @@ func (v ChatMemberOwner) MarshalJSON() ([]byte, error) {
 		Status string `json:"status"`
 		alias
 	}{
-		Status: "owner",
+		Status: "creator",
 		alias:  (alias)(v),
 	}
 	return json.Marshal(a)

--- a/scripts/generate/common.go
+++ b/scripts/generate/common.go
@@ -121,6 +121,12 @@ func getAllFields(types []TypeDescription, parentType string) []Field {
 			continue
 		}
 
+		// If not all subtypes use it, then its optional; update description.
+		if f.Required {
+			f.Description = "Optional. " + f.Description
+		}
+
+		fields[idx].Required = false
 		fields[idx].Description = fmt.Sprintf("%s (Only for %s)", f.Description, strings.Join(typesUsingField, ", "))
 	}
 

--- a/scripts/generate/common.go
+++ b/scripts/generate/common.go
@@ -97,6 +97,36 @@ func goTypeStringer(t string) string {
 	}
 }
 
+func getAllFields(types []TypeDescription, parentType string) []Field {
+	if len(types) == 0 {
+		return nil
+	}
+
+	var fields []Field
+	isOK := map[string][]string{}
+
+	for _, t := range types {
+		for _, f := range t.Fields {
+			isOK[f.Name] = append(isOK[f.Name], t.getTypeNameFromParent(parentType))
+
+			if len(isOK[f.Name]) == 1 {
+				fields = append(fields, f)
+			}
+		}
+	}
+
+	for idx, f := range fields {
+		typesUsingField := isOK[f.Name]
+		if len(typesUsingField) == len(types) {
+			continue
+		}
+
+		fields[idx].Description = fmt.Sprintf("%s (Only for %s)", f.Description, strings.Join(typesUsingField, ", "))
+	}
+
+	return fields
+}
+
 func getCommonFields(types []TypeDescription) []Field {
 	if len(types) == 0 {
 		return nil

--- a/scripts/generate/common.go
+++ b/scripts/generate/common.go
@@ -7,6 +7,15 @@ import (
 	"strings"
 )
 
+func contains(s string, ss []string) bool {
+	for _, str := range ss {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}
+
 func snakeToTitle(s string) string {
 	bd := strings.Builder{}
 

--- a/scripts/generate/common.go
+++ b/scripts/generate/common.go
@@ -75,7 +75,7 @@ func isArray(s string) bool {
 	return strings.HasPrefix(s, "[]")
 }
 
-func getDefaultReturnVal(s string) string {
+func getDefaultReturnVal(d APIDescription, s string) string {
 	if strings.HasPrefix(s, "*") || strings.HasPrefix(s, "[]") {
 		return "nil"
 	}
@@ -89,10 +89,14 @@ func getDefaultReturnVal(s string) string {
 		return "false"
 	case "string":
 		return "\"\""
-	}
+	default:
+		if _, ok := d.Types[s]; ok {
+			return "nil"
+		}
 
-	// this isnt great
-	return s
+		// this isnt great
+		return s
+	}
 }
 
 func goTypeStringer(t string) string {

--- a/scripts/generate/common.go
+++ b/scripts/generate/common.go
@@ -42,6 +42,10 @@ func titleToSnake(str string) string {
 	return strings.ToLower(snake)
 }
 
+func titleToCamelCase(str string) string {
+	return strings.ToLower(str[0:1]) + str[1:]
+}
+
 func toGoType(s string) string {
 	pref := ""
 	for isTgArray(s) {

--- a/scripts/generate/gen.go
+++ b/scripts/generate/gen.go
@@ -104,6 +104,21 @@ func (td TypeDescription) getConstantFieldFromParent(d APIDescription) (string, 
 	return common[0].Name, nil
 }
 
+func (td TypeDescription) docs() string {
+	docs := strings.Builder{}
+	for idx, desc := range td.Description {
+		text := desc
+		if idx == 0 {
+			text = td.Name + " " + desc
+		}
+
+		docs.WriteString("\n// " + text)
+	}
+
+	docs.WriteString("\n// " + td.Href)
+	return docs.String()
+}
+
 type MethodDescription struct {
 	Name        string   `json:"name"`
 	Fields      []Field  `json:"fields"`
@@ -117,6 +132,19 @@ type Field struct {
 	Types       []string `json:"types"`
 	Required    bool     `json:"required"`
 	Description string   `json:"description"`
+}
+
+func (f Field) isConstantField(d APIDescription, tgType TypeDescription) bool {
+	for _, parent := range tgType.SubtypeOf {
+		constantField, err := d.Types[parent].getConstantFieldFromParent(d)
+		if err != nil {
+			continue
+		}
+		if constantField == f.Name {
+			return true
+		}
+	}
+	return false
 }
 
 const (

--- a/scripts/generate/gen.go
+++ b/scripts/generate/gen.go
@@ -50,6 +50,7 @@ func (td TypeDescription) sentByAPI(d APIDescription) bool {
 func (td TypeDescription) getTypeNameFromParent(parentType string) string {
 	typeName := strings.TrimPrefix(td.Name, parentType)
 	typeName = strings.TrimPrefix(typeName, "Cached") // some of them are "Cached"
+	typeName = strings.TrimSuffix(typeName, "Field")  // some of them are "Field"
 	return typeName
 }
 

--- a/scripts/generate/gen.go
+++ b/scripts/generate/gen.go
@@ -67,6 +67,8 @@ const (
 	tgTypePassportElementError = "PassportElementError"
 	tgTypeCallbackGame         = "CallbackGame"
 	tgTypeVoiceChatStarted     = "VoiceChatStarted"
+	tgTypeBotCommandScope      = "BotCommandScope"
+	tgTypeChatMember           = "ChatMember"
 	// This is actually a custom type.
 	tgTypeReplyMarkup = "ReplyMarkup"
 )

--- a/scripts/generate/gen.go
+++ b/scripts/generate/gen.go
@@ -84,6 +84,8 @@ func (td TypeDescription) getTypeNameFromParent(parentType string) string {
 	// Telegram inconsistencies
 	if td.Name == "ChatMemberOwner" {
 		return "creator"
+	} else if td.Name == "ChatMemberBanned" {
+		return "kicked"
 	}
 
 	typeName := strings.TrimPrefix(td.Name, parentType)

--- a/scripts/generate/gen.go
+++ b/scripts/generate/gen.go
@@ -81,6 +81,11 @@ func CheckChildTypes(d APIDescription, tgType TypeDescription, typeName string, 
 }
 
 func (td TypeDescription) getTypeNameFromParent(parentType string) string {
+	// Telegram inconsistencies
+	if td.Name == "ChatMemberOwner" {
+		return "creator"
+	}
+
 	typeName := strings.TrimPrefix(td.Name, parentType)
 	typeName = strings.TrimPrefix(typeName, "Cached") // some of them are "Cached"
 	typeName = strings.TrimSuffix(typeName, "Field")  // some of them are "Field"

--- a/scripts/generate/gen.go
+++ b/scripts/generate/gen.go
@@ -51,7 +51,7 @@ func (td TypeDescription) getTypeNameFromParent(parentType string) string {
 	typeName := strings.TrimPrefix(td.Name, parentType)
 	typeName = strings.TrimPrefix(typeName, "Cached") // some of them are "Cached"
 	typeName = strings.TrimSuffix(typeName, "Field")  // some of them are "Field"
-	return typeName
+	return titleToSnake(typeName)
 }
 
 func (td TypeDescription) getConstantFieldFromParent(d APIDescription) (string, error) {

--- a/scripts/generate/gen.go
+++ b/scripts/generate/gen.go
@@ -55,6 +55,10 @@ func (td TypeDescription) getTypeNameFromParent(parentType string) string {
 }
 
 func (td TypeDescription) getConstantFieldFromParent(d APIDescription) (string, error) {
+	if len(td.Subtypes) == 0 {
+		return "", fmt.Errorf("expected %s to be a parent", td.Name)
+	}
+
 	subTypes, err := getTypesByName(d, td.Subtypes)
 	if err != nil {
 		return "", fmt.Errorf("failed to get parent type %s: %w", td.Name, err)

--- a/scripts/generate/gen.go
+++ b/scripts/generate/gen.go
@@ -310,7 +310,7 @@ func (m MethodDescription) GetReturnType(d APIDescription) (string, error) {
 	}
 
 	retType := toGoType(prefRetVal)
-	if isTgType(d, retType) {
+	if isTgType(d, retType) && len(d.Types[prefRetVal].Subtypes) == 0 {
 		retType = "*" + retType
 	}
 

--- a/scripts/generate/helpers.go
+++ b/scripts/generate/helpers.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"html/template"
 	"strings"
+	"text/template"
 )
 
 func generateHelpers(d APIDescription) error {

--- a/scripts/generate/helpers.go
+++ b/scripts/generate/helpers.go
@@ -75,7 +75,7 @@ func generateHelperDef(d APIDescription, tgMethod MethodDescription) (string, er
 
 		receiverName := tgType.receiverName()
 
-		funcCallArgList, funcDefArgList, optsContent, err := generateHelperArguments(tgMethod, receiverName, fields)
+		funcCallArgList, funcDefArgList, optsContent, err := generateHelperArguments(d, tgMethod, receiverName, fields)
 		if err != nil {
 			return "", err
 		}
@@ -104,7 +104,7 @@ func generateHelperDef(d APIDescription, tgMethod MethodDescription) (string, er
 	return helperDef.String(), nil
 }
 
-func generateHelperArguments(tgMethod MethodDescription, receiverName string, fields map[string]string) ([]string, []string, string, error) {
+func generateHelperArguments(d APIDescription, tgMethod MethodDescription, receiverName string, fields map[string]string) ([]string, []string, string, error) {
 	var funcCallArgList []string
 	optsContent := strings.Builder{}
 	funcDefArgList := []string{"b *Bot"}
@@ -120,7 +120,7 @@ func generateHelperArguments(tgMethod MethodDescription, receiverName string, fi
 
 		if fName, ok := fields[mf.Name]; ok {
 			if !mf.Required {
-				def := getDefaultReturnVal(prefType)
+				def := getDefaultReturnVal(d, prefType)
 				optsContent.WriteString("\n	if opts." + snakeToTitle(mf.Name) + " == " + def + " {")
 				optsContent.WriteString("\n		opts." + snakeToTitle(mf.Name) + " = " + receiverName + "." + snakeToTitle(fName))
 				optsContent.WriteString("\n	}")

--- a/scripts/generate/methods.go
+++ b/scripts/generate/methods.go
@@ -105,8 +105,12 @@ func generateMethodDef(d APIDescription, tgMethod MethodDescription) (string, er
 		addr = "&"
 	}
 
-	method.WriteString("\nvar " + retVarName + " " + retVarType)
-	method.WriteString("\nreturn " + addr + retVarName + ", json.Unmarshal(r, &" + retVarName + ")")
+	if len(d.Types[retType].Subtypes) != 0 {
+		method.WriteString(fmt.Sprintf("\nreturn unmarshal%s(r)", retType))
+	} else {
+		method.WriteString("\nvar " + retVarName + " " + retVarType)
+		method.WriteString("\nreturn " + addr + retVarName + ", json.Unmarshal(r, &" + retVarName + ")")
+	}
 	method.WriteString("\n}")
 
 	return method.String(), nil

--- a/scripts/generate/methods.go
+++ b/scripts/generate/methods.go
@@ -253,17 +253,8 @@ if %s != %s {
 			return "", false, fmt.Errorf("failed to execute inputmedia array branch template: %w", err)
 		}
 
-	case "ReplyMarkup":
-		bd.WriteString("\nif " + goParam + " != nil {")
-		bd.WriteString("\n	bs, err := " + goParam + ".ReplyMarkup()")
-		bd.WriteString("\n	if err != nil {")
-		bd.WriteString("\n		return " + defaultRetVal + ", fmt.Errorf(\"failed to marshal field " + f.Name + ": %w\", err)")
-		bd.WriteString("\n	}")
-		bd.WriteString("\n	v.Add(\"" + f.Name + "\", string(bs))")
-		bd.WriteString("\n}")
-
 	default:
-		if isArray(fieldType) {
+		if isArray(fieldType) || fieldType == tgTypeReplyMarkup {
 			bd.WriteString("\nif " + goParam + " != nil {")
 		}
 
@@ -273,7 +264,7 @@ if %s != %s {
 		bd.WriteString("\n	}")
 		bd.WriteString("\n	v.Add(\"" + f.Name + "\", string(bs))")
 
-		if isArray(fieldType) {
+		if isArray(fieldType) || fieldType == tgTypeReplyMarkup {
 			bd.WriteString("\n}")
 		}
 	}

--- a/scripts/generate/types.go
+++ b/scripts/generate/types.go
@@ -118,21 +118,6 @@ func generateParentType(d APIDescription, tgType TypeDescription) (string, error
 	return typeDef.String(), nil
 }
 
-func (td TypeDescription) docs() string {
-	docs := strings.Builder{}
-	for idx, desc := range td.Description {
-		text := desc
-		if idx == 0 {
-			text = td.Name + " " + desc
-		}
-
-		docs.WriteString("\n// " + text)
-	}
-
-	docs.WriteString("\n// " + td.Href)
-	return docs.String()
-}
-
 // Incoming types which marshal into interfaces need special handling to make sure the interfaces are
 // populated correctly.
 func setupCustomUnmarshal(d APIDescription, tgType TypeDescription) (string, error) {
@@ -161,7 +146,7 @@ func setupCustomUnmarshal(d APIDescription, tgType TypeDescription) (string, err
 			}
 		}
 
-		if idx == 0 && len(tgType.SubtypeOf) > 0 && (f.Name == "type" || f.Name == "status") {
+		if idx == 0 && len(tgType.SubtypeOf) > 0 && f.isConstantField(d, tgType) {
 			continue
 		}
 

--- a/scripts/generate/types.go
+++ b/scripts/generate/types.go
@@ -414,10 +414,12 @@ func generateGenericInterfaceType(d APIDescription, name string, subtypes []Type
 	bd.WriteString(fmt.Sprintf("\n%s() ([]byte, error)", name))
 
 	if name == tgTypeInputMedia {
+		bd.WriteString(fmt.Sprintf("\n// %sParams allows for uploading %s files with attachments.", name, name))
 		bd.WriteString(fmt.Sprintf("\n%sParams(string, map[string]NamedReader) ([]byte, error)", name))
 	}
 
 	if len(commonFields) > 0 {
+		bd.WriteString(fmt.Sprintf("\n// Merge%s returns a Merged%s struct to simplify working with complex telegram types in a non-generic world.", name, name))
 		bd.WriteString(fmt.Sprintf("\nMerge%s() Merged%s", name, name))
 		bd.WriteString("\n}")
 
@@ -468,6 +470,7 @@ func generateMergeFunc(d APIDescription, tgType TypeDescription, parentType stri
 
 	bd := strings.Builder{}
 
+	bd.WriteString(fmt.Sprintf("\n// %s.Merge%s returns a Merged%s struct to simply working with types in a non-generic world.", tgType.Name, parentType, parentType))
 	bd.WriteString(fmt.Sprintf("\nfunc (v %s) Merge%s() Merged%s {", tgType.Name, parentType, parentType))
 	bd.WriteString(fmt.Sprintf("\n\treturn Merged%s{", parentType))
 	for _, f := range tgType.Fields {

--- a/scripts/generate/types.go
+++ b/scripts/generate/types.go
@@ -432,9 +432,10 @@ func generateGenericInterfaceType(d APIDescription, name string, subtypes []Type
 		bd.WriteString(commonGetMethods)
 		bd.WriteString(generateGenericInterfaceMethod("Merged"+name, name))
 		bd.WriteString(fmt.Sprintf(`
+// Merge%s returns a Merged%s struct to simplify working with types in a non-generic world.
 func (v Merged%s) Merge%s() Merged%s {
 	return v
-}`, name, name, name))
+}`, name, name, name, name, name))
 	}
 
 	return bd.String(), nil
@@ -447,10 +448,11 @@ func generateMergedStruct(d APIDescription, name string, subtypes []TypeDescript
 	}
 
 	return fmt.Sprintf(`
+// Merged%s is a helper type to simplify interactions with the various %s subtypes.
 type Merged%s struct {
 	%s
 }
-`, name, strings.TrimSpace(fields)), nil
+`, name, name, name, strings.TrimSpace(fields)), nil
 }
 
 func generateCommonGetMethod(t string, commonName string, commonType string, commonValue string) string {
@@ -521,6 +523,7 @@ type customUnmarshalData struct {
 }
 
 const customUnmarshal = `
+// UnmarshalJSON is a custom JSON unmarshaller to use the helpers which allow for unmarshalling structs into interfaces.
 func (v *{{.Type}}) UnmarshalJSON(b []byte) error {
 	// All fields in {{.Type}}, with interface fields as json.RawMessage
 	type tmp struct {
@@ -561,6 +564,8 @@ type customStructUnmarshalCaseData struct {
 }
 
 const customStructUnmarshal = `
+// {{.UnmarshalFuncName}} is a JSON unmarshal helper to marshal the right structs into a {{.ParentType}} interface
+// based on the {{.ConstantFieldName}} field.
 func {{.UnmarshalFuncName}}(d json.RawMessage) ({{.ParentType}}, error) {
 		if len(d) == 0 {
 			return nil, nil
@@ -597,6 +602,7 @@ type customMarshalData struct {
 
 // The alias type is required to avoid infinite MarshalJSON loops.
 const customMarshal = `
+// MarshalJSON is a custom JSON marshaller to allow for enforcing the {{.ConstantFieldName}} value.
 func (v {{.Type}}) MarshalJSON() ([]byte, error) {
 	type alias {{.Type}}
 	a := struct{

--- a/scripts/generate/types.go
+++ b/scripts/generate/types.go
@@ -455,10 +455,11 @@ type Merged%s struct {
 
 func generateCommonGetMethod(t string, commonName string, commonType string, commonValue string) string {
 	return fmt.Sprintf(`
+// Get%s is a helper method to easily access the common fields of an interface.
 func (v %s) Get%s() %s {
 	return %s
 }
-`, t, commonName, commonType, commonValue)
+`, commonName, t, commonName, commonType, commonValue)
 }
 
 func generateMergeFunc(d APIDescription, typeName string, shortname string, fields []Field, parentType string, constantField string) (string, error) {
@@ -471,7 +472,7 @@ func generateMergeFunc(d APIDescription, typeName string, shortname string, fiel
 
 	bd := strings.Builder{}
 
-	bd.WriteString(fmt.Sprintf("\n// %s.Merge%s returns a Merged%s struct to simply working with types in a non-generic world.", typeName, parentType, parentType))
+	bd.WriteString(fmt.Sprintf("\n// Merge%s returns a Merged%s struct to simply working with types in a non-generic world.", parentType, parentType))
 	bd.WriteString(fmt.Sprintf("\nfunc (v %s) Merge%s() Merged%s {", typeName, parentType, parentType))
 	bd.WriteString(fmt.Sprintf("\n\treturn Merged%s{", parentType))
 	for _, f := range fields {

--- a/scripts/generate/types.go
+++ b/scripts/generate/types.go
@@ -29,7 +29,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"errors"
 )
 `)
 
@@ -522,7 +521,7 @@ func {{.UnmarshalFuncName}}(d json.RawMessage) ({{.ParentType}}, error) {
 			{{ $val }}
 		{{- end -}}
 		}
-		return nil, errors.New("failed to unmarshal: unknown interface with {{.ConstantFieldName}} " +t.{{.ConstantFieldName}} )
+		return nil, fmt.Errorf("unknown interface with {{.ConstantFieldName}} %v", t.{{.ConstantFieldName}})
 }`
 
 type customStructUnmarshalCaseData struct {

--- a/scripts/generate/types.go
+++ b/scripts/generate/types.go
@@ -472,7 +472,7 @@ func generateMergeFunc(d APIDescription, typeName string, shortname string, fiel
 
 	bd := strings.Builder{}
 
-	bd.WriteString(fmt.Sprintf("\n// Merge%s returns a Merged%s struct to simply working with types in a non-generic world.", parentType, parentType))
+	bd.WriteString(fmt.Sprintf("\n// Merge%s returns a Merged%s struct to simplify working with types in a non-generic world.", parentType, parentType))
 	bd.WriteString(fmt.Sprintf("\nfunc (v %s) Merge%s() Merged%s {", typeName, parentType, parentType))
 	bd.WriteString(fmt.Sprintf("\n\treturn Merged%s{", parentType))
 	for _, f := range fields {

--- a/scripts/generate/types.go
+++ b/scripts/generate/types.go
@@ -483,7 +483,8 @@ type customStructUnmarshalData struct {
 }
 
 // The alias type is required to avoid infinite MarshalJSON loops.
-const customStructUnmarshal = `func {{.UnmarshalFuncName}}(d json.RawMessage) ({{.ParentType}}, error) {
+const customStructUnmarshal = `
+func {{.UnmarshalFuncName}}(d json.RawMessage) ({{.ParentType}}, error) {
 		if len(d) == 0 {
 			return nil, nil
 		}
@@ -497,8 +498,9 @@ const customStructUnmarshal = `func {{.UnmarshalFuncName}}(d json.RawMessage) ({
 		}
 
 		switch t.{{.ConstantFieldName}} {
-		{{ range $val := .CaseStatements }} {{ $val }}
-		{{end}}
+		{{-  range $val := .CaseStatements -}}
+			{{ $val }}
+		{{- end -}}
 		}
 		return nil, errors.New("failed to unmarshal: unknown interface with {{.ConstantFieldName}} " +t.{{.ConstantFieldName}} )
 }`
@@ -509,7 +511,8 @@ type customStructUnmarshalCaseData struct {
 }
 
 // The alias type is required to avoid infinite MarshalJSON loops.
-const customStructUnmarshalCase = `case "{{.ConstantFieldName}}":
+const customStructUnmarshalCase = `
+case "{{.ConstantFieldName}}":
 	s := {{.TypeName}}{}
 	err := json.Unmarshal(d, &s)
 	if err != nil {


### PR DESCRIPTION
# What

Update library to [Bot API 5.3](https://core.telegram.org/bots/api#june-25-2021).

## Breaking changes:
- `kickChatMember` is now called `banChatMember`
- The `ChatMember` struct is now an interface split into various other types, eg `ChatMemberOwner`. These are all structs which implement the `ChatMember` interface. For those who prefer the previous structure, the `MergeChatMember` method is implemented as part of the interface to obtain the "merged" struct; ie, the same as was previously available.

## Code generation changes:
- Cleaned up some of the generation code to simplify future additions.
- Added more comments.
- Removed some previously hard coded strings in an attempt to make the overall generation more flexible (at the cost of some additional complexity).

# Impact

- Are your changes backwards compatible? No. See above for breaking changes.
- Have you included documentation, or updated existing documentation? New docs have been generated.
- Do errors and log messages provide enough context? yes
