### PR TITLE
Pass data to ProcessUpdate and NewContext

### DIFF
--- a/ext/context.go
+++ b/ext/context.go
@@ -11,12 +11,19 @@ type Context struct {
 	*gotgbot.Update
 	Data map[string]interface{}
 
+	// EffectiveMessage is the message which triggered the update, if possible
 	EffectiveMessage *gotgbot.Message
-	EffectiveChat    *gotgbot.Chat
-	EffectiveUser    *gotgbot.User
+	// EffectiveChat is the chat the update was triggered in, if possible
+	EffectiveChat *gotgbot.Chat
+	// EffectiveUser is the user who triggered the update, if possible.
+	// Note: when adding a user, the user who ADDED should be the EffectiveUser;
+	// they caused the update. If a user joins naturally, then they are the EffectiveUser.
+	EffectiveUser *gotgbot.User
 }
 
-func NewContext(b *gotgbot.Bot, update *gotgbot.Update) *Context {
+// NewContext populates a context with the relevant fields from the current update.
+// It takes a data field in the case where custom data needs to be passed.
+func NewContext(update *gotgbot.Update, data map[string]interface{}) *Context {
 	var msg *gotgbot.Message
 	var chat *gotgbot.Chat
 	var user *gotgbot.User
@@ -68,9 +75,13 @@ func NewContext(b *gotgbot.Bot, update *gotgbot.Update) *Context {
 
 	}
 
+	if data == nil {
+		data = make(map[string]interface{})
+	}
+
 	return &Context{
 		Update:           update,
-		Data:             make(map[string]interface{}),
+		Data:             data,
 		EffectiveMessage: msg,
 		EffectiveChat:    chat,
 		EffectiveUser:    user,

--- a/ext/dispatcher.go
+++ b/ext/dispatcher.go
@@ -181,10 +181,11 @@ func (d *Dispatcher) ProcessRawUpdate(b *gotgbot.Bot, r json.RawMessage) {
 		return
 	}
 
-	d.ProcessUpdate(b, &upd)
+	d.ProcessUpdate(b, &upd, nil)
 }
 
-func (d *Dispatcher) ProcessUpdate(b *gotgbot.Bot, update *gotgbot.Update) {
+// ProcessUpdate iterates over the list of groups to execute the matching handlers.
+func (d *Dispatcher) ProcessUpdate(b *gotgbot.Bot, update *gotgbot.Update, data map[string]interface{}) {
 	var ctx *Context
 
 	defer func() {
@@ -205,7 +206,7 @@ func (d *Dispatcher) ProcessUpdate(b *gotgbot.Bot, update *gotgbot.Update) {
 			}
 
 			if ctx == nil {
-				ctx = NewContext(b, update)
+				ctx = NewContext(update, data)
 			}
 
 			err := handler.HandleUpdate(b, ctx)


### PR DESCRIPTION
# What

This PR adds support for passing custom data to ProcessUpdate and NewContext. This makes it possible to generate updates with custom data programatically, and have those updates processed by the bot like any regular update would be


# Impact

- Are your changes backwards compatible? No - very small changes which should be easily adaptable. (simply add a nil parameter)
- Have you included documentation, or updated existing documentation? Yes.
- Do errors and log messages provide enough context? N/A
