### PR TITLE
Method to get message link

### DIFF
--- a/custom_helpers.go
+++ b/custom_helpers.go
@@ -1,5 +1,22 @@
 package gotgbot
 
+import (
+	"fmt"
+	"strings"
+)
+
+/* GetLink is a helper method to easily get the message link excluding group and private chat types.
+(It will return en empty string in case of private or group chat type)*/
+func (m Message) GetLink() string {
+	if m.Chat.Type == "private" || m.Chat.Type == "group" {
+		return ""
+	}
+	if m.Chat.Username != "" {
+		return fmt.Sprintf("https://t.me/%s/%d", m.Chat.Username, m.MessageId)
+	}
+	return strings.Replace(fmt.Sprintf("https://t.me/c/%d/%d", m.Chat.Id, m.MessageId), "-100", "", 1)
+}
+
 // Reply is a helper function to easily call Bot.SendMessage as a reply to an existing message.
 func (m Message) Reply(b *Bot, text string, opts *SendMessageOpts) (*Message, error) {
 	if opts == nil {

--- a/custom_helpers.go
+++ b/custom_helpers.go
@@ -14,7 +14,9 @@ func (m Message) GetLink() string {
 	if m.Chat.Username != "" {
 		return fmt.Sprintf("https://t.me/%s/%d", m.Chat.Username, m.MessageId)
 	}
-	return strings.Replace(fmt.Sprintf("https://t.me/c/%d/%d", m.Chat.Id, m.MessageId), "-100", "", 1)
+	// Message links use raw chatIds without the -100 prefix; this trims that prefix.
+	rawChatId := strings.TrimPrefix(strconv.FormatInt(m.Chat.Id, 10), "-100")
+	return fmt.Sprintf("https://t.me/c/%s/%d", rawChatId, m.MessageId)
 }
 
 // Reply is a helper function to easily call Bot.SendMessage as a reply to an existing message.

--- a/custom_helpers.go
+++ b/custom_helpers.go
@@ -5,8 +5,7 @@ import (
 	"strings"
 )
 
-/* GetLink is a helper method to easily get the message link excluding group and private chat types.
-(It will return en empty string in case of private or group chat type)*/
+// GetLink is a helper method to easily get the message link (It will return an empty string in case of private or group chat type).
 func (m Message) GetLink() string {
 	if m.Chat.Type == "private" || m.Chat.Type == "group" {
 		return ""

--- a/gen_types.go
+++ b/gen_types.go
@@ -3562,6 +3562,20 @@ type Message struct {
 	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
 }
 
+// GetLink is a helper method to easily get the message link excluding group and private chat types.
+func (m *Message) GetLink() string {
+	if m.Chat.Type != "private" && m.Chat.Type != "group" {
+		var to_link string
+		if m.Chat.Username != "" {
+			to_link = m.Chat.Username
+		} else {
+			to_link = fmt.Sprintf("c/%v", m.Chat.Id)
+		}
+		return fmt.Sprintf("https://t.me/%s/%v", to_link, m.MessageId)
+	}
+	return ""
+}
+
 // MessageAutoDeleteTimerChanged This object represents a service message about a change in auto-delete timer settings.
 // https://core.telegram.org/bots/api#messageautodeletetimerchanged
 type MessageAutoDeleteTimerChanged struct {

--- a/gen_types.go
+++ b/gen_types.go
@@ -3562,20 +3562,6 @@ type Message struct {
 	ReplyMarkup *InlineKeyboardMarkup `json:"reply_markup,omitempty"`
 }
 
-// GetLink is a helper method to easily get the message link excluding group and private chat types.
-func (m *Message) GetLink() string {
-	if m.Chat.Type != "private" && m.Chat.Type != "group" {
-		var to_link string
-		if m.Chat.Username != "" {
-			to_link = m.Chat.Username
-		} else {
-			to_link = fmt.Sprintf("c/%v", m.Chat.Id)
-		}
-		return fmt.Sprintf("https://t.me/%s/%v", to_link, m.MessageId)
-	}
-	return ""
-}
-
 // MessageAutoDeleteTimerChanged This object represents a service message about a change in auto-delete timer settings.
 // https://core.telegram.org/bots/api#messageautodeletetimerchanged
 type MessageAutoDeleteTimerChanged struct {


### PR DESCRIPTION
Added Message.GetLink() Method to get message link

<!--
Hey, thank you for opening a PR!

Please fill out the details below; they're there to help both you and the maintainers!
-->

# What

Inspired by python-telegram-bot, added Message.GetLink() to make it easier to get the link of a message in a supergroup or channel.


