### PR TITLE
Fix issue with inlinequerybutton type

### DIFF
--- a/gen_types.go
+++ b/gen_types.go
@@ -1176,9 +1176,9 @@ type InlineKeyboardButton struct {
 	// Optional. Data to be sent in a callback query to the bot when button is pressed, 1-64 bytes
 	CallbackData string `json:"callback_data,omitempty"`
 	// Optional. If set, pressing the button will prompt the user to select one of their chats, open that chat and insert the bot's username and the specified inline query in the input field. Can be empty, in which case just the bot's username will be inserted.Note: This offers an easy way for users to start using your bot in inline mode when they are currently in a private chat with it. Especially useful when combined with switch_pm… actions – in this case the user will be automatically returned to the chat they switched from, skipping the chat selection screen.
-	SwitchInlineQuery string `json:"switch_inline_query,omitempty"`
+	SwitchInlineQuery *string `json:"switch_inline_query,omitempty"`
 	// Optional. If set, pressing the button will insert the bot's username and the specified inline query in the current chat's input field. Can be empty, in which case only the bot's username will be inserted.This offers a quick way for the user to open your bot in inline mode in the same chat – good for selecting something from multiple options.
-	SwitchInlineQueryCurrentChat string `json:"switch_inline_query_current_chat,omitempty"`
+	SwitchInlineQueryCurrentChat *string `json:"switch_inline_query_current_chat,omitempty"`
 	// Optional. Description of the game that will be launched when the user presses the button.NOTE: This type of button must always be the first button in the first row.
 	CallbackGame *CallbackGame `json:"callback_game,omitempty"`
 	// Optional. Specify True, to send a Pay button.NOTE: This type of button must always be the first button in the first row.

--- a/scripts/generate/gen.go
+++ b/scripts/generate/gen.go
@@ -291,6 +291,12 @@ func (f Field) getPreferredType() (string, error) {
 		return tgTypeReplyMarkup, nil
 	}
 
+	// Some fields are marked as "can be empty", in which case we do want to pass the empty values.
+	// These should be handled as pointers, so we can differentiate the empty case.
+	if strings.Contains(f.Description, "Can be empty") {
+		return "*" + toGoType(f.Types[0]), nil
+	}
+
 	if len(f.Types) == 1 {
 		return toGoType(f.Types[0]), nil
 	}


### PR DESCRIPTION
Certain fields in the inlinequery button type are specifically marked as "can be empty". In these cases, we should use a pointer instead of the string value, so we can determine between if it is empty, or unset (nil pointer).


