### PR TITLE
Allow CI to check for codegen diff on PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,3 +21,15 @@ jobs:
           # skip cache to avoid flakes (and avoid using gh-action storage)
           skip-build-cache: true
           skip-pkg-cache: true
+  generate_code:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          version: latest
+      - name: Check if regenerating causes a diff
+        run: scripts/ci/generate.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
           skip-build-cache: true
           skip-pkg-cache: true
   generate_code:
-    name: lint
+    name: Check generated code diff
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,6 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          version: latest
+          go-version: 1.17.3
       - name: Check if regenerating causes a diff
         run: scripts/ci/generate.sh

--- a/scripts/ci/generate.sh
+++ b/scripts/ci/generate.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# regenerate library
+go generate
+
+# Check if a diff is found. If yes, fail.
+diff="$(git diff)"
+if [[ -n "$diff" ]]; then
+  echo "A diff was found when generating the docs" >&2
+  exit 1
+fi

--- a/scripts/ci/generate.sh
+++ b/scripts/ci/generate.sh
@@ -7,6 +7,7 @@ go generate
 # Check if a diff is found. If yes, fail.
 diff="$(git diff)"
 if [[ -n "$diff" ]]; then
-  echo "A diff was found when generating the docs" >&2
+  echo "A diff was found when generating the docs. Please commit the changes." >&2
   exit 1
 fi
+echo "No diff found, all is well!" >&2


### PR DESCRIPTION

# What
Allow CI to check for codegen diff on PRs. This should ensure that master always has the latest generated values.

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
