### PR TITLE
Paul/support dual returns

### DIFF
--- a/gen_helpers.go
+++ b/gen_helpers.go
@@ -74,7 +74,7 @@ func (c Chat) EditInviteLink(b *Bot, inviteLink string, opts *EditChatInviteLink
 }
 
 // EditCaption Helper method for Bot.EditMessageCaption
-func (m Message) EditCaption(b *Bot, opts *EditMessageCaptionOpts) (*Message, error) {
+func (m Message) EditCaption(b *Bot, opts *EditMessageCaptionOpts) (*Message, bool, error) {
 	if opts == nil {
 		opts = &EditMessageCaptionOpts{}
 	}
@@ -90,7 +90,7 @@ func (m Message) EditCaption(b *Bot, opts *EditMessageCaptionOpts) (*Message, er
 }
 
 // EditLiveLocation Helper method for Bot.EditMessageLiveLocation
-func (m Message) EditLiveLocation(b *Bot, latitude float64, longitude float64, opts *EditMessageLiveLocationOpts) (*Message, error) {
+func (m Message) EditLiveLocation(b *Bot, latitude float64, longitude float64, opts *EditMessageLiveLocationOpts) (*Message, bool, error) {
 	if opts == nil {
 		opts = &EditMessageLiveLocationOpts{}
 	}
@@ -106,7 +106,7 @@ func (m Message) EditLiveLocation(b *Bot, latitude float64, longitude float64, o
 }
 
 // EditMedia Helper method for Bot.EditMessageMedia
-func (m Message) EditMedia(b *Bot, media InputMedia, opts *EditMessageMediaOpts) (*Message, error) {
+func (m Message) EditMedia(b *Bot, media InputMedia, opts *EditMessageMediaOpts) (*Message, bool, error) {
 	if opts == nil {
 		opts = &EditMessageMediaOpts{}
 	}
@@ -122,7 +122,7 @@ func (m Message) EditMedia(b *Bot, media InputMedia, opts *EditMessageMediaOpts)
 }
 
 // EditReplyMarkup Helper method for Bot.EditMessageReplyMarkup
-func (m Message) EditReplyMarkup(b *Bot, opts *EditMessageReplyMarkupOpts) (*Message, error) {
+func (m Message) EditReplyMarkup(b *Bot, opts *EditMessageReplyMarkupOpts) (*Message, bool, error) {
 	if opts == nil {
 		opts = &EditMessageReplyMarkupOpts{}
 	}
@@ -138,7 +138,7 @@ func (m Message) EditReplyMarkup(b *Bot, opts *EditMessageReplyMarkupOpts) (*Mes
 }
 
 // EditText Helper method for Bot.EditMessageText
-func (m Message) EditText(b *Bot, text string, opts *EditMessageTextOpts) (*Message, error) {
+func (m Message) EditText(b *Bot, text string, opts *EditMessageTextOpts) (*Message, bool, error) {
 	if opts == nil {
 		opts = &EditMessageTextOpts{}
 	}
@@ -259,7 +259,7 @@ func (c Chat) SetTitle(b *Bot, title string) (bool, error) {
 }
 
 // StopLiveLocation Helper method for Bot.StopMessageLiveLocation
-func (m Message) StopLiveLocation(b *Bot, opts *StopMessageLiveLocationOpts) (*Message, error) {
+func (m Message) StopLiveLocation(b *Bot, opts *StopMessageLiveLocationOpts) (*Message, bool, error) {
 	if opts == nil {
 		opts = &StopMessageLiveLocationOpts{}
 	}

--- a/gen_methods.go
+++ b/gen_methods.go
@@ -708,7 +708,7 @@ type EditMessageCaptionOpts struct {
 // EditMessageCaption Use this method to edit captions of messages. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
 // - opts (type EditMessageCaptionOpts): All optional parameters.
 // https://core.telegram.org/bots/api#editmessagecaption
-func (bot *Bot) EditMessageCaption(opts *EditMessageCaptionOpts) (*Message, error) {
+func (bot *Bot) EditMessageCaption(opts *EditMessageCaptionOpts) (*Message, bool, error) {
 	v := urlLib.Values{}
 	if opts != nil {
 		if opts.ChatId != 0 {
@@ -723,24 +723,32 @@ func (bot *Bot) EditMessageCaption(opts *EditMessageCaptionOpts) (*Message, erro
 		if opts.CaptionEntities != nil {
 			bs, err := json.Marshal(opts.CaptionEntities)
 			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field caption_entities: %w", err)
+				return nil, false, fmt.Errorf("failed to marshal field caption_entities: %w", err)
 			}
 			v.Add("caption_entities", string(bs))
 		}
 		bs, err := json.Marshal(opts.ReplyMarkup)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
+			return nil, false, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 		}
 		v.Add("reply_markup", string(bs))
 	}
 
 	r, err := bot.Get("editMessageCaption", v)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	var m Message
-	return &m, json.Unmarshal(r, &m)
+	if err := json.Unmarshal(r, &m); err != nil {
+		var b bool
+		if err := json.Unmarshal(r, &b); err != nil {
+			return nil, false, err
+		}
+		return nil, b, nil
+	}
+	return &m, true, nil
+
 }
 
 // EditMessageLiveLocationOpts is the set of optional fields for Bot.EditMessageLiveLocation.
@@ -766,7 +774,7 @@ type EditMessageLiveLocationOpts struct {
 // - longitude (type float64): Longitude of new location
 // - opts (type EditMessageLiveLocationOpts): All optional parameters.
 // https://core.telegram.org/bots/api#editmessagelivelocation
-func (bot *Bot) EditMessageLiveLocation(latitude float64, longitude float64, opts *EditMessageLiveLocationOpts) (*Message, error) {
+func (bot *Bot) EditMessageLiveLocation(latitude float64, longitude float64, opts *EditMessageLiveLocationOpts) (*Message, bool, error) {
 	v := urlLib.Values{}
 	v.Add("latitude", strconv.FormatFloat(latitude, 'f', -1, 64))
 	v.Add("longitude", strconv.FormatFloat(longitude, 'f', -1, 64))
@@ -789,18 +797,26 @@ func (bot *Bot) EditMessageLiveLocation(latitude float64, longitude float64, opt
 		}
 		bs, err := json.Marshal(opts.ReplyMarkup)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
+			return nil, false, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 		}
 		v.Add("reply_markup", string(bs))
 	}
 
 	r, err := bot.Get("editMessageLiveLocation", v)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	var m Message
-	return &m, json.Unmarshal(r, &m)
+	if err := json.Unmarshal(r, &m); err != nil {
+		var b bool
+		if err := json.Unmarshal(r, &b); err != nil {
+			return nil, false, err
+		}
+		return nil, b, nil
+	}
+	return &m, true, nil
+
 }
 
 // EditMessageMediaOpts is the set of optional fields for Bot.EditMessageMedia.
@@ -819,12 +835,12 @@ type EditMessageMediaOpts struct {
 // - media (type InputMedia): A JSON-serialized object for a new media content of the message
 // - opts (type EditMessageMediaOpts): All optional parameters.
 // https://core.telegram.org/bots/api#editmessagemedia
-func (bot *Bot) EditMessageMedia(media InputMedia, opts *EditMessageMediaOpts) (*Message, error) {
+func (bot *Bot) EditMessageMedia(media InputMedia, opts *EditMessageMediaOpts) (*Message, bool, error) {
 	v := urlLib.Values{}
 	data := map[string]NamedReader{}
 	inputMediaBs, err := media.InputMediaParams("media", data)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal field media: %w", err)
+		return nil, false, fmt.Errorf("failed to marshal field media: %w", err)
 	}
 	v.Add("media", string(inputMediaBs))
 	if opts != nil {
@@ -837,18 +853,26 @@ func (bot *Bot) EditMessageMedia(media InputMedia, opts *EditMessageMediaOpts) (
 		v.Add("inline_message_id", opts.InlineMessageId)
 		bs, err := json.Marshal(opts.ReplyMarkup)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
+			return nil, false, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 		}
 		v.Add("reply_markup", string(bs))
 	}
 
 	r, err := bot.Post("editMessageMedia", v, data)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	var m Message
-	return &m, json.Unmarshal(r, &m)
+	if err := json.Unmarshal(r, &m); err != nil {
+		var b bool
+		if err := json.Unmarshal(r, &b); err != nil {
+			return nil, false, err
+		}
+		return nil, b, nil
+	}
+	return &m, true, nil
+
 }
 
 // EditMessageReplyMarkupOpts is the set of optional fields for Bot.EditMessageReplyMarkup.
@@ -866,7 +890,7 @@ type EditMessageReplyMarkupOpts struct {
 // EditMessageReplyMarkup Use this method to edit only the reply markup of messages. On success, if the edited message is not an inline message, the edited Message is returned, otherwise True is returned.
 // - opts (type EditMessageReplyMarkupOpts): All optional parameters.
 // https://core.telegram.org/bots/api#editmessagereplymarkup
-func (bot *Bot) EditMessageReplyMarkup(opts *EditMessageReplyMarkupOpts) (*Message, error) {
+func (bot *Bot) EditMessageReplyMarkup(opts *EditMessageReplyMarkupOpts) (*Message, bool, error) {
 	v := urlLib.Values{}
 	if opts != nil {
 		if opts.ChatId != 0 {
@@ -878,18 +902,26 @@ func (bot *Bot) EditMessageReplyMarkup(opts *EditMessageReplyMarkupOpts) (*Messa
 		v.Add("inline_message_id", opts.InlineMessageId)
 		bs, err := json.Marshal(opts.ReplyMarkup)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
+			return nil, false, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 		}
 		v.Add("reply_markup", string(bs))
 	}
 
 	r, err := bot.Get("editMessageReplyMarkup", v)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	var m Message
-	return &m, json.Unmarshal(r, &m)
+	if err := json.Unmarshal(r, &m); err != nil {
+		var b bool
+		if err := json.Unmarshal(r, &b); err != nil {
+			return nil, false, err
+		}
+		return nil, b, nil
+	}
+	return &m, true, nil
+
 }
 
 // EditMessageTextOpts is the set of optional fields for Bot.EditMessageText.
@@ -914,7 +946,7 @@ type EditMessageTextOpts struct {
 // - text (type string): New text of the message, 1-4096 characters after entities parsing
 // - opts (type EditMessageTextOpts): All optional parameters.
 // https://core.telegram.org/bots/api#editmessagetext
-func (bot *Bot) EditMessageText(text string, opts *EditMessageTextOpts) (*Message, error) {
+func (bot *Bot) EditMessageText(text string, opts *EditMessageTextOpts) (*Message, bool, error) {
 	v := urlLib.Values{}
 	v.Add("text", text)
 	if opts != nil {
@@ -929,25 +961,33 @@ func (bot *Bot) EditMessageText(text string, opts *EditMessageTextOpts) (*Messag
 		if opts.Entities != nil {
 			bs, err := json.Marshal(opts.Entities)
 			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field entities: %w", err)
+				return nil, false, fmt.Errorf("failed to marshal field entities: %w", err)
 			}
 			v.Add("entities", string(bs))
 		}
 		v.Add("disable_web_page_preview", strconv.FormatBool(opts.DisableWebPagePreview))
 		bs, err := json.Marshal(opts.ReplyMarkup)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
+			return nil, false, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 		}
 		v.Add("reply_markup", string(bs))
 	}
 
 	r, err := bot.Get("editMessageText", v)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	var m Message
-	return &m, json.Unmarshal(r, &m)
+	if err := json.Unmarshal(r, &m); err != nil {
+		var b bool
+		if err := json.Unmarshal(r, &b); err != nil {
+			return nil, false, err
+		}
+		return nil, b, nil
+	}
+	return &m, true, nil
+
 }
 
 // ExportChatInviteLink Use this method to generate a new primary invite link for a chat; any previously generated primary link is revoked. The bot must be an administrator in the chat for this to work and must have the appropriate administrator rights. Returns the new invite link as String on success.
@@ -3006,7 +3046,7 @@ type SetGameScoreOpts struct {
 // - score (type int64): New score, must be non-negative
 // - opts (type SetGameScoreOpts): All optional parameters.
 // https://core.telegram.org/bots/api#setgamescore
-func (bot *Bot) SetGameScore(userId int64, score int64, opts *SetGameScoreOpts) (*Message, error) {
+func (bot *Bot) SetGameScore(userId int64, score int64, opts *SetGameScoreOpts) (*Message, bool, error) {
 	v := urlLib.Values{}
 	v.Add("user_id", strconv.FormatInt(userId, 10))
 	v.Add("score", strconv.FormatInt(score, 10))
@@ -3024,11 +3064,19 @@ func (bot *Bot) SetGameScore(userId int64, score int64, opts *SetGameScoreOpts) 
 
 	r, err := bot.Get("setGameScore", v)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	var m Message
-	return &m, json.Unmarshal(r, &m)
+	if err := json.Unmarshal(r, &m); err != nil {
+		var b bool
+		if err := json.Unmarshal(r, &b); err != nil {
+			return nil, false, err
+		}
+		return nil, b, nil
+	}
+	return &m, true, nil
+
 }
 
 // SetMyCommandsOpts is the set of optional fields for Bot.SetMyCommands.
@@ -3242,7 +3290,7 @@ type StopMessageLiveLocationOpts struct {
 // StopMessageLiveLocation Use this method to stop updating a live location message before live_period expires. On success, if the message is not an inline message, the edited Message is returned, otherwise True is returned.
 // - opts (type StopMessageLiveLocationOpts): All optional parameters.
 // https://core.telegram.org/bots/api#stopmessagelivelocation
-func (bot *Bot) StopMessageLiveLocation(opts *StopMessageLiveLocationOpts) (*Message, error) {
+func (bot *Bot) StopMessageLiveLocation(opts *StopMessageLiveLocationOpts) (*Message, bool, error) {
 	v := urlLib.Values{}
 	if opts != nil {
 		if opts.ChatId != 0 {
@@ -3254,18 +3302,26 @@ func (bot *Bot) StopMessageLiveLocation(opts *StopMessageLiveLocationOpts) (*Mes
 		v.Add("inline_message_id", opts.InlineMessageId)
 		bs, err := json.Marshal(opts.ReplyMarkup)
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
+			return nil, false, fmt.Errorf("failed to marshal field reply_markup: %w", err)
 		}
 		v.Add("reply_markup", string(bs))
 	}
 
 	r, err := bot.Get("stopMessageLiveLocation", v)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	var m Message
-	return &m, json.Unmarshal(r, &m)
+	if err := json.Unmarshal(r, &m); err != nil {
+		var b bool
+		if err := json.Unmarshal(r, &b); err != nil {
+			return nil, false, err
+		}
+		return nil, b, nil
+	}
+	return &m, true, nil
+
 }
 
 // StopPollOpts is the set of optional fields for Bot.StopPoll.

--- a/samples/echoBot/main.go
+++ b/samples/echoBot/main.go
@@ -137,13 +137,13 @@ func startCB(b *gotgbot.Bot, ctx *ext.Context) error {
 	cb := ctx.Update.CallbackQuery
 
 	_, err := cb.Answer(b, &gotgbot.AnswerCallbackQueryOpts{
-		Text:      "You pressed a button!",
+		Text: "You pressed a button!",
 	})
 	if err != nil {
 		return fmt.Errorf("failed to answer start callback query: %w", err)
 	}
 
-	_, err = cb.Message.EditText(b, "You edited the start message.", nil)
+	_, _, err = cb.Message.EditText(b, "You edited the start message.", nil)
 	if err != nil {
 		return fmt.Errorf("failed to edit start message text: %w", err)
 	}

--- a/scripts/generate/common.go
+++ b/scripts/generate/common.go
@@ -73,12 +73,16 @@ func isTgArray(s string) bool {
 	return strings.HasPrefix(s, "Array of ")
 }
 
+func isPointer(s string) bool {
+	return strings.HasPrefix(s, "*")
+}
+
 func isArray(s string) bool {
 	return strings.HasPrefix(s, "[]")
 }
 
-func getDefaultReturnVal(d APIDescription, s string) string {
-	if strings.HasPrefix(s, "*") || strings.HasPrefix(s, "[]") {
+func getDefaultTypeVal(d APIDescription, s string) string {
+	if isPointer(s) || isArray(s) {
 		return "nil"
 	}
 
@@ -99,6 +103,14 @@ func getDefaultReturnVal(d APIDescription, s string) string {
 		// this isnt great
 		return s
 	}
+}
+
+func getDefaultReturnVals(d APIDescription, types []string) []string {
+	var retVals []string
+	for _, retType := range types {
+		retVals = append(retVals, getDefaultTypeVal(d, retType))
+	}
+	return retVals
 }
 
 func goTypeStringer(t string) string {

--- a/scripts/generate/gen.go
+++ b/scripts/generate/gen.go
@@ -293,23 +293,23 @@ func (f Field) getPreferredType() (string, error) {
 	return "", fmt.Errorf("unable to choose one of %v for field %s", f.Types, f.Name)
 }
 
-func (m MethodDescription) GetReturnType(d APIDescription) (string, error) {
-	var prefRetVal string
-
-	if len(m.Returns) == 1 {
-		prefRetVal = m.Returns[0]
-	} else if len(m.Returns) == 2 && m.Returns[0] == tgTypeMessage && m.Returns[1] == tgTypeBoolean {
-		prefRetVal = m.Returns[0]
-	} else {
-		return "", fmt.Errorf("failed to determine return type for method %s", m.Name)
+func (m MethodDescription) GetReturnTypes(d APIDescription) ([]string, error) {
+	// We currently only support dual returns for msg+bool
+	if len(m.Returns) >= 2 && !(len(m.Returns) == 2 && m.Returns[0] == tgTypeMessage && m.Returns[1] == tgTypeBoolean) {
+		return nil, fmt.Errorf("no support for multiple returns for types %s", m.Name)
 	}
 
-	retType := toGoType(prefRetVal)
-	if isTgType(d, retType) && len(d.Types[prefRetVal].Subtypes) == 0 {
-		retType = "*" + retType
+	var retTypes []string
+	for _, prefRetVal := range m.Returns {
+		goRetType := toGoType(prefRetVal)
+		if isTgType(d, goRetType) && len(d.Types[prefRetVal].Subtypes) == 0 {
+			goRetType = "*" + goRetType
+		}
+
+		retTypes = append(retTypes, goRetType)
 	}
 
-	return retType, nil
+	return retTypes, nil
 }
 
 func (m MethodDescription) optsName() string {

--- a/scripts/generate/helpers.go
+++ b/scripts/generate/helpers.go
@@ -68,7 +68,7 @@ func generateHelperDef(d APIDescription, tgMethod MethodDescription) (string, er
 
 		newMethodName = strings.Title(newMethodName)
 
-		ret, err := tgMethod.GetReturnType(d)
+		ret, err := tgMethod.GetReturnTypes(d)
 		if err != nil {
 			return "", fmt.Errorf("failed to get return type for %s: %w", tgMethod.Name, err)
 		}
@@ -89,7 +89,7 @@ func generateHelperDef(d APIDescription, tgMethod MethodDescription) (string, er
 			Receiver:     receiverName,
 			TypeName:     typeName,
 			HelperName:   newMethodName,
-			ReturnType:   ret,
+			ReturnType:   strings.Join(ret, ", "),
 			FuncDefArgs:  funcDefArgs,
 			Contents:     optsContent,
 			OptsName:     tgMethod.optsName(),
@@ -120,7 +120,7 @@ func generateHelperArguments(d APIDescription, tgMethod MethodDescription, recei
 
 		if fName, ok := fields[mf.Name]; ok {
 			if !mf.Required {
-				def := getDefaultReturnVal(d, prefType)
+				def := getDefaultTypeVal(d, prefType)
 				optsContent.WriteString("\n	if opts." + snakeToTitle(mf.Name) + " == " + def + " {")
 				optsContent.WriteString("\n		opts." + snakeToTitle(mf.Name) + " = " + receiverName + "." + snakeToTitle(fName))
 				optsContent.WriteString("\n	}")


### PR DESCRIPTION
# What

Support dual returns for methods such as `editMessageText`, which can return either the edited `Message`, or `bool`. 

Previously, this just returned Message, but this throws an error when the bool fails to unmarshal.
Instead, we now return both (and populate the boolean as true if the `msg != nil`). 

Example error: https://t.me/GotgbotChat/6877

# Impact

- Are your changes backwards compatible? No - this changes some function definitions. These are all compile-time errors, and simple to fix.
- Have you included documentation, or updated existing documentation? Yes.
- Do errors and log messages provide enough context? N/A
