### PR TITLE
Fix nil struct calls in `ForwardFromUserID` and `ForwardFromChatID` filters

### DIFF
--- a/ext/handlers/filters/message/message.go
+++ b/ext/handlers/filters/message/message.go
@@ -38,13 +38,13 @@ func ChatID(id int64) filters.Message {
 
 func ForwardFromUserID(id int64) filters.Message {
 	return func(m *gotgbot.Message) bool {
-		return m.ForwardFrom.Id == id
+		return m.ForwardFrom != nil && m.ForwardFrom.Id == id
 	}
 }
 
 func ForwardFromChatID(id int64) filters.Message {
 	return func(m *gotgbot.Message) bool {
-		return m.ForwardFromChat.Id == id
+		return m.ForwardFromChat != nil && m.ForwardFromChat.Id == id
 	}
 }
 


### PR DESCRIPTION
<!--
Hey, thank you for opening a PR!

Please fill out the details below; they're there to help both you and the maintainers!
-->

# What 

Add a check to ensure that the structs `User` and `Chat` of `m.ForwardFrom` and `m.ForwardFromChat` respectively are not nil to avoid nil dereference error if the forward privacy of a user is turned on, or a similar case in chats.
