### PR TITLE
Fix updater.stop() panic

### DIFF
--- a/ext/updater.go
+++ b/ext/updater.go
@@ -124,7 +124,7 @@ func (u *Updater) pollingLoop(b *gotgbot.Bot, opts *gotgbot.RequestOpts, dropPen
 	var offset int64
 
 	u.running = make(chan bool)
-	for true {
+	for {
 		select {
 		case <-u.running:
 			// if anything comes in, stop.
@@ -183,7 +183,7 @@ func (u *Updater) pollingLoop(b *gotgbot.Bot, opts *gotgbot.RequestOpts, dropPen
 func (u *Updater) Idle() {
 	u.stopIdling = make(chan bool)
 
-	for true {
+	for {
 		select {
 		case <-u.stopIdling:
 			return

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -204,8 +204,11 @@ func (u *Updater) Stop() error {
 		}
 	}
 
-	// stop the polling loop
-	u.running <- false
+	if u.running != nil {
+		// stop the polling loop
+		u.running <- false
+		close(u.running)
+	}
 
 	close(u.UpdateChan)
 
@@ -214,6 +217,7 @@ func (u *Updater) Stop() error {
 	if u.stopIdling != nil {
 		// stop idling
 		u.stopIdling <- false
+		close(u.stopIdling)
 	}
 	return nil
 }


### PR DESCRIPTION

# What

Fix a reported issue where a concurrency issue causes writes to the closed `UpdateChan` in the `Updater`.  The fix to this is to use channels to communicate that this should not be done.

# Impact

- Are your changes backwards compatible? yes
- Have you included documentation, or updated existing documentation? yes
- Do errors and log messages provide enough context? N/A
