### PR TITLE
Add support for using the tg test environment

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -26,6 +26,10 @@ type BotOpts struct {
 	// token can be assumed to be valid (eg lambdas).
 	// Warning: Disabling the token check will mean that the Bot.User struct will no longer be populated.
 	DisableTokenCheck bool
+	// UseTestEnvironment defines whether this bot was created to run on telegram's test environment.
+	// Enabling this uses a slightly different API path.
+	// See https://core.telegram.org/bots/webapps#using-bots-in-the-test-environment for more details.
+	UseTestEnvironment bool
 	// Request opts to use for checking token validity with Bot.GetMe. Can be slow - a high timeout (eg 10s) is
 	// recommended.
 	RequestOpts *RequestOpts
@@ -50,6 +54,7 @@ func NewBot(token string, opts *BotOpts) (*Bot, error) {
 	checkTokenValidity := true
 	if opts != nil {
 		botClient.Client = opts.Client
+		botClient.UseTestEnvironment = opts.UseTestEnvironment
 		if opts.DefaultRequestOpts != nil {
 			botClient.DefaultRequestOpts = opts.DefaultRequestOpts
 		}

--- a/request.go
+++ b/request.go
@@ -35,6 +35,10 @@ type BaseBotClient struct {
 	Token string
 	// Client is the HTTP Client used for all HTTP requests made for this bot.
 	Client http.Client
+	// UseTestEnvironment defines whether this bot was created to run on telegram's test environment.
+	// Enabling this uses a slightly different API path.
+	// See https://core.telegram.org/bots/webapps#using-bots-in-the-test-environment for more details.
+	UseTestEnvironment bool
 	// The default request opts for this bot instance.
 	DefaultRequestOpts *RequestOpts
 }
@@ -247,5 +251,8 @@ func (bot *BaseBotClient) getAPIURL(opts *RequestOpts) string {
 }
 
 func (bot *BaseBotClient) methodEnpoint(method string, opts *RequestOpts) string {
+	if bot.UseTestEnvironment {
+		return fmt.Sprintf("%s/bot%s/test/%s", bot.getAPIURL(opts), bot.Token, method)
+	}
 	return fmt.Sprintf("%s/bot%s/%s", bot.getAPIURL(opts), bot.Token, method)
 }


### PR DESCRIPTION

# What

Add support for using the tg test environment, as defined in https://core.telegram.org/bots/webapps#using-bots-in-the-test-environment

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? N/A
