### PR TITLE
Fix switchinlinequery option (again)

### DIFF
--- a/gen_types.go
+++ b/gen_types.go
@@ -1235,9 +1235,9 @@ type InlineKeyboardButton struct {
 	// Optional. An HTTPS URL used to automatically authorize the user. Can be used as a replacement for the Telegram Login Widget.
 	LoginUrl *LoginUrl `json:"login_url,omitempty"`
 	// Optional. If set, pressing the button will prompt the user to select one of their chats, open that chat and insert the bot's username and the specified inline query in the input field. May be empty, in which case just the bot's username will be inserted. Note: This offers an easy way for users to start using your bot in inline mode when they are currently in a private chat with it. Especially useful when combined with switch_pm... actions - in this case the user will be automatically returned to the chat they switched from, skipping the chat selection screen.
-	SwitchInlineQuery string `json:"switch_inline_query,omitempty"`
+	SwitchInlineQuery *string `json:"switch_inline_query,omitempty"`
 	// Optional. If set, pressing the button will insert the bot's username and the specified inline query in the current chat's input field. May be empty, in which case only the bot's username will be inserted. This offers a quick way for the user to open your bot in inline mode in the same chat - good for selecting something from multiple options.
-	SwitchInlineQueryCurrentChat string `json:"switch_inline_query_current_chat,omitempty"`
+	SwitchInlineQueryCurrentChat *string `json:"switch_inline_query_current_chat,omitempty"`
 	// Optional. Description of the game that will be launched when the user presses the button. NOTE: This type of button must always be the first button in the first row.
 	CallbackGame *CallbackGame `json:"callback_game,omitempty"`
 	// Optional. Specify True, to send a Pay button. NOTE: This type of button must always be the first button in the first row and can only be used in invoice messages.

--- a/gen_types_test.go
+++ b/gen_types_test.go
@@ -1,0 +1,24 @@
+package gotgbot
+
+import (
+	"testing"
+)
+
+func TestInlineQueriesHavePointers(t *testing.T) {
+	// This test is somewhat ridiculous, in that it actually only tests compilation.
+	// But it broke once, and I won't have it break again.
+
+	// Future readers, this is required because inline keyboard buttons can be passed many different things.
+	// One of those things, is an empty string "switch inline query" field. Go's type system sees this as an empty
+	// value, so doesn't include it in the JSON marshalling, since it has an omitempty tag. We therefore use a pointer
+	// here to differentiate between empty field (nil), and empty value ("").
+	// Reported as a bug here: https://t.me/GotgbotChat/4537
+	// Fixed here: https://github.com/PaulSonOfLars/gotgbot/pull/31, and again here https://github.com/PaulSonOfLars/gotgbot/pull/63
+
+	stringValue := "Foo"
+	_ = InlineKeyboardButton{
+		Text:                         "Barr",
+		SwitchInlineQuery:            nil,          // ilq can be nil
+		SwitchInlineQueryCurrentChat: &stringValue, // or can be a pointer
+	}
+}

--- a/scripts/generate/gen.go
+++ b/scripts/generate/gen.go
@@ -273,14 +273,16 @@ func (f Field) getPreferredType() (string, error) {
 		return tgTypeReplyMarkup, nil
 	}
 
-	// Some fields are marked as "can be empty", in which case we do want to pass the empty values.
-	// These should be handled as pointers, so we can differentiate the empty case.
-	if strings.Contains(f.Description, "Can be empty") {
-		return "*" + toGoType(f.Types[0]), nil
-	}
-
 	if len(f.Types) == 1 {
-		return toGoType(f.Types[0]), nil
+		goType := toGoType(f.Types[0])
+
+		// Some fields are marked as "May be empty", in which case the empty values are still meaningful.
+		// These should be handled as pointers, so we can differentiate the empty case.
+		if strings.Contains(f.Description, "May be empty") && !(isPointer(goType) || isArray(goType)) {
+			return "*" + goType, nil
+		}
+
+		return goType, nil
 	}
 
 	if len(f.Types) == 2 {


### PR DESCRIPTION
# What

This PR re-applies the fix to inlinequeries made in #31, which broke in the update to bot API 6.1.
Frustrating, but easy enough to handle. 

# Impact

- Are your changes backwards compatible? No, but yes - it undoes a previously invalid breaking change.
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
