### PR TITLE
Replace error loggers in updater+dispatcher with error funcs, for improved flexibility

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,16 +29,13 @@ output:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
     - asciicheck
     - bodyclose
     - bodyclose

--- a/ext/dispatcher.go
+++ b/ext/dispatcher.go
@@ -58,7 +58,7 @@ type Dispatcher struct {
 	// If this field is nil, the error will be passed to UnhandledErrFunc.
 	Panic DispatcherPanicHandler
 
-	// UnhandledErrFunc provides more flexibility for handling unhandled internal dispatcher errors.
+	// UnhandledErrFunc provides more flexibility for dealing with internal unhandled dispatcher errors.
 	// By design, these errors are mostly considered benign, and don't necessarily need to be handled.
 	// If nil, the error goes to ErrorLog.
 	UnhandledErrFunc ErrorFunc
@@ -88,10 +88,13 @@ type DispatcherOpts struct {
 	// If no panic handlers are defined, the stack is logged to ErrorLog.
 	// More info at Dispatcher.Panic.
 	Panic DispatcherPanicHandler
-	// UnhandledErrFunc defines the default handling of any unhandled errors from the dispatcher.
-	// Most commonly used for logging.
-	// More info at Dispatcher.UnhandledErrFunc.
+	// UnhandledErrFunc provides more flexibility for dealing with internal unhandled dispatcher errors.
+	// By design, these errors are mostly considered benign, and don't necessarily need to be handled.
+	// If nil, the error goes to ErrorLog.
 	UnhandledErrFunc ErrorFunc
+	// ErrorLog specifies an optional logger for unexpected behavior from handlers.
+	// If nil, logging is done via the log package's standard logger.
+	ErrorLog *log.Logger
 
 	// MaxRoutines is used to decide how to limit the number of goroutines spawned by the dispatcher.
 	// This defines how many updates can be processed at the same time.

--- a/ext/dispatcher.go
+++ b/ext/dispatcher.go
@@ -12,6 +12,9 @@ import (
 	"github.com/PaulSonOfLars/gotgbot/v2"
 )
 
+var ErrPanicRecovered = errors.New("panic recovered")
+var ErrUnknownDispatcherAction = errors.New("unknown dispatcher action")
+
 const DefaultMaxRoutines = 50
 
 type (
@@ -219,7 +222,7 @@ func (d *Dispatcher) ProcessUpdate(b *gotgbot.Bot, update *gotgbot.Update, data 
 				return
 
 			} else if d.UnhandledErrFunc != nil {
-				d.UnhandledErrFunc(fmt.Errorf("panic recovered while processing updates: %v\n%s", r, cleanedStack()))
+				d.UnhandledErrFunc(fmt.Errorf("%w: %v\n%s", ErrPanicRecovered, r, cleanedStack()))
 				return
 
 			} else {
@@ -262,7 +265,7 @@ func (d *Dispatcher) ProcessUpdate(b *gotgbot.Bot, update *gotgbot.Update, data 
 						// Stop all group handling.
 						return nil
 					default:
-						return fmt.Errorf("unknown action '%s', ending groups here", action)
+						return fmt.Errorf("%w: '%s', ending groups here", err, action)
 					}
 				}
 			}

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/PaulSonOfLars/gotgbot/v2"
@@ -261,47 +260,4 @@ func (u *Updater) StartWebhook(b *gotgbot.Bot, opts WebhookOpts) error {
 	}()
 
 	return nil
-}
-
-// WebhookOpts represent various fields that are needed for configuring the local webhook server.
-type WebhookOpts struct {
-	// Listen is the address to listen on (eg: localhost, 0.0.0.0, etc).
-	Listen string
-	// Port is the port listen on (eg 443, 8443, etc).
-	Port int
-	// URLPath defines the path to listen at; eg <domainname>/<URLPath>.
-	// Using the bot token here is often a good idea, as it is a secret known only by telegram.
-	URLPath string
-	// ReadTimeout is passed to the http server to limit the time it takes to read an incoming request.
-	// See http.Server for more details.
-	ReadTimeout time.Duration
-	// ReadHeaderTimeout is passed to the http server to limit the time it takes to read the headers of an incoming
-	// request.
-	// See http.Server for more details.
-	ReadHeaderTimeout time.Duration
-
-	// HTTPS cert and key files for custom signed certificates
-	CertFile string
-	KeyFile  string
-
-	// The secret token used in the Bot.SetWebhook call, which can be used to ensure that the request comes from a
-	// webhook set by you.
-	SecretToken string
-}
-
-// GetListenAddr returns the local listening address, including port.
-func (w *WebhookOpts) GetListenAddr() string {
-	if w.Listen == "" {
-		w.Listen = "0.0.0.0"
-	}
-	if w.Port == 0 {
-		w.Port = 443
-	}
-	return fmt.Sprintf("%s:%d", w.Listen, w.Port)
-}
-
-// GetWebhookURL returns the domain in the form domain/path.
-// eg: example.com/super_secret_token
-func (w *WebhookOpts) GetWebhookURL(domain string) string {
-	return fmt.Sprintf("%s/%s", strings.TrimSuffix(domain, "/"), w.URLPath)
 }

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -15,10 +15,12 @@ import (
 	"github.com/PaulSonOfLars/gotgbot/v2"
 )
 
-var ErrMissingCertOrKeyFile = errors.New("missing certfile or keyfile")
-var ErrExpectedEmptyServer = errors.New("expected server to be nil")
+var (
+	ErrMissingCertOrKeyFile = errors.New("missing certfile or keyfile")
+	ErrExpectedEmptyServer  = errors.New("expected server to be nil")
+)
 
-// botData is an internal struct that is used by the updater to keep track of the necessary update channels for each bot.
+// botData is an internal struct used by the updater to keep track of the necessary update channels for each bot.
 type botData struct {
 	bot        *gotgbot.Bot
 	updateChan chan json.RawMessage
@@ -39,12 +41,16 @@ type Updater struct {
 	// If nil, logging is done via the log package's standard logger.
 	ErrorLog *log.Logger
 
+	// stopIdling is the channel that blocks the main thread from exiting, to keep the bots running.
 	stopIdling chan bool
-	running    chan bool
-	server     *http.Server
-	// map tokens to channels
+	// polling is the channel which indicates that the updater is currently polling for updates.
+	polling chan bool
+	// serveMux is where all our webhook paths are added for the server to use.
+	serveMux *http.ServeMux
+	// webhookServer is the server in charge of receiving all incoming webhook updates.
+	webhookServer *http.Server
+	// botMapping keeps track of the data required for each bot.
 	botMapping map[string]botData
-	serveMux   *http.ServeMux
 }
 
 // UpdaterOpts defines various fields that can be changed to configure a new Updater.
@@ -167,10 +173,10 @@ func (u *Updater) pollingLoop(b *gotgbot.Bot, opts *gotgbot.RequestOpts, updateC
 
 	var offset int64
 
-	u.running = make(chan bool)
+	u.polling = make(chan bool)
 	for {
 		select {
-		case <-u.running:
+		case <-u.polling:
 			// if anything comes in, stop.
 			return
 		default:
@@ -246,18 +252,18 @@ func (u *Updater) Idle() {
 
 // Stop stops the current updater and dispatcher instances.
 func (u *Updater) Stop() error {
-	// if server, this is running on webhooks; shutdown the server
-	if u.server != nil {
-		err := u.server.Shutdown(context.Background())
+	// Stop any running servers.
+	if u.webhookServer != nil {
+		err := u.webhookServer.Shutdown(context.Background())
 		if err != nil {
 			return fmt.Errorf("failed to shutdown server: %w", err)
 		}
 	}
 
-	if u.running != nil {
-		// stop the polling loop
-		u.running <- false
-		close(u.running)
+	// Stop any running polling loops.
+	if u.polling != nil {
+		u.polling <- false
+		close(u.polling)
 	}
 
 	// Close all the update channels
@@ -265,10 +271,11 @@ func (u *Updater) Stop() error {
 		close(data.updateChan)
 	}
 
+	// Stop the dispatcher.
 	u.Dispatcher.Stop()
 
+	// Finally, atop idling.
 	if u.stopIdling != nil {
-		// stop idling
 		u.stopIdling <- false
 		close(u.stopIdling)
 	}
@@ -279,7 +286,7 @@ func (u *Updater) Stop() error {
 // This does NOT set the webhook on telegram - this should be done by the caller.
 // The opts parameter allows for specifying various webhook settings.
 func (u *Updater) StartWebhook(b *gotgbot.Bot, urlPath string, opts WebhookOpts) error {
-	if u.server != nil {
+	if u.webhookServer != nil {
 		return ErrExpectedEmptyServer
 	}
 
@@ -347,7 +354,7 @@ func (u *Updater) StartServer(opts WebhookOpts) error {
 		return ErrMissingCertOrKeyFile
 	}
 
-	u.server = &http.Server{
+	u.webhookServer = &http.Server{
 		Addr:              opts.GetListenAddr(),
 		Handler:           u.serveMux,
 		ReadTimeout:       opts.ReadTimeout,
@@ -357,9 +364,9 @@ func (u *Updater) StartServer(opts WebhookOpts) error {
 	go func() {
 		var err error
 		if tls {
-			err = u.server.ListenAndServeTLS(opts.CertFile, opts.KeyFile)
+			err = u.webhookServer.ListenAndServeTLS(opts.CertFile, opts.KeyFile)
 		} else {
-			err = u.server.ListenAndServe()
+			err = u.webhookServer.ListenAndServe()
 		}
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			panic("http server failed: " + err.Error())

--- a/ext/webhook.go
+++ b/ext/webhook.go
@@ -1,0 +1,50 @@
+package ext
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// WebhookOpts represent various fields that are needed for configuring the local webhook server.
+type WebhookOpts struct {
+	// Listen is the address to listen on (eg: localhost, 0.0.0.0, etc).
+	Listen string
+	// Port is the port listen on (eg 443, 8443, etc).
+	Port int
+	// URLPath defines the path to listen at; eg <domainname>/<URLPath>.
+	// Using the bot token here is often a good idea, as it is a secret known only by telegram.
+	URLPath string
+	// ReadTimeout is passed to the http server to limit the time it takes to read an incoming request.
+	// See http.Server for more details.
+	ReadTimeout time.Duration
+	// ReadHeaderTimeout is passed to the http server to limit the time it takes to read the headers of an incoming
+	// request.
+	// See http.Server for more details.
+	ReadHeaderTimeout time.Duration
+
+	// HTTPS cert and key files for custom signed certificates
+	CertFile string
+	KeyFile  string
+
+	// The secret token used in the Bot.SetWebhook call, which can be used to ensure that the request comes from a
+	// webhook set by you.
+	SecretToken string
+}
+
+// GetListenAddr returns the local listening address, including port.
+func (w *WebhookOpts) GetListenAddr() string {
+	if w.Listen == "" {
+		w.Listen = "0.0.0.0"
+	}
+	if w.Port == 0 {
+		w.Port = 443
+	}
+	return fmt.Sprintf("%s:%d", w.Listen, w.Port)
+}
+
+// GetWebhookURL returns the domain in the form domain/path.
+// eg: example.com/super_secret_token
+func (w *WebhookOpts) GetWebhookURL(domain string) string {
+	return fmt.Sprintf("%s/%s", strings.TrimSuffix(domain, "/"), w.URLPath)
+}

--- a/samples/callbackqueryBot/main.go
+++ b/samples/callbackqueryBot/main.go
@@ -36,7 +36,6 @@ func main() {
 
 	// Create updater and dispatcher.
 	updater := ext.NewUpdater(&ext.UpdaterOpts{
-		ErrorFunc: nil,
 		DispatcherOpts: ext.DispatcherOpts{
 			// If an error is returned by a handler, log it and continue going.
 			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {

--- a/samples/callbackqueryBot/main.go
+++ b/samples/callbackqueryBot/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	// Create updater and dispatcher.
 	updater := ext.NewUpdater(&ext.UpdaterOpts{
-		ErrorLog: nil,
+		ErrorFunc: nil,
 		DispatcherOpts: ext.DispatcherOpts{
 			// If an error is returned by a handler, log it and continue going.
 			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {

--- a/samples/commandBot/main.go
+++ b/samples/commandBot/main.go
@@ -36,7 +36,6 @@ func main() {
 
 	// Create updater and dispatcher.
 	updater := ext.NewUpdater(&ext.UpdaterOpts{
-		ErrorFunc: nil,
 		DispatcherOpts: ext.DispatcherOpts{
 			// If an error is returned by a handler, log it and continue going.
 			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {

--- a/samples/commandBot/main.go
+++ b/samples/commandBot/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	// Create updater and dispatcher.
 	updater := ext.NewUpdater(&ext.UpdaterOpts{
-		ErrorLog: nil,
+		ErrorFunc: nil,
 		DispatcherOpts: ext.DispatcherOpts{
 			// If an error is returned by a handler, log it and continue going.
 			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {

--- a/samples/conversationBot/main.go
+++ b/samples/conversationBot/main.go
@@ -40,7 +40,6 @@ func main() {
 
 	// Create updater and dispatcher.
 	updater := ext.NewUpdater(&ext.UpdaterOpts{
-		ErrorFunc: nil,
 		DispatcherOpts: ext.DispatcherOpts{
 			// If an error is returned by a handler, log it and continue going.
 			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {

--- a/samples/conversationBot/main.go
+++ b/samples/conversationBot/main.go
@@ -40,7 +40,7 @@ func main() {
 
 	// Create updater and dispatcher.
 	updater := ext.NewUpdater(&ext.UpdaterOpts{
-		ErrorLog: nil,
+		ErrorFunc: nil,
 		DispatcherOpts: ext.DispatcherOpts{
 			// If an error is returned by a handler, log it and continue going.
 			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {

--- a/samples/echoBot/main.go
+++ b/samples/echoBot/main.go
@@ -35,7 +35,7 @@ func main() {
 
 	// Create updater and dispatcher.
 	updater := ext.NewUpdater(&ext.UpdaterOpts{
-		ErrorLog: nil,
+		ErrorFunc: nil,
 		DispatcherOpts: ext.DispatcherOpts{
 			// If an error is returned by a handler, log it and continue going.
 			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {

--- a/samples/echoBot/main.go
+++ b/samples/echoBot/main.go
@@ -35,7 +35,6 @@ func main() {
 
 	// Create updater and dispatcher.
 	updater := ext.NewUpdater(&ext.UpdaterOpts{
-		ErrorFunc: nil,
 		DispatcherOpts: ext.DispatcherOpts{
 			// If an error is returned by a handler, log it and continue going.
 			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {

--- a/samples/echoWebhookBot/main.go
+++ b/samples/echoWebhookBot/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 
@@ -52,7 +53,6 @@ func main() {
 
 	// Create updater and dispatcher.
 	updater := ext.NewUpdater(&ext.UpdaterOpts{
-		ErrorFunc: nil,
 		DispatcherOpts: ext.DispatcherOpts{
 			// If an error is returned by a handler, log it and continue going.
 			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {

--- a/samples/echoWebhookBot/main.go
+++ b/samples/echoWebhookBot/main.go
@@ -52,7 +52,7 @@ func main() {
 
 	// Create updater and dispatcher.
 	updater := ext.NewUpdater(&ext.UpdaterOpts{
-		ErrorLog: nil,
+		ErrorFunc: nil,
 		DispatcherOpts: ext.DispatcherOpts{
 			// If an error is returned by a handler, log it and continue going.
 			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {

--- a/samples/middlewareBot/main.go
+++ b/samples/middlewareBot/main.go
@@ -38,7 +38,6 @@ func main() {
 
 	// Create updater and dispatcher.
 	updater := ext.NewUpdater(&ext.UpdaterOpts{
-		ErrorLog: nil,
 		DispatcherOpts: ext.DispatcherOpts{
 			// If an error is returned by a handler, log it and continue going.
 			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {

--- a/samples/middlewareBot/main.go
+++ b/samples/middlewareBot/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"time"

--- a/samples/middlewareBot/middleware.go
+++ b/samples/middlewareBot/middleware.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"strings"
 
 	"github.com/PaulSonOfLars/gotgbot/v2"

--- a/samples/webappBot/main.go
+++ b/samples/webappBot/main.go
@@ -46,7 +46,7 @@ func main() {
 
 	// Create updater and dispatcher to handle updates in a simple manner.
 	updater := ext.NewUpdater(&ext.UpdaterOpts{
-		ErrorLog: nil,
+		ErrorFunc: nil,
 		DispatcherOpts: ext.DispatcherOpts{
 			// If an error is returned by a handler, log it and continue going.
 			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {

--- a/samples/webappBot/main.go
+++ b/samples/webappBot/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 
@@ -46,7 +47,6 @@ func main() {
 
 	// Create updater and dispatcher to handle updates in a simple manner.
 	updater := ext.NewUpdater(&ext.UpdaterOpts{
-		ErrorFunc: nil,
 		DispatcherOpts: ext.DispatcherOpts{
 			// If an error is returned by a handler, log it and continue going.
 			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {

--- a/samples/webappBot/routes.go
+++ b/samples/webappBot/routes.go
@@ -27,8 +27,8 @@ func validate(token string) func(writer http.ResponseWriter, request *http.Reque
 	return func(writer http.ResponseWriter, request *http.Request) {
 		ok, err := ext.ValidateWebAppQuery(request.URL.Query(), token)
 		if err != nil {
-			writer.Write([]byte("validation failed; error: " + err.Error()))
 			writer.WriteHeader(http.StatusBadRequest)
+			writer.Write([]byte("validation failed; error: " + err.Error()))
 			return
 		}
 		if ok {


### PR DESCRIPTION
# What

Improve error handling flexibility in the Updater and Dispatcher by providing error funcs instead of simple logs.

This should allow users to panic and close their program if necessary. 

# Impact

- Are your changes backwards compatible? No - some method and struct signatures changed to apply new changes. Overall minor. 
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
