### PR TITLE
MultiUpdater support

### DIFF
--- a/ext/updater.go
+++ b/ext/updater.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -18,54 +18,65 @@ import (
 
 var ErrMissingCertOrKeyFile = errors.New("missing certfile or keyfile")
 
+type botData struct {
+	bot        *gotgbot.Bot
+	updateChan chan json.RawMessage
+	urlPath    string
+}
+
 type Updater struct {
+	// Dispatcher defines how to handle incoming updates.
 	Dispatcher *Dispatcher
-	UpdateChan chan json.RawMessage
-	ErrorLog   *log.Logger
+	// ErrorLog defines how to log errors which occur in the updater.
+	ErrorLog *log.Logger
 
 	stopIdling chan bool
 	running    chan bool
 	server     *http.Server
+	// map tokens to channels
+	botMapping map[string]botData
+	serveMux   *http.ServeMux
 }
 
 var errorLog = log.New(os.Stderr, "ERROR", log.LstdFlags)
 
 type UpdaterOpts struct {
 	ErrorLog *log.Logger
-
-	DispatcherOpts DispatcherOpts
+	// The dispatcher instance to be used by the updater.
+	Dispatcher *Dispatcher
 }
 
 // NewUpdater Creates a new Updater, as well as the necessary structures required for the associated Dispatcher.
 func NewUpdater(opts *UpdaterOpts) Updater {
 	errLog := errorLog
-	var dispatcherOpts DispatcherOpts
+	// Default dispatcher
+	dispatcher := NewDispatcher(nil)
 
 	if opts != nil {
 		if opts.ErrorLog != nil {
 			errLog = opts.ErrorLog
 		}
-
-		dispatcherOpts = opts.DispatcherOpts
+		if opts.Dispatcher != nil {
+			dispatcher = opts.Dispatcher
+		}
 	}
 
-	updateChan := make(chan json.RawMessage)
 	return Updater{
 		ErrorLog:   errLog,
-		Dispatcher: NewDispatcher(updateChan, &dispatcherOpts),
-		UpdateChan: updateChan,
+		Dispatcher: dispatcher,
+		serveMux:   http.NewServeMux(),
 	}
 }
 
 // PollingOpts represents the optional values to start long polling.
 type PollingOpts struct {
-	// DropPendingUpdates decides whether or not to drop "pending" updates; these are updates which were sent before
+	// DropPendingUpdates decides  whether to drop "pending" updates; these are updates which were sent before
 	// the bot was started.
 	DropPendingUpdates bool
 	// GetUpdatesOpts represents the opts passed to GetUpdates.
 	// Note: It is recommended you edit the values here when running in production environments.
 	// Changes might include:
-	//    - Changing the "GetUpdatesOpts.AllowedUpates" to only refer to relevant updates
+	//    - Changing the "GetUpdatesOpts.AllowedUpdates" to only refer to relevant updates
 	//    - Using a non-0 "GetUpdatesOpts.Timeout" value. This is how "long" telegram will hold the long-polling call
 	//    while waiting for new messages. A value of 0 causes telegram to reply immediately, which will then cause
 	//    your bot to immediately ask for more updates. While this can seem fine, it will eventually causing
@@ -109,14 +120,19 @@ func (u *Updater) StartPolling(b *gotgbot.Bot, opts *PollingOpts) error {
 		}
 	}
 
-	go u.Dispatcher.Start(b)
-	go u.pollingLoop(b, reqOpts, dropPendingUpdates, v)
+	updateChan := make(chan json.RawMessage)
+	u.botMapping[b.GetToken()] = botData{
+		bot:        b,
+		updateChan: updateChan,
+	}
+
+	go u.Dispatcher.Start(b, updateChan)
+	go u.pollingLoop(b, reqOpts, updateChan, dropPendingUpdates, v)
 
 	return nil
 }
 
-func (u *Updater) pollingLoop(b *gotgbot.Bot, opts *gotgbot.RequestOpts, dropPendingUpdates bool, v map[string]string) {
-
+func (u *Updater) pollingLoop(b *gotgbot.Bot, opts *gotgbot.RequestOpts, updateChan chan json.RawMessage, dropPendingUpdates bool, v map[string]string) {
 	// if dropPendingUpdates, force the offset to -1
 	if dropPendingUpdates {
 		v["offset"] = "-1"
@@ -175,7 +191,7 @@ func (u *Updater) pollingLoop(b *gotgbot.Bot, opts *gotgbot.RequestOpts, dropPen
 
 		for _, updData := range rawUpdates {
 			temp := updData // use new mem address to avoid loop conflicts
-			u.UpdateChan <- temp
+			updateChan <- temp
 		}
 	}
 }
@@ -205,7 +221,10 @@ func (u *Updater) Stop() error {
 		close(u.running)
 	}
 
-	close(u.UpdateChan)
+	// Close all the update channels
+	for _, data := range u.botMapping {
+		close(data.updateChan)
+	}
 
 	u.Dispatcher.Stop()
 
@@ -217,8 +236,55 @@ func (u *Updater) Stop() error {
 	return nil
 }
 
-// StartWebhook Starts the webhook server. The opts parameter allows for specifying TLS settings.
-func (u *Updater) StartWebhook(b *gotgbot.Bot, opts WebhookOpts) error {
+// StartWebhook starts the webhook server for a single bot instance. The opts parameter allows for specifying various webhook settings.
+func (u *Updater) StartWebhook(b *gotgbot.Bot, urlPath string, opts WebhookOpts) error {
+	if u.server != nil {
+		return fmt.Errorf("expected the server to be nil")
+	}
+
+	u.AddWebhook(b, urlPath, opts)
+	return u.StartServer(opts)
+}
+
+// AddWebhook prepares the webhook server to receive webhook updates on a specific path.
+func (u *Updater) AddWebhook(b *gotgbot.Bot, urlPath string, opts WebhookOpts) {
+	if u.serveMux == nil {
+		u.serveMux = http.NewServeMux()
+	}
+
+	updateChan := make(chan json.RawMessage)
+	u.serveMux.HandleFunc("/"+urlPath, func(w http.ResponseWriter, r *http.Request) {
+		if opts.SecretToken != "" && opts.SecretToken != r.Header.Get("X-Telegram-Bot-Api-Secret-Token") {
+			// Drop any updates from invalid secret tokens.
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		bytes, _ := io.ReadAll(r.Body)
+		updateChan <- bytes
+	})
+
+	u.botMapping[b.GetToken()] = botData{
+		bot:        b,
+		updateChan: updateChan,
+		urlPath:    urlPath,
+	}
+}
+
+// SetWebhooks sets all the webhooks for the bots using this updater.
+func (u *Updater) SetWebhooks(domain string, opts *gotgbot.SetWebhookOpts) error {
+	for _, data := range u.botMapping {
+		_, err := data.bot.SetWebhook(fmt.Sprintf("%s/%s", strings.TrimSuffix(domain, "/"), data.urlPath), opts)
+		if err != nil {
+			// Extract the botID, so we don't intentionally log the token
+			botId := strings.Split(data.bot.GetToken(), ":")[0]
+			return fmt.Errorf("failed to set webhook for %s: %w", botId, err)
+		}
+	}
+	return nil
+}
+
+// StartServer Starts the webhook server for all registered bots. The opts parameter allows for specifying TLS settings.
+func (u *Updater) StartServer(opts WebhookOpts) error {
 	var tls bool
 	if opts.CertFile == "" && opts.KeyFile == "" {
 		tls = false
@@ -228,22 +294,14 @@ func (u *Updater) StartWebhook(b *gotgbot.Bot, opts WebhookOpts) error {
 		return ErrMissingCertOrKeyFile
 	}
 
-	go u.Dispatcher.Start(b)
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/"+opts.URLPath, func(w http.ResponseWriter, r *http.Request) {
-		if opts.SecretToken != "" && opts.SecretToken != r.Header.Get("X-Telegram-Bot-Api-Secret-Token") {
-			// Drop any updates from invalid secret tokens.
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
-		bytes, _ := ioutil.ReadAll(r.Body)
-		u.UpdateChan <- bytes
-	})
+	for _, data := range u.botMapping {
+		// start dispatcher for each bot
+		go u.Dispatcher.Start(data.bot, data.updateChan)
+	}
 
 	u.server = &http.Server{
 		Addr:              opts.GetListenAddr(),
-		Handler:           mux,
+		Handler:           u.serveMux,
 		ReadTimeout:       opts.ReadTimeout,
 		ReadHeaderTimeout: opts.ReadHeaderTimeout,
 	}
@@ -261,47 +319,4 @@ func (u *Updater) StartWebhook(b *gotgbot.Bot, opts WebhookOpts) error {
 	}()
 
 	return nil
-}
-
-// WebhookOpts represent various fields that are needed for configuring the local webhook server.
-type WebhookOpts struct {
-	// Listen is the address to listen on (eg: localhost, 0.0.0.0, etc).
-	Listen string
-	// Port is the port listen on (eg 443, 8443, etc).
-	Port int
-	// URLPath defines the path to listen at; eg <domainname>/<URLPath>.
-	// Using the bot token here is often a good idea, as it is a secret known only by telegram.
-	URLPath string
-	// ReadTimeout is passed to the http server to limit the time it takes to read an incoming request.
-	// See http.Server for more details.
-	ReadTimeout time.Duration
-	// ReadHeaderTimeout is passed to the http server to limit the time it takes to read the headers of an incoming
-	// request.
-	// See http.Server for more details.
-	ReadHeaderTimeout time.Duration
-
-	// HTTPS cert and key files for custom signed certificates
-	CertFile string
-	KeyFile  string
-
-	// The secret token used in the Bot.SetWebhook call, which can be used to ensure that the request comes from a
-	// webhook set by you.
-	SecretToken string
-}
-
-// GetListenAddr returns the local listening address, including port.
-func (w *WebhookOpts) GetListenAddr() string {
-	if w.Listen == "" {
-		w.Listen = "0.0.0.0"
-	}
-	if w.Port == 0 {
-		w.Port = 443
-	}
-	return fmt.Sprintf("%s:%d", w.Listen, w.Port)
-}
-
-// GetWebhookURL returns the domain in the form domain/path.
-// eg: example.com/super_secret_token
-func (w *WebhookOpts) GetWebhookURL(domain string) string {
-	return fmt.Sprintf("%s/%s", strings.TrimSuffix(domain, "/"), w.URLPath)
 }

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -17,6 +17,7 @@ import (
 )
 
 var ErrMissingCertOrKeyFile = errors.New("missing certfile or keyfile")
+var ErrExpectedEmptyServer = errors.New("expected server to be nil")
 
 type botData struct {
 	bot        *gotgbot.Bot
@@ -239,7 +240,7 @@ func (u *Updater) Stop() error {
 // StartWebhook starts the webhook server for a single bot instance. The opts parameter allows for specifying various webhook settings.
 func (u *Updater) StartWebhook(b *gotgbot.Bot, urlPath string, opts WebhookOpts) error {
 	if u.server != nil {
-		return fmt.Errorf("expected the server to be nil")
+		return ErrExpectedEmptyServer
 	}
 
 	u.AddWebhook(b, urlPath, opts)

--- a/ext/webhook.go
+++ b/ext/webhook.go
@@ -1,0 +1,39 @@
+package ext
+
+import (
+	"fmt"
+	"time"
+)
+
+// WebhookOpts represent various fields that are needed for configuring the local webhook server.
+type WebhookOpts struct {
+	// Listen is the address to listen on (eg: localhost, 0.0.0.0, etc).
+	Listen string
+	// Port is the port listen on (eg 443, 8443, etc).
+	Port int
+	// ReadTimeout is passed to the http server to limit the time it takes to read an incoming request.
+	// See http.Server for more details.
+	ReadTimeout time.Duration
+	// ReadHeaderTimeout is passed to the http server to limit the time it takes to read the headers of an incoming
+	// request.
+	// See http.Server for more details.
+	ReadHeaderTimeout time.Duration
+
+	// HTTPS cert and key files for custom signed certificates
+	CertFile string
+	KeyFile  string
+
+	// SecretToken to be used by the bots on this webhook
+	SecretToken string
+}
+
+// GetListenAddr returns the local listening address, including port.
+func (w *WebhookOpts) GetListenAddr() string {
+	if w.Listen == "" {
+		w.Listen = "0.0.0.0"
+	}
+	if w.Port == 0 {
+		w.Port = 443
+	}
+	return fmt.Sprintf("%s:%d", w.Listen, w.Port)
+}

--- a/samples/README.md
+++ b/samples/README.md
@@ -25,6 +25,12 @@ In this case, the bot has commands to start a conversation, which then causes it
 
 This bot is as basic as it gets - it simply repeats everything you say.
 
+## samples/echoMultiBot
+
+This bot demonstrates how to create echo bot that works with multiple bot instances at once.
+It also shows how to stop the bot gracefully using the Updater.Stop() mechanism.
+It has options to use either polling or webhooks.
+
 ## samples/echoWebhookBot
 
 This bot repeats everything you say - but it uses webhooks instead of long polling.

--- a/samples/callbackqueryBot/main.go
+++ b/samples/callbackqueryBot/main.go
@@ -37,14 +37,14 @@ func main() {
 	// Create updater and dispatcher.
 	updater := ext.NewUpdater(&ext.UpdaterOpts{
 		ErrorLog: nil,
-		DispatcherOpts: ext.DispatcherOpts{
+		Dispatcher: ext.NewDispatcher(&ext.DispatcherOpts{
 			// If an error is returned by a handler, log it and continue going.
 			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {
 				log.Println("an error occurred while handling update:", err.Error())
 				return ext.DispatcherActionNoop
 			},
 			MaxRoutines: ext.DefaultMaxRoutines,
-		},
+		}),
 	})
 	dispatcher := updater.Dispatcher
 

--- a/samples/commandBot/main.go
+++ b/samples/commandBot/main.go
@@ -37,14 +37,14 @@ func main() {
 	// Create updater and dispatcher.
 	updater := ext.NewUpdater(&ext.UpdaterOpts{
 		ErrorLog: nil,
-		DispatcherOpts: ext.DispatcherOpts{
+		Dispatcher: ext.NewDispatcher(&ext.DispatcherOpts{
 			// If an error is returned by a handler, log it and continue going.
 			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {
 				log.Println("an error occurred while handling update:", err.Error())
 				return ext.DispatcherActionNoop
 			},
 			MaxRoutines: ext.DefaultMaxRoutines,
-		},
+		}),
 	})
 	dispatcher := updater.Dispatcher
 

--- a/samples/echoBot/main.go
+++ b/samples/echoBot/main.go
@@ -36,14 +36,14 @@ func main() {
 	// Create updater and dispatcher.
 	updater := ext.NewUpdater(&ext.UpdaterOpts{
 		ErrorLog: nil,
-		DispatcherOpts: ext.DispatcherOpts{
+		Dispatcher: ext.NewDispatcher(&ext.DispatcherOpts{
 			// If an error is returned by a handler, log it and continue going.
 			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {
 				log.Println("an error occurred while handling update:", err.Error())
 				return ext.DispatcherActionNoop
 			},
 			MaxRoutines: ext.DefaultMaxRoutines,
-		},
+		}),
 	})
 	dispatcher := updater.Dispatcher
 

--- a/samples/echoMultiBot/go.mod
+++ b/samples/echoMultiBot/go.mod
@@ -1,0 +1,7 @@
+module github.com/PaulSonOfLars/gotgbot/samples/echoBot
+
+go 1.15
+
+require github.com/PaulSonOfLars/gotgbot/v2 v2.0.0-rc.8
+
+replace github.com/PaulSonOfLars/gotgbot/v2 => ../../

--- a/samples/echoMultiBot/go.mod
+++ b/samples/echoMultiBot/go.mod
@@ -1,4 +1,4 @@
-module github.com/PaulSonOfLars/gotgbot/samples/echoBot
+module github.com/PaulSonOfLars/gotgbot/samples/echoMultiBot
 
 go 1.15
 

--- a/samples/echoMultiBot/main.go
+++ b/samples/echoMultiBot/main.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/PaulSonOfLars/gotgbot/v2"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext/handlers"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext/handlers/filters/message"
+)
+
+func main() {
+	// This example defines how to define an echo bot that works for multiple bot instances at once.
+	// It also shows how to stop the bot gracefully using the Updater.Stop() mechanism.
+
+	// Get comma separated bot tokens from environment variable
+	tokens := os.Getenv("TOKENS")
+	if tokens == "" {
+		panic("TOKENS environment variable is empty")
+	}
+
+	// Create updater and dispatcher.
+	updater := ext.NewUpdater(&ext.UpdaterOpts{
+		ErrorLog: nil,
+		Dispatcher: ext.NewDispatcher(&ext.DispatcherOpts{
+			// If an error is returned by a handler, log it and continue going.
+			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {
+				fmt.Println("an error occurred while handling update:", err.Error())
+				return ext.DispatcherActionNoop
+			},
+			MaxRoutines: ext.DefaultMaxRoutines,
+		}),
+	})
+	dispatcher := updater.Dispatcher
+
+	// Add stop handler to stop all bots gracefully.
+	dispatcher.AddHandler(handlers.NewCommand("stop", func(b *gotgbot.Bot, ctx *ext.Context) error {
+		// Using an anonymous function here can be a nice way of passing additional parameters into bot methods.
+		// In this case we pass the updater - this will allow us to stop it and exit the program.
+		return stop(b, ctx, &updater)
+	}))
+	// Add echo handler to reply to all other text messages.
+	dispatcher.AddHandler(handlers.NewMessage(message.Text, echo))
+
+	// We iterate over all the tokens provided, to create and start polling on each one.
+	for idx, token := range strings.Split(tokens, ",") {
+		b, err := gotgbot.NewBot(token, &gotgbot.BotOpts{
+			Client: http.Client{},
+			DefaultRequestOpts: &gotgbot.RequestOpts{
+				Timeout: gotgbot.DefaultTimeout,
+				APIURL:  gotgbot.DefaultAPIURL,
+			},
+		})
+		if err != nil {
+			panic(fmt.Errorf("bot %d: failed to create bot: %w", idx, err))
+		}
+
+		// Start polling for the current bot.
+		err = updater.StartPolling(b, &ext.PollingOpts{
+			DropPendingUpdates: true,
+			GetUpdatesOpts: gotgbot.GetUpdatesOpts{
+				Timeout: 9,
+				RequestOpts: &gotgbot.RequestOpts{
+					Timeout: time.Second * 10,
+				},
+			},
+		})
+		if err != nil {
+			panic(fmt.Errorf("bot %d: failed to start polling: %w", idx, err))
+		}
+
+		fmt.Printf("bot %d: %s has been started...\n", idx, b.User.Username)
+	}
+
+	// Idle, to keep updates coming in, and thus avoid our bots from stopping.
+	fmt.Println("Idling to keep main thread active, while incoming updates are handled.")
+	updater.Idle()
+
+	// If we get here, the updater.Idle() has ended.
+	// This means the bots have been gracefully stopped via updater.Stop()
+	fmt.Println("All bots have been gracefully stopped.")
+}
+
+// echo replies to a messages with its own contents.
+func echo(b *gotgbot.Bot, ctx *ext.Context) error {
+	_, err := ctx.EffectiveMessage.Reply(b, ctx.EffectiveMessage.Text, nil)
+	if err != nil {
+		return fmt.Errorf("failed to echo message: %w", err)
+	}
+	return nil
+}
+
+// echo replies to a messages with its own contents.
+func stop(b *gotgbot.Bot, ctx *ext.Context, updater *ext.Updater) error {
+	_, err := ctx.EffectiveMessage.Reply(b, "Stopping all bots...", nil)
+	if err != nil {
+		return fmt.Errorf("failed to echo message: %w", err)
+	}
+
+	// We stop the updater in a separate goroutine, otherwise it would be stuck waiting for itself.
+	go func() {
+		err = updater.Stop()
+		if err != nil {
+			ctx.EffectiveMessage.Reply(b, fmt.Sprintf("Failed to stop updater: %s", err.Error()), nil)
+			return
+		}
+	}()
+
+	return nil
+}

--- a/samples/echoMultiBot/main.go
+++ b/samples/echoMultiBot/main.go
@@ -14,10 +14,10 @@ import (
 	"github.com/PaulSonOfLars/gotgbot/v2/ext/handlers/filters/message"
 )
 
+// This bot demonstrates how to create echo bot that works with multiple bot instances at once.
+// It also shows how to stop the bot gracefully using the Updater.Stop() mechanism.
+// It has options to use either polling or webhooks.
 func main() {
-	// This example defines how to define an echo bot that works for multiple bot instances at once.
-	// It also shows how to stop the bot gracefully using the Updater.Stop() mechanism.
-	// It has options to toggle between polling, or webhooks.
 
 	// Get comma separated bot tokens from environment variable
 	tokens := os.Getenv("TOKENS")

--- a/samples/echoMultiBot/main.go
+++ b/samples/echoMultiBot/main.go
@@ -94,6 +94,7 @@ func main() {
 	log.Println("All bots have been gracefully stopped.")
 }
 
+// startLongPollingBots demonstrates how to start multiple bots with long-polling.
 func startLongPollingBots(updater *ext.Updater, bots []*gotgbot.Bot) error {
 	for idx, b := range bots {
 		err := updater.StartPolling(b, &ext.PollingOpts{
@@ -115,6 +116,7 @@ func startLongPollingBots(updater *ext.Updater, bots []*gotgbot.Bot) error {
 	return nil
 }
 
+// startWebhookBots demonstrates how to start multiple bots with webhooks.
 func startWebhookBots(updater *ext.Updater, bots []*gotgbot.Bot, domain string, webhookSecret string) error {
 	opts := ext.WebhookOpts{
 		Listen:      "0.0.0.0", // This example assumes you're in a dev environment running ngrok on 8080.
@@ -122,20 +124,20 @@ func startWebhookBots(updater *ext.Updater, bots []*gotgbot.Bot, domain string, 
 		SecretToken: webhookSecret,
 	}
 
-	// We start the server before we set the webhooks, so that we are immediately able to process incoming updates.
+	// We start the server before we set the webhooks, so that incoming requests can be processed immediately.
 	err := updater.StartServer(opts)
 	if err != nil {
 		return fmt.Errorf("failed to start the webhook server: %w", err)
 	}
 
-	// We iterate over all the bots, to register them with the updater.
+	// We add all the bots to the updater.
 	for idx, b := range bots {
 		updater.AddWebhook(b, b.GetToken(), opts)
 		log.Printf("bot %d: %s has been added to the updater\n", idx, b.User.Username)
 	}
 
-	// We set the webhooks for all the registered bots, so telegram starts sending updates.
-	return updater.SetWebhooks(domain, &gotgbot.SetWebhookOpts{
+	// We set the webhooks for all the added bots, so telegram starts sending updates.
+	return updater.SetAllBotWebhooks(domain, &gotgbot.SetWebhookOpts{
 		MaxConnections:     100,
 		AllowedUpdates:     nil,
 		DropPendingUpdates: false,

--- a/samples/echoMultiBot/main.go
+++ b/samples/echoMultiBot/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -16,6 +17,7 @@ import (
 func main() {
 	// This example defines how to define an echo bot that works for multiple bot instances at once.
 	// It also shows how to stop the bot gracefully using the Updater.Stop() mechanism.
+	// It has options to toggle between polling, or webhooks.
 
 	// Get comma separated bot tokens from environment variable
 	tokens := os.Getenv("TOKENS")
@@ -23,13 +25,21 @@ func main() {
 		panic("TOKENS environment variable is empty")
 	}
 
+	// Get the webhook domain from the environment variable.
+	webhookDomain := os.Getenv("WEBHOOK_DOMAIN")
+	if webhookDomain == "" {
+		log.Println("no webhook domain specified; using long polling.")
+	}
+	// Get the webhook secret from the environment variable.
+	webhookSecret := os.Getenv("WEBHOOK_SECRET")
+
 	// Create updater and dispatcher.
 	updater := ext.NewUpdater(&ext.UpdaterOpts{
 		ErrorLog: nil,
 		Dispatcher: ext.NewDispatcher(&ext.DispatcherOpts{
 			// If an error is returned by a handler, log it and continue going.
 			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {
-				fmt.Println("an error occurred while handling update:", err.Error())
+				log.Println("an error occurred while handling update:", err.Error())
 				return ext.DispatcherActionNoop
 			},
 			MaxRoutines: ext.DefaultMaxRoutines,
@@ -41,11 +51,12 @@ func main() {
 	dispatcher.AddHandler(handlers.NewCommand("stop", func(b *gotgbot.Bot, ctx *ext.Context) error {
 		// Using an anonymous function here can be a nice way of passing additional parameters into bot methods.
 		// In this case we pass the updater - this will allow us to stop it and exit the program.
-		return stop(b, ctx, &updater)
+		return stop(b, ctx, updater)
 	}))
 	// Add echo handler to reply to all other text messages.
 	dispatcher.AddHandler(handlers.NewMessage(message.Text, echo))
 
+	var bots []*gotgbot.Bot
 	// We iterate over all the tokens provided, to create and start polling on each one.
 	for idx, token := range strings.Split(tokens, ",") {
 		b, err := gotgbot.NewBot(token, &gotgbot.BotOpts{
@@ -58,9 +69,34 @@ func main() {
 		if err != nil {
 			panic(fmt.Errorf("bot %d: failed to create bot: %w", idx, err))
 		}
+		bots = append(bots, b)
+	}
 
-		// Start polling for the current bot.
-		err = updater.StartPolling(b, &ext.PollingOpts{
+	if webhookDomain != "" {
+		err := startWebhookBots(updater, bots, webhookDomain, webhookSecret)
+		if err != nil {
+			panic("Failed to start bots via webhook: " + err.Error())
+		}
+
+	} else {
+		err := startLongPollingBots(updater, bots)
+		if err != nil {
+			panic("Failed to start bots via polling: " + err.Error())
+		}
+	}
+
+	// Idle, to keep updates coming in, and thus avoid our bots from stopping.
+	log.Println("Idling to keep main thread active while incoming updates are handled.")
+	updater.Idle()
+
+	// If we get here, the updater.Idle() has ended.
+	// This means the bots have been gracefully stopped via updater.Stop()
+	log.Println("All bots have been gracefully stopped.")
+}
+
+func startLongPollingBots(updater *ext.Updater, bots []*gotgbot.Bot) error {
+	for idx, b := range bots {
+		err := updater.StartPolling(b, &ext.PollingOpts{
 			DropPendingUpdates: true,
 			GetUpdatesOpts: gotgbot.GetUpdatesOpts{
 				Timeout: 9,
@@ -70,19 +106,41 @@ func main() {
 			},
 		})
 		if err != nil {
-			panic(fmt.Errorf("bot %d: failed to start polling: %w", idx, err))
+			return fmt.Errorf("failed to start polling for bot %d: %w", idx, err)
 		}
 
-		fmt.Printf("bot %d: %s has been started...\n", idx, b.User.Username)
+		log.Printf("bot %d: %s has started polling...\n", idx, b.User.Username)
 	}
 
-	// Idle, to keep updates coming in, and thus avoid our bots from stopping.
-	fmt.Println("Idling to keep main thread active, while incoming updates are handled.")
-	updater.Idle()
+	return nil
+}
 
-	// If we get here, the updater.Idle() has ended.
-	// This means the bots have been gracefully stopped via updater.Stop()
-	fmt.Println("All bots have been gracefully stopped.")
+func startWebhookBots(updater *ext.Updater, bots []*gotgbot.Bot, domain string, webhookSecret string) error {
+	opts := ext.WebhookOpts{
+		Listen:      "0.0.0.0", // This example assumes you're in a dev environment running ngrok on 8080.
+		Port:        8080,
+		SecretToken: webhookSecret,
+	}
+
+	// We start the server before we set the webhooks, so that we are immediately able to process incoming updates.
+	err := updater.StartServer(opts)
+	if err != nil {
+		return fmt.Errorf("failed to start the webhook server: %w", err)
+	}
+
+	// We iterate over all the bots, to register them with the updater.
+	for idx, b := range bots {
+		updater.AddWebhook(b, b.GetToken(), opts)
+		log.Printf("bot %d: %s has been added to the updater\n", idx, b.User.Username)
+	}
+
+	// We set the webhooks for all the registered bots, so telegram starts sending updates.
+	return updater.SetWebhooks(domain, &gotgbot.SetWebhookOpts{
+		MaxConnections:     100,
+		AllowedUpdates:     nil,
+		DropPendingUpdates: false,
+		SecretToken:        webhookSecret,
+	})
 }
 
 // echo replies to a messages with its own contents.

--- a/samples/echoWebhookBot/go.mod
+++ b/samples/echoWebhookBot/go.mod
@@ -1,4 +1,4 @@
-module github.com/PaulSonOfLars/gotgbot/samples/echoBot
+module github.com/PaulSonOfLars/gotgbot/samples/echoWebhookBot
 
 go 1.15
 

--- a/samples/echoWebhookBot/main.go
+++ b/samples/echoWebhookBot/main.go
@@ -80,7 +80,7 @@ func main() {
 		panic("failed to start webhook: " + err.Error())
 	}
 
-	err = updater.SetWebhooks(webhookDomain, &gotgbot.SetWebhookOpts{
+	err = updater.SetAllBotWebhooks(webhookDomain, &gotgbot.SetWebhookOpts{
 		MaxConnections:     100,
 		DropPendingUpdates: true,
 		SecretToken:        webhookOpts.SecretToken,

--- a/samples/middlewareBot/main.go
+++ b/samples/middlewareBot/main.go
@@ -39,14 +39,14 @@ func main() {
 	// Create updater and dispatcher.
 	updater := ext.NewUpdater(&ext.UpdaterOpts{
 		ErrorLog: nil,
-		DispatcherOpts: ext.DispatcherOpts{
+		Dispatcher: ext.NewDispatcher(&ext.DispatcherOpts{
 			// If an error is returned by a handler, log it and continue going.
 			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {
 				log.Println("an error occurred while handling update:", err.Error())
 				return ext.DispatcherActionNoop
 			},
 			MaxRoutines: ext.DefaultMaxRoutines,
-		},
+		}),
 	})
 	dispatcher := updater.Dispatcher
 

--- a/samples/webappBot/main.go
+++ b/samples/webappBot/main.go
@@ -47,14 +47,14 @@ func main() {
 	// Create updater and dispatcher to handle updates in a simple manner.
 	updater := ext.NewUpdater(&ext.UpdaterOpts{
 		ErrorLog: nil,
-		DispatcherOpts: ext.DispatcherOpts{
+		Dispatcher: ext.NewDispatcher(&ext.DispatcherOpts{
 			// If an error is returned by a handler, log it and continue going.
 			Error: func(b *gotgbot.Bot, ctx *ext.Context, err error) ext.DispatcherAction {
 				log.Println("an error occurred while handling update:", err.Error())
 				return ext.DispatcherActionNoop
 			},
 			MaxRoutines: ext.DefaultMaxRoutines,
-		},
+		}),
 	})
 	dispatcher := updater.Dispatcher
 

--- a/scripts/hooks/pre-push.sh
+++ b/scripts/hooks/pre-push.sh
@@ -7,3 +7,6 @@ set -euo pipefail
 
 # Run golangci-lint to lint against all go code in the repo. Configuration in .golangci.yaml.
 golangci-lint run
+
+# Ensure all generated code has up to date.
+./scripts/ci/ensure-generated.sh >/dev/null


### PR DESCRIPTION
# What

This PR outlines some possible additions to the updater to support running multiple bots at once on the same updater.

This would allow users to easily run multiple bots with the same codebase, as the same program, but with different names.

# Impact

- Are your changes backwards compatible? No - many minor method changes.
- Have you included documentation, or updated existing documentation? TODO
- Do errors and log messages provide enough context? TODO
