### PR TITLE
Fix close on a potential nil channel in dispatcher stop

### DIFF
--- a/ext/dispatcher.go
+++ b/ext/dispatcher.go
@@ -203,7 +203,9 @@ func (d *Dispatcher) Start(b *gotgbot.Bot, updates chan json.RawMessage) {
 // Stop waits for all currently processing updates to finish, and then returns.
 func (d *Dispatcher) Stop() {
 	d.waitGroup.Wait()
-	close(d.limiter)
+	if d.limiter != nil {
+		close(d.limiter)
+	}
 }
 
 // AddHandler adds a new handler to the dispatcher. The dispatcher will call CheckUpdate() to see whether the handler

--- a/ext/dispatcher.go
+++ b/ext/dispatcher.go
@@ -165,6 +165,7 @@ func (d *Dispatcher) MaxUsage() int {
 }
 
 // Start to handle incoming updates.
+// This is a blocking method; it should be called as a goroutine, such that it can receive incoming updates.
 func (d *Dispatcher) Start(b *gotgbot.Bot, updates chan json.RawMessage) {
 	// Listen to updates as they come in from the updater.
 	for upd := range updates {

--- a/ext/dispatcher_test.go
+++ b/ext/dispatcher_test.go
@@ -1,0 +1,58 @@
+package ext
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestDispatcherStop(t *testing.T) {
+	d := NewDispatcher(nil)
+
+	go d.Start(nil, make(chan json.RawMessage))
+
+	waited := false
+	d.waitGroup.Add(1)
+	d.limiter <- struct{}{}
+
+	// imitate a "wait"
+	go func() {
+		time.Sleep(time.Second)
+		waited = true
+
+		<-d.limiter
+		d.waitGroup.Done()
+	}()
+
+	d.Stop()
+	if !waited {
+		t.Errorf("Dispatcher was stopped before the updates were done being handled.")
+	}
+
+}
+
+func TestLimitedDispatcherStop(t *testing.T) {
+	d := NewDispatcher(&DispatcherOpts{
+		MaxRoutines: DefaultMaxRoutines,
+	})
+
+	if cap(d.limiter) != DefaultMaxRoutines {
+		t.Errorf("Expected limiter to be of max size %d, got %d", DefaultMaxRoutines, cap(d.limiter))
+	}
+
+	go d.Start(nil, make(chan json.RawMessage))
+	d.Stop() // ensure no panics
+}
+
+func TestUnlimitedDispatcherStop(t *testing.T) {
+	d := NewDispatcher(&DispatcherOpts{
+		MaxRoutines: -1,
+	})
+
+	if d.limiter != nil {
+		t.Errorf("Expected limiter to be nil for unlimited dispatcher")
+	}
+
+	go d.Start(nil, make(chan json.RawMessage))
+	d.Stop() // ensure no panics
+}


### PR DESCRIPTION
# What

Handle case where limiter channel is nil (eg, when using an unlimited dispatcher)

Also added tests for this edge case.

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
