### PR TITLE
add an option to listen on UNIX socket

### DIFF
--- a/ext/dispatcher.go
+++ b/ext/dispatcher.go
@@ -196,7 +196,6 @@ func (d *Dispatcher) Start(b *gotgbot.Bot, updates chan json.RawMessage) {
 					d.logf("Failed to process update: %s", err.Error())
 				}
 			}
-
 		}(upd)
 	}
 }
@@ -243,13 +242,13 @@ func (d *Dispatcher) ProcessUpdate(b *gotgbot.Bot, update *gotgbot.Update, data 
 			// If a panic handler is defined, handle the error.
 			if d.Panic != nil {
 				d.Panic(b, ctx, r)
-				return
 
-			} else {
-				// Otherwise, create an error from the panic, and return it.
-				err = fmt.Errorf("%w: %v\n%s", ErrPanicRecovered, r, cleanedStack())
 				return
 			}
+			// Otherwise, create an error from the panic, and return it.
+			err = fmt.Errorf("%w: %v\n%s", ErrPanicRecovered, r, cleanedStack())
+
+			return
 		}
 	}()
 

--- a/ext/dispatcher_test.go
+++ b/ext/dispatcher_test.go
@@ -28,7 +28,6 @@ func TestDispatcherStop(t *testing.T) {
 	if !waited {
 		t.Errorf("Dispatcher was stopped before the updates were done being handled.")
 	}
-
 }
 
 func TestLimitedDispatcherStop(t *testing.T) {

--- a/ext/handlers/callbackquery.go
+++ b/ext/handlers/callbackquery.go
@@ -9,9 +9,9 @@ import (
 )
 
 type CallbackQuery struct {
-	AllowChannel bool
 	Filter       filters.CallbackQuery
 	Response     Response
+	AllowChannel bool
 }
 
 func NewCallback(filter filters.CallbackQuery, r Response) CallbackQuery {

--- a/ext/handlers/common_test.go
+++ b/ext/handlers/common_test.go
@@ -33,11 +33,11 @@ func NewTestBot() *gotgbot.Bot {
 	}
 }
 
-func NewMessage(userId int64, chatId int64, message string) *ext.Context {
+func NewMessage(userId, chatId int64, message string) *ext.Context {
 	return newMessage(userId, chatId, message, nil)
 }
 
-func NewCommandMessage(userId int64, chatId int64, command string, args []string) *ext.Context {
+func NewCommandMessage(userId, chatId int64, command string, args []string) *ext.Context {
 	msg, ents := buildCommand(command, args)
 	return newMessage(userId, chatId, msg, ents)
 }
@@ -53,7 +53,7 @@ func buildCommand(cmd string, args []string) (string, []gotgbot.MessageEntity) {
 		}
 }
 
-func newMessage(userId int64, chatId int64, message string, entities []gotgbot.MessageEntity) *ext.Context {
+func newMessage(userId, chatId int64, message string, entities []gotgbot.MessageEntity) *ext.Context {
 	chatType := "supergroup"
 	if userId == chatId {
 		chatType = "private"

--- a/ext/handlers/conversation.go
+++ b/ext/handlers/conversation.go
@@ -36,14 +36,14 @@ type Conversation struct {
 }
 
 type ConversationOpts struct {
+	// StateStorage is responsible for storing all running conversations.
+	StateStorage conversation.Storage
 	// Exits is the list of handlers to exit the current conversation partway (eg /cancel commands)
 	Exits []ext.Handler
 	// Fallbacks is the list of handlers to handle updates which haven't been matched by any states.
 	Fallbacks []ext.Handler
 	// If True, a user can restart the conversation by hitting one of the entry points.
 	AllowReEntry bool
-	// StateStorage is responsible for storing all running conversations.
-	StateStorage conversation.Storage
 }
 
 func NewConversation(entryPoints []ext.Handler, states map[string][]ext.Handler, opts *ConversationOpts) Conversation {
@@ -122,10 +122,10 @@ func (c Conversation) HandleUpdate(b *gotgbot.Bot, ctx *ext.Context) error {
 type ConversationStateChange struct {
 	// The next state to handle in the current conversation.
 	NextState *string
-	// End the current conversation
-	End bool
 	// Move the parent conversation (if any) to the desired state.
 	ParentState *ConversationStateChange
+	// End the current conversation
+	End bool
 }
 
 func (s *ConversationStateChange) Error() string {

--- a/ext/handlers/conversation_test.go
+++ b/ext/handlers/conversation_test.go
@@ -136,6 +136,7 @@ func TestFallbackConversation(t *testing.T) {
 	// Ensure conversation has ended.
 	checkExpectedState(t, &conv, cancelCommand, "")
 }
+
 func TestReEntryConversation(t *testing.T) {
 	b := NewTestBot()
 
@@ -256,7 +257,7 @@ func TestNestedConversation(t *testing.T) {
 	checkExpectedState(t, &conv, textMessage, "")
 }
 
-func runHandler(t *testing.T, b *gotgbot.Bot, conv *handlers.Conversation, message *ext.Context, currentState string, nextState string) {
+func runHandler(t *testing.T, b *gotgbot.Bot, conv *handlers.Conversation, message *ext.Context, currentState, nextState string) {
 	willRunHandler(t, b, conv, message, currentState)
 	if err := conv.HandleUpdate(b, message); err != nil {
 		t.Fatalf("unexpected error from handler: %s", err.Error())

--- a/ext/handlers/filters/message/message.go
+++ b/ext/handlers/filters/message/message.go
@@ -101,7 +101,6 @@ func Text(msg *gotgbot.Message) bool {
 func HasPrefix(prefix string) filters.Message {
 	return func(msg *gotgbot.Message) bool {
 		return strings.HasPrefix(msg.Text, prefix) || strings.HasSuffix(msg.Caption, prefix)
-
 	}
 }
 

--- a/ext/queryvalidation.go
+++ b/ext/queryvalidation.go
@@ -24,7 +24,7 @@ func ValidateLoginQuery(query url.Values, token string) (bool, error) {
 // ValidateWebAppInitData validates a webapp's initData field for safe use on the server-side.
 // The initData field is stored as a query string, so this is converted and then validated.
 // See https://core.telegram.org/bots/webapps#validating-data-received-via-the-web-app for more details.
-func ValidateWebAppInitData(initData string, token string) (bool, error) {
+func ValidateWebAppInitData(initData, token string) (bool, error) {
 	query, err := url.ParseQuery(initData)
 	if err != nil {
 		return false, fmt.Errorf("failed to parse URL query: %w", err)

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -171,7 +171,7 @@ func (u *Updater) StartPolling(b *gotgbot.Bot, opts *PollingOpts) error {
 	return nil
 }
 
-func (u *Updater) pollingLoop(b *gotgbot.Bot, opts *gotgbot.RequestOpts, polling <-chan struct{}, updateChan chan json.RawMessage, dropPendingUpdates bool, v map[string]string) {
+func (u *Updater) pollingLoop(b *gotgbot.Bot, opts *gotgbot.RequestOpts, polling <-chan struct{}, updateChan chan<- json.RawMessage, dropPendingUpdates bool, v map[string]string) {
 	// if dropPendingUpdates, force the offset to -1
 	if dropPendingUpdates {
 		v["offset"] = "-1"

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -331,7 +331,7 @@ func (u *Updater) AddWebhook(b *gotgbot.Bot, urlPath string, opts WebhookOpts) {
 // SetAllBotWebhooks sets all the webhooks for the bots that have been added to this updater via AddWebhook.
 func (u *Updater) SetAllBotWebhooks(domain string, opts *gotgbot.SetWebhookOpts) error {
 	for _, data := range u.botMapping {
-		_, err := data.bot.SetWebhook(fmt.Sprintf("%s/%s", strings.TrimSuffix(domain, "/"), data.urlPath), opts)
+		_, err := data.bot.SetWebhook(strings.Join([]string{strings.TrimSuffix(domain, "/"), data.urlPath}, "/"), opts)
 		if err != nil {
 			// Extract the botID, so we don't intentionally log the token
 			botId := strings.Split(data.bot.GetToken(), ":")[0]

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -27,7 +27,7 @@ type botData struct {
 	// updateChan represents the incoming updates channel.
 	updateChan chan json.RawMessage
 	// polling allows us to close the polling loop.
-	polling chan bool
+	polling chan struct{}
 	// urlPath defines the incoming webhook URL path for this bot.
 	urlPath string
 }
@@ -47,7 +47,7 @@ type Updater struct {
 	ErrorLog *log.Logger
 
 	// stopIdling is the channel that blocks the main thread from exiting, to keep the bots running.
-	stopIdling chan bool
+	stopIdling chan struct{}
 	// serveMux is where all our webhook paths are added for the server to use.
 	serveMux *http.ServeMux
 	// webhookServer is the server in charge of receiving all incoming webhook updates.
@@ -157,7 +157,7 @@ func (u *Updater) StartPolling(b *gotgbot.Bot, opts *PollingOpts) error {
 	}
 
 	updateChan := make(chan json.RawMessage)
-	pollChan := make(chan bool)
+	pollChan := make(chan struct{})
 	u.botMapping[b.GetToken()] = &botData{
 		bot:        b,
 		updateChan: updateChan,
@@ -170,7 +170,7 @@ func (u *Updater) StartPolling(b *gotgbot.Bot, opts *PollingOpts) error {
 	return nil
 }
 
-func (u *Updater) pollingLoop(b *gotgbot.Bot, opts *gotgbot.RequestOpts, polling chan bool, updateChan chan json.RawMessage, dropPendingUpdates bool, v map[string]string) {
+func (u *Updater) pollingLoop(b *gotgbot.Bot, opts *gotgbot.RequestOpts, polling <-chan struct{}, updateChan chan json.RawMessage, dropPendingUpdates bool, v map[string]string) {
 	// if dropPendingUpdates, force the offset to -1
 	if dropPendingUpdates {
 		v["offset"] = "-1"
@@ -248,7 +248,7 @@ func (u *Updater) pollingLoop(b *gotgbot.Bot, opts *gotgbot.RequestOpts, polling
 // Idle starts an infinite loop to avoid the program exciting while the background threads handle updates.
 func (u *Updater) Idle() {
 	// Create the idling channel
-	u.stopIdling = make(chan bool)
+	u.stopIdling = make(chan struct{})
 
 	// Wait until some input is received from the idle channel, which will stop the idling.
 	<-u.stopIdling
@@ -269,7 +269,6 @@ func (u *Updater) Stop() error {
 		// Close polling loops first, to ensure any updates currently being polled have the time to be sent to the
 		// updateChan.
 		if data.polling != nil {
-			data.polling <- false
 			close(data.polling)
 		}
 
@@ -282,7 +281,6 @@ func (u *Updater) Stop() error {
 
 	// Finally, atop idling.
 	if u.stopIdling != nil {
-		u.stopIdling <- false
 		close(u.stopIdling)
 	}
 	return nil

--- a/ext/webhook.go
+++ b/ext/webhook.go
@@ -11,6 +11,8 @@ type WebhookOpts struct {
 	Listen string
 	// Port is the port listen on (eg 443, 8443, etc).
 	Port int
+	// UnixListen is the UNIX socket to listen on (mutually exclusive with Listen/Port options)
+	UnixListen string
 	// ReadTimeout is passed to the http server to limit the time it takes to read an incoming request.
 	// See http.Server for more details.
 	ReadTimeout time.Duration
@@ -29,6 +31,9 @@ type WebhookOpts struct {
 
 // GetListenAddr returns the local listening address, including port.
 func (w *WebhookOpts) GetListenAddr() string {
+	if w.UnixListen != "" {
+		return w.UnixListen
+	}
 	if w.Listen == "" {
 		w.Listen = "0.0.0.0"
 	}


### PR DESCRIPTION
For those that are running their bot behind a Web server, this MR contains a patch to listen on UNIX socket (as well as some small other unrelated changes that I can exclude from this MR if you don't want to merge them).