### PR TITLE
rework the web hook listen options

### DIFF
--- a/ext/updater.go
+++ b/ext/updater.go
@@ -362,23 +362,18 @@ func (u *Updater) StartServer(opts WebhookOpts) error {
 		return ErrMissingCertOrKeyFile
 	}
 
-	var network string
-	if opts.UnixListen != "" {
-		network = "unix"
-	} else {
-		network = "tcp"
+	opts.setDefaults()
+
+	ln, err := net.Listen(opts.ListenNet, opts.ListenAddr)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s:%s: %w", opts.ListenNet, opts.ListenAddr, err)
 	}
 
 	u.webhookServer = &http.Server{
-		Addr:              opts.GetListenAddr(),
+		Addr:              ln.Addr().String(),
 		Handler:           u.serveMux,
 		ReadTimeout:       opts.ReadTimeout,
 		ReadHeaderTimeout: opts.ReadHeaderTimeout,
-	}
-
-	ln, err := net.Listen(network, u.webhookServer.Addr)
-	if err != nil {
-		return fmt.Errorf("failed to listen on %s:%s: %w", network, u.webhookServer.Addr, err)
 	}
 
 	go func() {

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -362,15 +362,12 @@ func (u *Updater) StartServer(opts WebhookOpts) error {
 		return ErrMissingCertOrKeyFile
 	}
 
-	opts.setDefaults()
-
-	ln, err := net.Listen(opts.ListenNet, opts.ListenAddr)
+	ln, err := net.Listen(opts.GetListenNet(), opts.ListenAddr)
 	if err != nil {
 		return fmt.Errorf("failed to listen on %s:%s: %w", opts.ListenNet, opts.ListenAddr, err)
 	}
 
 	u.webhookServer = &http.Server{
-		Addr:              ln.Addr().String(),
 		Handler:           u.serveMux,
 		ReadTimeout:       opts.ReadTimeout,
 		ReadHeaderTimeout: opts.ReadHeaderTimeout,

--- a/ext/webhook.go
+++ b/ext/webhook.go
@@ -11,6 +11,8 @@ type WebhookOpts struct {
 	Listen string
 	// Port is the port listen on (eg 443, 8443, etc).
 	Port int
+	// UnixListen is the UNIX socket to listen on (mutually exclusive with Listen/Port options)
+	UnixListen string
 	// ReadTimeout is passed to the http server to limit the time it takes to read an incoming request.
 	// See http.Server for more details.
 	ReadTimeout time.Duration
@@ -29,6 +31,9 @@ type WebhookOpts struct {
 
 // GetListenAddr returns the local listening address, including port.
 func (w *WebhookOpts) GetListenAddr() string {
+	if w.UnixListen != "" {
+		return w.UnixListen
+	}
 	if w.Listen == "" {
 		w.Listen = "0.0.0.0"
 	}

--- a/ext/webhook.go
+++ b/ext/webhook.go
@@ -28,8 +28,9 @@ type WebhookOpts struct {
 	SecretToken string
 }
 
-func (w *WebhookOpts) setDefaults() {
+func (w *WebhookOpts) GetListenNet() string {
 	if w.ListenNet == "" {
-		w.ListenNet = "tcp"
+		return "tcp"
 	}
+	return w.ListenNet
 }

--- a/ext/webhook.go
+++ b/ext/webhook.go
@@ -1,18 +1,17 @@
 package ext
 
 import (
-	"fmt"
 	"time"
 )
 
 // WebhookOpts represent various fields that are needed for configuring the local webhook server.
 type WebhookOpts struct {
-	// Listen is the address to listen on (eg: localhost, 0.0.0.0, etc).
-	Listen string
-	// Port is the port listen on (eg 443, 8443, etc).
-	Port int
-	// UnixListen is the UNIX socket to listen on (mutually exclusive with Listen/Port options)
-	UnixListen string
+	// ListenAddr is the address and port to listen on (eg: localhost:http, 0.0.0.0:8080, :https, "[::1]:", etc).
+	// See the net package for details.
+	ListenAddr string
+	// ListenNet is the network type to listen on (must be "tcp", "tcp4", "tcp6", "unix" or "unixpacket").
+	// Empty means the default, "tcp".
+	ListenNet string
 	// ReadTimeout is passed to the http server to limit the time it takes to read an incoming request.
 	// See http.Server for more details.
 	ReadTimeout time.Duration
@@ -29,16 +28,8 @@ type WebhookOpts struct {
 	SecretToken string
 }
 
-// GetListenAddr returns the local listening address, including port.
-func (w *WebhookOpts) GetListenAddr() string {
-	if w.UnixListen != "" {
-		return w.UnixListen
+func (w *WebhookOpts) setDefaults() {
+	if w.ListenNet == "" {
+		w.ListenNet = "tcp"
 	}
-	if w.Listen == "" {
-		w.Listen = "0.0.0.0"
-	}
-	if w.Port == 0 {
-		w.Port = 443
-	}
-	return fmt.Sprintf("%s:%d", w.Listen, w.Port)
 }

--- a/samples/echoMultiBot/.gitignore
+++ b/samples/echoMultiBot/.gitignore
@@ -1,0 +1,1 @@
+echoMultiBot

--- a/samples/echoMultiBot/go.mod
+++ b/samples/echoMultiBot/go.mod
@@ -2,6 +2,6 @@ module github.com/PaulSonOfLars/gotgbot/samples/echoMultiBot
 
 go 1.15
 
-require github.com/PaulSonOfLars/gotgbot/v2 v2.0.0-rc.8
+require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 
 replace github.com/PaulSonOfLars/gotgbot/v2 => ../../

--- a/samples/echoMultiBot/main.go
+++ b/samples/echoMultiBot/main.go
@@ -18,7 +18,6 @@ import (
 // It also shows how to stop the bot gracefully using the Updater.Stop() mechanism.
 // It has options to use either polling or webhooks.
 func main() {
-
 	// Get comma separated bot tokens from environment variable
 	tokens := os.Getenv("TOKENS")
 	if tokens == "" {
@@ -119,8 +118,7 @@ func startLongPollingBots(updater *ext.Updater, bots []*gotgbot.Bot) error {
 // startWebhookBots demonstrates how to start multiple bots with webhooks.
 func startWebhookBots(updater *ext.Updater, bots []*gotgbot.Bot, domain string, webhookSecret string) error {
 	opts := ext.WebhookOpts{
-		Listen:      "0.0.0.0", // This example assumes you're in a dev environment running ngrok on 8080.
-		Port:        8080,
+		ListenAddr:  "127.0.0.1:8080", // This example assumes you're in a dev environment running ngrok on 8080.
 		SecretToken: webhookSecret,
 	}
 

--- a/samples/echoWebhookBot/.gitignore
+++ b/samples/echoWebhookBot/.gitignore
@@ -1,0 +1,1 @@
+echoWebhookBot

--- a/samples/echoWebhookBot/go.mod
+++ b/samples/echoWebhookBot/go.mod
@@ -2,6 +2,6 @@ module github.com/PaulSonOfLars/gotgbot/samples/echoWebhookBot
 
 go 1.15
 
-require github.com/PaulSonOfLars/gotgbot/v2 v2.0.0-rc.8
+require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 
 replace github.com/PaulSonOfLars/gotgbot/v2 => ../../

--- a/samples/echoWebhookBot/main.go
+++ b/samples/echoWebhookBot/main.go
@@ -70,9 +70,8 @@ func main() {
 	// Start the webhook server. We start the server before we set the webhook itself, so that when telegram starts
 	// sending updates, the server is already ready.
 	webhookOpts := ext.WebhookOpts{
-		Listen:      "0.0.0.0", // This example assumes you're in a dev environment running ngrok on 8080.
-		Port:        8080,
-		SecretToken: webhookSecret, // Setting a webhook secret here allows you to ensure the webhook is set by you (must be set here AND in SetWebhook!).
+		ListenAddr:  "localhost:8080", // This example assumes you're in a dev environment running ngrok on 8080.
+		SecretToken: webhookSecret,    // Setting a webhook secret here allows you to ensure the webhook is set by you (must be set here AND in SetWebhook!).
 	}
 	// We use the token as the urlPath for the webhook, as using a secret ensures that strangers aren't crafting fake updates.
 	err = updater.StartWebhook(b, token, webhookOpts)


### PR DESCRIPTION
For those that are running their bot behind a Web server, this MR contains a patch to listen on UNIX socket.
(backward-compatible, as this adds an optional field)