### PR TITLE
optimisation of GC for heavily-accessed structures and small linting

### DIFF
--- a/ext/dispatcher.go
+++ b/ext/dispatcher.go
@@ -196,7 +196,6 @@ func (d *Dispatcher) Start(b *gotgbot.Bot, updates chan json.RawMessage) {
 					d.logf("Failed to process update: %s", err.Error())
 				}
 			}
-
 		}(upd)
 	}
 }
@@ -243,13 +242,13 @@ func (d *Dispatcher) ProcessUpdate(b *gotgbot.Bot, update *gotgbot.Update, data 
 			// If a panic handler is defined, handle the error.
 			if d.Panic != nil {
 				d.Panic(b, ctx, r)
-				return
 
-			} else {
-				// Otherwise, create an error from the panic, and return it.
-				err = fmt.Errorf("%w: %v\n%s", ErrPanicRecovered, r, cleanedStack())
 				return
 			}
+			// Otherwise, create an error from the panic, and return it.
+			err = fmt.Errorf("%w: %v\n%s", ErrPanicRecovered, r, cleanedStack())
+
+			return
 		}
 	}()
 

--- a/ext/dispatcher_test.go
+++ b/ext/dispatcher_test.go
@@ -28,7 +28,6 @@ func TestDispatcherStop(t *testing.T) {
 	if !waited {
 		t.Errorf("Dispatcher was stopped before the updates were done being handled.")
 	}
-
 }
 
 func TestLimitedDispatcherStop(t *testing.T) {

--- a/ext/handlers/callbackquery.go
+++ b/ext/handlers/callbackquery.go
@@ -9,9 +9,9 @@ import (
 )
 
 type CallbackQuery struct {
-	AllowChannel bool
 	Filter       filters.CallbackQuery
 	Response     Response
+	AllowChannel bool
 }
 
 func NewCallback(filter filters.CallbackQuery, r Response) CallbackQuery {

--- a/ext/handlers/conversation.go
+++ b/ext/handlers/conversation.go
@@ -36,14 +36,14 @@ type Conversation struct {
 }
 
 type ConversationOpts struct {
+	// StateStorage is responsible for storing all running conversations.
+	StateStorage conversation.Storage
 	// Exits is the list of handlers to exit the current conversation partway (eg /cancel commands)
 	Exits []ext.Handler
 	// Fallbacks is the list of handlers to handle updates which haven't been matched by any states.
 	Fallbacks []ext.Handler
 	// If True, a user can restart the conversation by hitting one of the entry points.
 	AllowReEntry bool
-	// StateStorage is responsible for storing all running conversations.
-	StateStorage conversation.Storage
 }
 
 func NewConversation(entryPoints []ext.Handler, states map[string][]ext.Handler, opts *ConversationOpts) Conversation {
@@ -122,10 +122,10 @@ func (c Conversation) HandleUpdate(b *gotgbot.Bot, ctx *ext.Context) error {
 type ConversationStateChange struct {
 	// The next state to handle in the current conversation.
 	NextState *string
-	// End the current conversation
-	End bool
 	// Move the parent conversation (if any) to the desired state.
 	ParentState *ConversationStateChange
+	// End the current conversation
+	End bool
 }
 
 func (s *ConversationStateChange) Error() string {

--- a/ext/handlers/conversation_test.go
+++ b/ext/handlers/conversation_test.go
@@ -136,6 +136,7 @@ func TestFallbackConversation(t *testing.T) {
 	// Ensure conversation has ended.
 	checkExpectedState(t, &conv, cancelCommand, "")
 }
+
 func TestReEntryConversation(t *testing.T) {
 	b := NewTestBot()
 

--- a/ext/handlers/filters/message/message.go
+++ b/ext/handlers/filters/message/message.go
@@ -101,7 +101,6 @@ func Text(msg *gotgbot.Message) bool {
 func HasPrefix(prefix string) filters.Message {
 	return func(msg *gotgbot.Message) bool {
 		return strings.HasPrefix(msg.Text, prefix) || strings.HasSuffix(msg.Caption, prefix)
-
 	}
 }
 

--- a/samples/echoMultiBot/main.go
+++ b/samples/echoMultiBot/main.go
@@ -18,7 +18,6 @@ import (
 // It also shows how to stop the bot gracefully using the Updater.Stop() mechanism.
 // It has options to use either polling or webhooks.
 func main() {
-
 	// Get comma separated bot tokens from environment variable
 	tokens := os.Getenv("TOKENS")
 	if tokens == "" {

--- a/scripts/generate/main.go
+++ b/scripts/generate/main.go
@@ -78,7 +78,7 @@ func updatePinnedCommit() (string, error) {
 
 	commit := res[0].Sha
 
-	err = os.WriteFile(specCommitFileName, []byte(commit), 0600)
+	err = os.WriteFile(specCommitFileName, []byte(commit), 0o600)
 	if err != nil {
 		return "", fmt.Errorf("failed to update commit pin file: %w", err)
 	}


### PR DESCRIPTION
The Go garbage collector scans for pointers to free referenced objects in every allocated structures up to the last field that potentially reference something.

By moving reference field to the beginning of the structure this allows the GC to fetch less often from memory as they can fetch the whole referenced part of the structure in one operation if it fits the CPU cacheline size

For example, `handlers.Conversation` became a consolidated 48 bytes of pointers instead of 72 bytes. If we follow 10 000 conversations this may well reduce the GC interruption time.

Of course, they are numerous factors (like a change of the Go runtime GC implementation in the future) that can make this optimisation useless, but as far as Go 1.19, there is no harm to try.

Others seldom allocated structures are not pointer-aligned, but as changing their order may break users using unnamed fields, better not to change them.