### PR TITLE
Add support for auto-generating ChatTypes constants.

### DIFF
--- a/gen_consts.go
+++ b/gen_consts.go
@@ -35,3 +35,11 @@ const (
 	StickerTypeMask        = "mask"
 	StickerTypeCustomEmoji = "custom_emoji"
 )
+
+// The consts listed below represent all the chat types that can be obtained from telegram.
+const (
+	ChatTypePrivate    = "private"
+	ChatTypeGroup      = "group"
+	ChatTypeSupergroup = "supergroup"
+	ChatTypeChannel    = "channel"
+)

--- a/scripts/generate/consts.go
+++ b/scripts/generate/consts.go
@@ -24,13 +24,13 @@ package gotgbot
 
 	consts.WriteString(generateParseModeConsts())
 
-	stickerTypeConsts, err := generateStickerTypeConsts(d)
+	stickerTypeConsts, err := generateTypeConsts(d, "Sticker")
 	if err != nil {
 		return fmt.Errorf("failed to generate consts for sticker types: %w", err)
 	}
 	consts.WriteString(stickerTypeConsts)
 
-	chatTypeConsts, err := generateChatTypeConsts(d)
+	chatTypeConsts, err := generateTypeConsts(d, "Chat")
 	if err != nil {
 		return fmt.Errorf("failed to generate consts for chat types: %w", err)
 	}
@@ -59,13 +59,13 @@ func generateUpdateTypeConsts(d APIDescription) (string, error) {
 	return out.String(), nil
 }
 
-func generateStickerTypeConsts(d APIDescription) (string, error) {
-	updType, ok := d.Types["Sticker"]
+func generateTypeConsts(d APIDescription, typeName string) (string, error) {
+	updType, ok := d.Types[typeName]
 	if !ok {
-		return "", errors.New("missing 'Sticker' type data")
+		return "", errors.New("missing '" + typeName + "' type data")
 	}
 	out := strings.Builder{}
-	out.WriteString("// The consts listed below represent all the sticker types that can be obtained from telegram.\n")
+	out.WriteString("// The consts listed below represent all the " + strings.ToLower(typeName) + " types that can be obtained from telegram.\n")
 	out.WriteString("const (\n")
 	for _, f := range updType.Fields {
 		if f.Name != "type" {
@@ -77,33 +77,7 @@ func generateStickerTypeConsts(d APIDescription) (string, error) {
 			return "", fmt.Errorf("failed to get quoted types: %w", err)
 		}
 		for _, t := range types {
-			constName := "StickerType" + snakeToTitle(t)
-			out.WriteString(writeConst(constName, t))
-		}
-	}
-	out.WriteString(")\n\n")
-	return out.String(), nil
-}
-
-func generateChatTypeConsts(d APIDescription) (string, error) {
-	updType, ok := d.Types["Chat"]
-	if !ok {
-		return "", errors.New("missing 'Chat' type data")
-	}
-	out := strings.Builder{}
-	out.WriteString("// The consts listed below represent all the chat types that can be obtained from telegram.\n")
-	out.WriteString("const (\n")
-	for _, f := range updType.Fields {
-		if f.Name != "type" {
-			// the field we want to look at is called "type", ignore all others.
-			continue
-		}
-		types, err := extractQuotedValues(f.Description)
-		if err != nil {
-			return "", fmt.Errorf("failed to get quoted types: %w", err)
-		}
-		for _, t := range types {
-			constName := "ChatType" + snakeToTitle(t)
+			constName := typeName + "Type" + snakeToTitle(t)
 			out.WriteString(writeConst(constName, t))
 		}
 	}


### PR DESCRIPTION

<!--
Hey, thank you for opening a PR!

Please fill out the details below; they're there to help both you and the maintainers!
-->

# What
Since we already have [UpdateType](https://github.com/PaulSonOfLars/gotgbot/blob/371f60d4841ef41c6b99542f3157f97be45ca5c9/gen_consts.go#L7), [ParseMode](https://github.com/PaulSonOfLars/gotgbot/blob/371f60d4841ef41c6b99542f3157f97be45ca5c9/gen_consts.go#L25) and [StickerType](https://github.com/PaulSonOfLars/gotgbot/blob/371f60d4841ef41c6b99542f3157f97be45ca5c9/gen_consts.go#L33) constants, I thought it's better we have `ChatType` constants as well (this makes it easy to do comparison on `Chat.Type` field on custom filters/handlers for us)

# Impact

- Are your changes backwards compatible? Yes.
- Have you included documentation, or updated existing documentation? Yes.
- Do errors and log messages provide enough context? Yes.
