### PR TITLE
Use go mod edit for ensuring sample bot go mod files

### DIFF
--- a/scripts/ci/ensure-consistent-sample-mod-files.sh
+++ b/scripts/ci/ensure-consistent-sample-mod-files.sh
@@ -6,13 +6,7 @@ SAMPLES_DIR="samples"
 REPO="github.com/PaulSonOfLars/gotgbot" # Current library import path
 GO_VERSION="1.15"                       # Go version we expect our samples to be using
 V_MAJOR="v2"                            # Current major version for the library
-
-# We need to do some bash magic for systems that aren't using gnused
-sedCmd="sed"
-if [[ "$(uname)" == "Darwin" ]]; then
-  command -v gsed || (echo "gnu-sed not installed. Please install with 'brew install gnu-sed'" && return 1)
-  sedCmd="gsed"
-fi
+V_DUMMY="v2.99.99"                      # dummy version for the library
 
 for d in "${SAMPLES_DIR}"/*; do
   if [ ! -d "${d}" ]; then
@@ -20,13 +14,23 @@ for d in "${SAMPLES_DIR}"/*; do
     continue
   fi
 
-  echo "Checking ${d}"
-  # Ensure the module has the right name
-  "${sedCmd}" -i "s:^module .*:module ${REPO}/${d}:g" "${d}/go.mod"
+  goModFile="${d}/go.mod"
+  echo "Checking ${goModFile}"
 
-  # Ensure the current library version is a dummy version to avoid confusion
-  "${sedCmd}" -i "s:${REPO}/${V_MAJOR} ${V_MAJOR}.*$:${REPO}/${V_MAJOR} ${V_MAJOR}.99.99:g" "${d}/go.mod"
+  pushd "${d}" >/dev/null
 
-  # Ensure go version is consistent
-  "${sedCmd}" -i "s:^go .*:go ${GO_VERSION}:g" "${d}/go.mod"
+  # Ensure the following are correct:
+  # - module name
+  # - go version
+  # - library version (set to a dummy version to avoid needing constant updates)
+  # - library replace to use the lib in the repo
+  go mod edit \
+    -module "${REPO}/${d}" \
+    -go="${GO_VERSION}" \
+    -require="${REPO}/${V_MAJOR}@${V_DUMMY}" \
+    -replace="${REPO}/${V_MAJOR}=../../"
+
+  go mod tidy
+
+  popd >/dev/null
 done


### PR DESCRIPTION

# What

Replace sed usage with `go mod edit ...` commands to reduce script brittle-ness.

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
