### PR TITLE
Improve code generation

### DIFF
--- a/gen_helpers.go
+++ b/gen_helpers.go
@@ -196,11 +196,6 @@ func (c Chat) GetMenuButton(b *Bot, opts *GetChatMenuButtonOpts) (MenuButton, er
 	return b.GetChatMenuButton(opts)
 }
 
-// Get Helper method for Bot.GetFile
-func (f File) Get(b *Bot, opts *GetFileOpts) (*File, error) {
-	return b.GetFile(f.FileId, opts)
-}
-
 // GetProfilePhotos Helper method for Bot.GetUserProfilePhotos
 func (u User) GetProfilePhotos(b *Bot, opts *GetUserProfilePhotosOpts) (*UserProfilePhotos, error) {
 	return b.GetUserProfilePhotos(u.Id, opts)

--- a/scripts/generate/common.go
+++ b/scripts/generate/common.go
@@ -114,6 +114,9 @@ func getDefaultReturnVals(d APIDescription, types []string) []string {
 	return retVals
 }
 
+// goTypeStringer provides us with the fmt strings that allow us to convert basic types into strings.
+// For example, we define how to handle ints, bools, and strings.
+// More complicated types should be handled separately.
 func goTypeStringer(t string) string {
 	switch t {
 	case "int64":
@@ -200,6 +203,15 @@ func getCommonFields(types []TypeDescription) []Field {
 	return fields
 }
 
+// getFieldNames turns a list of fields into a list of the field's names, as described.
+func getFieldNames(fs []Field) (out []string) {
+	for _, t := range fs {
+		out = append(out, t.Name)
+	}
+	return out
+}
+
+// getReplyMarkupTypes gets all the different types which are used in "reply_markup" fields.
 func getReplyMarkupTypes(d APIDescription) []TypeDescription {
 	typesMap := map[string]struct{}{}
 	for _, m := range d.Methods {

--- a/scripts/generate/gen.go
+++ b/scripts/generate/gen.go
@@ -159,11 +159,10 @@ const (
 	tgTypeFloat   = "Float"
 	tgTypeInteger = "Integer"
 	// These are all custom telegram types.
-	tgTypeMessage      = "Message"
-	tgTypeFile         = "File"
-	tgTypeInputFile    = "InputFile"
-	tgTypeInputMedia   = "InputMedia"
-	tgTypeInputSticker = "InputSticker"
+	tgTypeMessage    = "Message"
+	tgTypeFile       = "File"
+	tgTypeInputFile  = "InputFile"
+	tgTypeInputMedia = "InputMedia"
 	// This is actually a custom type.
 	tgTypeReplyMarkup = "ReplyMarkup"
 )

--- a/scripts/generate/helpers.go
+++ b/scripts/generate/helpers.go
@@ -46,6 +46,10 @@ func generateHelperDef(d APIDescription, tgMethod MethodDescription) (string, er
 	}
 
 	for _, typeName := range orderedTgTypes(d) {
+		if typeName == tgTypeFile {
+			continue
+		}
+
 		tgType := d.Types[typeName]
 
 		newMethodName := strings.Replace(tgMethod.Name, typeName, "", 1)
@@ -53,10 +57,7 @@ func generateHelperDef(d APIDescription, tgMethod MethodDescription) (string, er
 			continue
 		}
 
-		fields := map[string]string{}
-
-		getMethodFieldsTypeMatches(tgMethod, typeName, fields)
-
+		fields := getMethodFieldsTypeMatches(tgMethod, typeName)
 		if len(fields) == 0 {
 			continue
 		}
@@ -176,7 +177,8 @@ func getMethodFieldsSubtypeMatches(d APIDescription, tgMethod MethodDescription,
 	return repl, nil
 }
 
-func getMethodFieldsTypeMatches(tgMethod MethodDescription, typeName string, fields map[string]string) {
+func getMethodFieldsTypeMatches(tgMethod MethodDescription, typeName string) map[string]string {
+	fields := map[string]string{}
 	for _, f := range tgMethod.Fields {
 		if f.Name == titleToSnake(typeName)+"_id" || f.Name == "id" {
 			idField := "id"
@@ -190,6 +192,7 @@ func getMethodFieldsTypeMatches(tgMethod MethodDescription, typeName string, fie
 			fields[titleToSnake(typeName)+"_id"] = idField
 		}
 	}
+	return fields
 }
 
 var helperFuncTmpl = template.Must(template.New("helperFunc").Parse(helperFunc))

--- a/scripts/generate/types.go
+++ b/scripts/generate/types.go
@@ -442,7 +442,7 @@ func generateGenericInterfaceType(d APIDescription, name string, subtypes []Type
 		return "", fmt.Errorf("failed to check if %s types all contain inputfiles: %w", name, err)
 	}
 
-	// If the inputfile is a common field, return true.
+	// If the inputfile is a common field, then the interface contains fields.
 	hasInputFile = hasInputFile && contains(fieldName, getFieldNames(commonFields))
 
 	bd := strings.Builder{}

--- a/scripts/generate/types.go
+++ b/scripts/generate/types.go
@@ -103,6 +103,24 @@ func generateTypeDef(d APIDescription, tgType TypeDescription) (string, error) {
 	return typeDef.String(), nil
 }
 
+// fieldContainsInputFile checks whether the field's type contains any inputfiles, and thus might be used to send data.
+func fieldContainsInputFile(d APIDescription, field Field) (bool, error) {
+	goType, err := field.getPreferredType()
+	if err != nil {
+		return false, err
+	}
+	cleanName := strings.TrimPrefix(goType, "[]")
+	tgType, ok := d.Types[cleanName]
+	if !ok {
+		return false, nil
+	}
+
+	ok, _, err = containsInputFile(d, tgType, map[string]bool{})
+	return ok, err
+}
+
+// containsInputFile returns a boolean to indicate whether or not tgType contains an InputFile.
+// If true, it also returns the field name of that inputfile.
 func containsInputFile(d APIDescription, tgType TypeDescription, checked map[string]bool) (bool, string, error) {
 	// If already checked, we don't need to check again. This avoids infinite recursive loops.
 	if checked[tgType.Name] {
@@ -110,14 +128,20 @@ func containsInputFile(d APIDescription, tgType TypeDescription, checked map[str
 	}
 	checked[tgType.Name] = true
 
+	if tgType.Name == tgTypeInputMedia {
+		return true, "media", nil
+	}
+
 	for _, f := range tgType.Fields {
 		goType, err := f.getPreferredType()
 		if err != nil {
 			return false, "", err
 		}
+
 		if goType == tgTypeInputFile {
 			return true, f.Name, nil
 		}
+
 		if isTgType(d, goType) {
 			ok, _, err := containsInputFile(d, d.Types[goType], checked)
 			if err != nil {
@@ -413,6 +437,14 @@ func generateGenericInterfaceType(d APIDescription, name string, subtypes []Type
 
 	commonFields := getCommonFields(subtypes)
 
+	hasInputFile, fieldName, err := containsInputFile(d, subtypes[0], map[string]bool{})
+	if err != nil {
+		return "", fmt.Errorf("failed to check if %s types all contain inputfiles: %w", name, err)
+	}
+
+	// If the inputfile is a common field, return true.
+	hasInputFile = hasInputFile && contains(fieldName, getFieldNames(commonFields))
+
 	bd := strings.Builder{}
 	bd.WriteString(fmt.Sprintf("\ntype %s interface{", name))
 	for _, f := range commonFields {
@@ -427,7 +459,7 @@ func generateGenericInterfaceType(d APIDescription, name string, subtypes []Type
 	bd.WriteString(fmt.Sprintf("\n// %s exists to avoid external types implementing this interface.", titleToCamelCase(name)))
 	bd.WriteString(fmt.Sprintf("\n%s()", titleToCamelCase(name)))
 
-	if name == tgTypeInputMedia {
+	if hasInputFile {
 		bd.WriteString("\n// InputParams allows for uploading attachments with files.")
 		bd.WriteString("\nInputParams(string, map[string]NamedReader) ([]byte, error)")
 	}


### PR DESCRIPTION
# What

Improve code generation to avoid multiple hardcoded values, focusing on behaviour rather than type names.

Eg, instead of hardcoding that `InputMedia` requires an `InputParams` method, we can work it out by knowing that all `InputMedia` types contain `InputFile`s, and so will have data.

This also removes file.Get, which was a pointless helper method which just got the same file from an existing file, and so achieved nothing. Bad codegen there.

# Impact

- Are your changes backwards compatible? N - technically the removal of file.get is a breaking change, but i dont expect anyone to be relying on a useless method.
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
