### PR TITLE
Add better pointer checks, to handle interface situations

### DIFF
--- a/gen_methods.go
+++ b/gen_methods.go
@@ -955,7 +955,7 @@ func (bot *Bot) DeleteMessage(chatId int64, messageId int64, opts *DeleteMessage
 // DeleteMyCommandsOpts is the set of optional fields for Bot.DeleteMyCommands.
 type DeleteMyCommandsOpts struct {
 	// A JSON-serialized object, describing scope of users for which the commands are relevant. Defaults to BotCommandScopeDefault.
-	Scope *BotCommandScope
+	Scope BotCommandScope
 	// A two-letter ISO 639-1 language code. If empty, commands will be applied to all users from the given scope, for whose language there are no dedicated commands
 	LanguageCode string
 	// RequestOpts are an additional optional field to configure timeouts for individual requests
@@ -969,13 +969,11 @@ type DeleteMyCommandsOpts struct {
 func (bot *Bot) DeleteMyCommands(opts *DeleteMyCommandsOpts) (bool, error) {
 	v := map[string]string{}
 	if opts != nil {
-		if opts.Scope != nil {
-			bs, err := json.Marshal(opts.Scope)
-			if err != nil {
-				return false, fmt.Errorf("failed to marshal field scope: %w", err)
-			}
-			v["scope"] = string(bs)
+		bs, err := json.Marshal(opts.Scope)
+		if err != nil {
+			return false, fmt.Errorf("failed to marshal field scope: %w", err)
 		}
+		v["scope"] = string(bs)
 		v["language_code"] = opts.LanguageCode
 	}
 
@@ -1937,7 +1935,7 @@ func (bot *Bot) GetMe(opts *GetMeOpts) (*User, error) {
 // GetMyCommandsOpts is the set of optional fields for Bot.GetMyCommands.
 type GetMyCommandsOpts struct {
 	// A JSON-serialized object, describing scope of users. Defaults to BotCommandScopeDefault.
-	Scope *BotCommandScope
+	Scope BotCommandScope
 	// A two-letter ISO 639-1 language code or an empty string
 	LanguageCode string
 	// RequestOpts are an additional optional field to configure timeouts for individual requests
@@ -1951,13 +1949,11 @@ type GetMyCommandsOpts struct {
 func (bot *Bot) GetMyCommands(opts *GetMyCommandsOpts) ([]BotCommand, error) {
 	v := map[string]string{}
 	if opts != nil {
-		if opts.Scope != nil {
-			bs, err := json.Marshal(opts.Scope)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field scope: %w", err)
-			}
-			v["scope"] = string(bs)
+		bs, err := json.Marshal(opts.Scope)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal field scope: %w", err)
 		}
+		v["scope"] = string(bs)
 		v["language_code"] = opts.LanguageCode
 	}
 
@@ -4369,7 +4365,7 @@ type SetChatMenuButtonOpts struct {
 	// Unique identifier for the target private chat. If not specified, default bot's menu button will be changed
 	ChatId *int64
 	// A JSON-serialized object for the bot's new menu button. Defaults to MenuButtonDefault
-	MenuButton *MenuButton
+	MenuButton MenuButton
 	// RequestOpts are an additional optional field to configure timeouts for individual requests
 	RequestOpts *RequestOpts
 }
@@ -4384,13 +4380,11 @@ func (bot *Bot) SetChatMenuButton(opts *SetChatMenuButtonOpts) (bool, error) {
 		if opts.ChatId != nil {
 			v["chat_id"] = strconv.FormatInt(*opts.ChatId, 10)
 		}
-		if opts.MenuButton != nil {
-			bs, err := json.Marshal(opts.MenuButton)
-			if err != nil {
-				return false, fmt.Errorf("failed to marshal field menu_button: %w", err)
-			}
-			v["menu_button"] = string(bs)
+		bs, err := json.Marshal(opts.MenuButton)
+		if err != nil {
+			return false, fmt.Errorf("failed to marshal field menu_button: %w", err)
 		}
+		v["menu_button"] = string(bs)
 	}
 
 	var reqOpts *RequestOpts
@@ -4655,7 +4649,7 @@ func (bot *Bot) SetGameScore(userId int64, score int64, opts *SetGameScoreOpts) 
 // SetMyCommandsOpts is the set of optional fields for Bot.SetMyCommands.
 type SetMyCommandsOpts struct {
 	// A JSON-serialized object, describing scope of users for which the commands are relevant. Defaults to BotCommandScopeDefault.
-	Scope *BotCommandScope
+	Scope BotCommandScope
 	// A two-letter ISO 639-1 language code. If empty, commands will be applied to all users from the given scope, for whose language there are no dedicated commands
 	LanguageCode string
 	// RequestOpts are an additional optional field to configure timeouts for individual requests
@@ -4677,13 +4671,11 @@ func (bot *Bot) SetMyCommands(commands []BotCommand, opts *SetMyCommandsOpts) (b
 		v["commands"] = string(bs)
 	}
 	if opts != nil {
-		if opts.Scope != nil {
-			bs, err := json.Marshal(opts.Scope)
-			if err != nil {
-				return false, fmt.Errorf("failed to marshal field scope: %w", err)
-			}
-			v["scope"] = string(bs)
+		bs, err := json.Marshal(opts.Scope)
+		if err != nil {
+			return false, fmt.Errorf("failed to marshal field scope: %w", err)
 		}
+		v["scope"] = string(bs)
 		v["language_code"] = opts.LanguageCode
 	}
 

--- a/scripts/generate/common.go
+++ b/scripts/generate/common.go
@@ -69,16 +69,6 @@ func toGoType(s string) string {
 	return pref + s
 }
 
-func isBaseGoType(s string) bool {
-	s = stripPointersAndArrays(s)
-	for _, v := range tgToGoTypeMap {
-		if s == v {
-			return true
-		}
-	}
-	return false
-}
-
 func stripPointersAndArrays(retType string) string {
 	for isPointer(retType) {
 		retType = strings.TrimPrefix(retType, "*")

--- a/scripts/generate/helpers.go
+++ b/scripts/generate/helpers.go
@@ -114,7 +114,7 @@ func generateHelperArguments(d APIDescription, tgMethod MethodDescription, recei
 	for _, mf := range tgMethod.Fields {
 		hasOpts = hasOpts || !mf.Required
 
-		prefType, err := mf.getPreferredType()
+		prefType, err := mf.getPreferredType(d)
 		if err != nil {
 			return nil, nil, "", fmt.Errorf("failed to get preferred type for field %s of %s: %w", mf.Name, tgMethod.Name, err)
 		}
@@ -158,7 +158,7 @@ func getMethodFieldsSubtypeMatches(d APIDescription, tgMethod MethodDescription,
 		}
 
 		for _, mf := range tgMethod.Fields {
-			prefType, err := f.getPreferredType()
+			prefType, err := f.getPreferredType(d)
 			if err != nil {
 				return "", fmt.Errorf("failed to get preferred type for field %s of %s: %w", mf.Name, tgMethod.Name, err)
 			}

--- a/scripts/generate/methods.go
+++ b/scripts/generate/methods.go
@@ -57,7 +57,7 @@ func generateMethodDef(d APIDescription, tgMethod MethodDescription) (string, er
 	}
 
 	// Generate method description
-	desc, err := tgMethod.description()
+	desc, err := tgMethod.description(d)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate method description for %s: %w", tgMethod.Name, err)
 	}
@@ -113,7 +113,7 @@ func generateMethodSignature(d APIDescription, tgMethod MethodDescription) (stri
 		return "", nil, "", fmt.Errorf("failed to get return for %s: %w", tgMethod.Name, err)
 	}
 
-	args, optionalsStruct, err := tgMethod.getArgs()
+	args, optionalsStruct, err := tgMethod.getArgs(d)
 	if err != nil {
 		return "", nil, "", fmt.Errorf("failed to get args for method %s: %w", tgMethod.Name, err)
 	}
@@ -169,7 +169,7 @@ return %s, true, nil
 	return returnString.String(), nil
 }
 
-func (m MethodDescription) description() (string, error) {
+func (m MethodDescription) description(d APIDescription) (string, error) {
 	description := strings.Builder{}
 
 	description.WriteString(m.docs())
@@ -179,7 +179,7 @@ func (m MethodDescription) description() (string, error) {
 			continue
 		}
 
-		prefType, err := f.getPreferredType()
+		prefType, err := f.getPreferredType(d)
 		if err != nil {
 			return "", err
 		}
@@ -236,7 +236,7 @@ func (m MethodDescription) argsToValues(d APIDescription, methodName string, def
 }
 
 func generateValue(d APIDescription, methodName string, f Field, goParam string, defaultRetVal string) (string, bool, error) {
-	fieldType, err := f.getPreferredType()
+	fieldType, err := f.getPreferredType(d)
 	if err != nil {
 		return "", false, fmt.Errorf("failed to get preferred type: %w", err)
 	}
@@ -367,12 +367,12 @@ func getRetVarName(retType string) string {
 	return strings.ToLower(retType[:1])
 }
 
-func (m MethodDescription) getArgs() (string, string, error) {
+func (m MethodDescription) getArgs(d APIDescription) (string, string, error) {
 	var requiredArgs []string
 	optionals := strings.Builder{}
 
 	for _, f := range m.Fields {
-		fieldType, err := f.getPreferredType()
+		fieldType, err := f.getPreferredType(d)
 		if err != nil {
 			return "", "", fmt.Errorf("failed to get preferred type: %w", err)
 		}


### PR DESCRIPTION
# What

Fix an inconvenience in the latest release which made sending botcommandscopes more verbose than necessary due to some unnecessary pointer magic

# Impact

- Are your changes backwards compatible? No, but for good reason
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
