### PR TITLE
[BUGFIX] Use conversation reentry option which wasnt being used

### DIFF
--- a/ext/handlers/conversation.go
+++ b/ext/handlers/conversation.go
@@ -57,6 +57,7 @@ func NewConversation(entryPoints []ext.Handler, states map[string][]ext.Handler,
 	if opts != nil {
 		c.Exits = opts.Exits
 		c.Fallbacks = opts.Fallbacks
+		c.AllowReEntry = opts.AllowReEntry
 
 		// If no StateStorage is specified, we should keep the default.
 		if opts.StateStorage != nil {

--- a/ext/handlers/conversation_test.go
+++ b/ext/handlers/conversation_test.go
@@ -155,7 +155,7 @@ func TestReEntryConversation(t *testing.T) {
 			})},
 		},
 		&handlers.ConversationOpts{
-			AllowReEntry: true, // Enable reentry
+			AllowReEntry: true,
 		},
 	)
 

--- a/ext/handlers/conversation_test.go
+++ b/ext/handlers/conversation_test.go
@@ -154,10 +154,10 @@ func TestReEntryConversation(t *testing.T) {
 				return handlers.EndConversation()
 			})},
 		},
-		nil,
+		&handlers.ConversationOpts{
+			AllowReEntry: true, // Enable reentry
+		},
 	)
-	// Enable reentry
-	conv.AllowReEntry = true
 
 	var userId int64 = 123
 	var chatId int64 = 1234

--- a/samples/conversationBot/main.go
+++ b/samples/conversationBot/main.go
@@ -60,6 +60,7 @@ func main() {
 		&handlers.ConversationOpts{
 			Exits:        []ext.Handler{handlers.NewCommand("cancel", cancel)},
 			StateStorage: conversation.NewInMemoryStorage(conversation.KeyStrategySenderAndChat),
+			AllowReEntry: true,
 		},
 	))
 


### PR DESCRIPTION
# What

Fix Issue raised in #91 caused by a missing opt in the NewConversation call.

Also, fix a test which should have caught this issue.

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? N/A
- Do errors and log messages provide enough context? Y
