### PR TITLE
Call DeleteWebhook before starting the polling loop

### DIFF
--- a/ext/updater.go
+++ b/ext/updater.go
@@ -129,6 +129,8 @@ type PollingOpts struct {
 	GetUpdatesOpts *gotgbot.GetUpdatesOpts
 }
 
+var ErrInvalidPendingUpdateAndWebhookConfiguration = errors.New("pending updates cannot be dropped without webhook deletion; consider setting the offset to -1 instead of enabling DropPendingUpdates")
+
 // StartPolling starts polling updates from telegram using getUpdates long-polling.
 // See PollingOpts for optional values to set in production environments.
 func (u *Updater) StartPolling(b *gotgbot.Bot, opts *PollingOpts) error {
@@ -149,7 +151,7 @@ func (u *Updater) StartPolling(b *gotgbot.Bot, opts *PollingOpts) error {
 			// opts.DropPendingUpdates depends on webhook deletion being enabled.
 			// If webhook deletions are disabled, the user should consider setting the offset to -1 instead.
 			// This is not perfect, but achieves nearly the same effect.
-			return errors.New("pending updates cannot be dropped without webhook deletion; consider setting the offset to -1 instead of enabling DropPendingUpdates")
+			return ErrInvalidPendingUpdateAndWebhookConfiguration
 		}
 
 		if !opts.DisableWebhookDeletion {

--- a/samples/callbackqueryBot/main.go
+++ b/samples/callbackqueryBot/main.go
@@ -55,7 +55,7 @@ func main() {
 	// Start receiving updates.
 	err = updater.StartPolling(b, &ext.PollingOpts{
 		DropPendingUpdates: true,
-		GetUpdatesOpts: gotgbot.GetUpdatesOpts{
+		GetUpdatesOpts: &gotgbot.GetUpdatesOpts{
 			Timeout: 9,
 			RequestOpts: &gotgbot.RequestOpts{
 				Timeout: time.Second * 10,

--- a/samples/commandBot/main.go
+++ b/samples/commandBot/main.go
@@ -55,7 +55,7 @@ func main() {
 	// Start receiving updates.
 	err = updater.StartPolling(b, &ext.PollingOpts{
 		DropPendingUpdates: true,
-		GetUpdatesOpts: gotgbot.GetUpdatesOpts{
+		GetUpdatesOpts: &gotgbot.GetUpdatesOpts{
 			Timeout: 9,
 			RequestOpts: &gotgbot.RequestOpts{
 				Timeout: time.Second * 10,

--- a/samples/conversationBot/main.go
+++ b/samples/conversationBot/main.go
@@ -67,7 +67,7 @@ func main() {
 	// Start receiving updates.
 	err = updater.StartPolling(b, &ext.PollingOpts{
 		DropPendingUpdates: true,
-		GetUpdatesOpts: gotgbot.GetUpdatesOpts{
+		GetUpdatesOpts: &gotgbot.GetUpdatesOpts{
 			Timeout: 9,
 			RequestOpts: &gotgbot.RequestOpts{
 				Timeout: time.Second * 10,

--- a/samples/echoBot/main.go
+++ b/samples/echoBot/main.go
@@ -52,7 +52,7 @@ func main() {
 	// Start receiving updates.
 	err = updater.StartPolling(b, &ext.PollingOpts{
 		DropPendingUpdates: true,
-		GetUpdatesOpts: gotgbot.GetUpdatesOpts{
+		GetUpdatesOpts: &gotgbot.GetUpdatesOpts{
 			Timeout: 9,
 			RequestOpts: &gotgbot.RequestOpts{
 				Timeout: time.Second * 10,

--- a/samples/echoMultiBot/main.go
+++ b/samples/echoMultiBot/main.go
@@ -98,7 +98,7 @@ func startLongPollingBots(updater *ext.Updater, bots []*gotgbot.Bot) error {
 	for idx, b := range bots {
 		err := updater.StartPolling(b, &ext.PollingOpts{
 			DropPendingUpdates: true,
-			GetUpdatesOpts: gotgbot.GetUpdatesOpts{
+			GetUpdatesOpts: &gotgbot.GetUpdatesOpts{
 				Timeout: 9,
 				RequestOpts: &gotgbot.RequestOpts{
 					Timeout: time.Second * 10,

--- a/samples/inlinequeryBot/main.go
+++ b/samples/inlinequeryBot/main.go
@@ -58,7 +58,7 @@ func main() {
 	// Start receiving updates.
 	err = updater.StartPolling(b, &ext.PollingOpts{
 		DropPendingUpdates: true,
-		GetUpdatesOpts: gotgbot.GetUpdatesOpts{
+		GetUpdatesOpts: &gotgbot.GetUpdatesOpts{
 			Timeout: 9,
 			RequestOpts: &gotgbot.RequestOpts{
 				Timeout: time.Second * 10,

--- a/samples/middlewareBot/main.go
+++ b/samples/middlewareBot/main.go
@@ -56,7 +56,7 @@ func main() {
 	// Start receiving updates.
 	err = updater.StartPolling(b, &ext.PollingOpts{
 		DropPendingUpdates: true,
-		GetUpdatesOpts: gotgbot.GetUpdatesOpts{
+		GetUpdatesOpts: &gotgbot.GetUpdatesOpts{
 			Timeout: 9,
 			RequestOpts: &gotgbot.RequestOpts{
 				Timeout: time.Second * 10,


### PR DESCRIPTION

# What
Call DeleteWebhook before starting the long polling loop, simplifying the long polling code.
Also, add a new `DisableWebhookDeletion` option, which allows you to manage webhook deletion yourself.

As a drive-by, improve docs and comments.

# Impact

- Are your changes backwards compatible? No - changed the GetUpdateOpts in the StartPolling method to use a pointer instead of a value.
- Have you included documentation, or updated existing documentation? Yes
- Do errors and log messages provide enough context? Yes
