### PR TITLE
Provide Logger interface to use non-std loggers

### DIFF
--- a/ext/dispatcher.go
+++ b/ext/dispatcher.go
@@ -65,7 +65,7 @@ type Dispatcher struct {
 	UnhandledErrFunc ErrorFunc
 	// ErrorLog specifies an optional logger for unexpected behavior from handlers.
 	// If nil, logging is done via the log package's standard logger.
-	ErrorLog *log.Logger
+	ErrorLog Logger
 
 	// handlerGroups represents the list of available handler groups, numerically sorted.
 	handlerGroups []int
@@ -95,7 +95,7 @@ type DispatcherOpts struct {
 	UnhandledErrFunc ErrorFunc
 	// ErrorLog specifies an optional logger for unexpected behavior from handlers.
 	// If nil, logging is done via the log package's standard logger.
-	ErrorLog *log.Logger
+	ErrorLog Logger
 
 	// MaxRoutines is used to decide how to limit the number of goroutines spawned by the dispatcher.
 	// This defines how many updates can be processed at the same time.
@@ -110,7 +110,7 @@ func NewDispatcher(opts *DispatcherOpts) *Dispatcher {
 	var errHandler DispatcherErrorHandler
 	var panicHandler DispatcherPanicHandler
 	var unhandledErrFunc ErrorFunc
-	var errLog *log.Logger
+	var errLog Logger
 
 	maxRoutines := DefaultMaxRoutines
 

--- a/ext/log.go
+++ b/ext/log.go
@@ -1,0 +1,10 @@
+package ext
+
+import "log"
+
+// Logger is an interface to use non standard loggers.
+type Logger interface {
+	Printf(format string, v ...interface{})
+}
+
+var _ Logger = log.Default()

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -45,7 +45,7 @@ type Updater struct {
 	UnhandledErrFunc ErrorFunc
 	// ErrorLog specifies an optional logger for unexpected behavior from handlers.
 	// If nil, logging is done via the log package's standard logger.
-	ErrorLog *log.Logger
+	ErrorLog Logger
 
 	// stopIdling is the channel that blocks the main thread from exiting, to keep the bots running.
 	stopIdling chan struct{}
@@ -65,7 +65,7 @@ type UpdaterOpts struct {
 	UnhandledErrFunc ErrorFunc
 	// ErrorLog specifies an optional logger for unexpected behavior from handlers.
 	// If nil, logging is done via the log package's standard logger.
-	ErrorLog *log.Logger
+	ErrorLog Logger
 	// The dispatcher instance to be used by the updater.
 	Dispatcher *Dispatcher
 }
@@ -73,7 +73,7 @@ type UpdaterOpts struct {
 // NewUpdater Creates a new Updater, as well as the necessary structures required for the associated Dispatcher.
 func NewUpdater(opts *UpdaterOpts) *Updater {
 	var unhandledErrFunc ErrorFunc
-	var errLog *log.Logger
+	var errLog Logger
 
 	// Default dispatcher, no special settings.
 	dispatcher := NewDispatcher(nil)


### PR DESCRIPTION
# What
Provides an ability to use non standard loggers. `*log.Logger` is too limited and providing an interface instead of that concrete type  makes integration with any other loggers much easier.

# Impact
- Are your changes backward compatible?
Yes. A compile time test is provided to make sure that the new interface is compatible with `*log.Logger`

- Have you included documentation, or updated existing documentation?
Comment to the interface was added.

- Do errors and log messages provide enough context?
Additioanl logs are not required...
