### PR TITLE
Make the Updater's multibot state thread safe

### DIFF
--- a/ext/botmapping.go
+++ b/ext/botmapping.go
@@ -44,18 +44,6 @@ func (m *botMapping) addBot(b *gotgbot.Bot, updateChan chan json.RawMessage, pol
 	}
 }
 
-// stopAllBots Stops all bots.
-func (m *botMapping) stopAllBots() {
-	m.mux.Lock()
-	defer m.mux.Unlock()
-
-	// Close all the update channels and polling loops
-	for key, bData := range m.mapping {
-		stopBot(bData)
-		delete(m.mapping, key)
-	}
-}
-
 func (m *botMapping) removeBot(b *gotgbot.Bot) (botData, bool) {
 	m.mux.Lock()
 	defer m.mux.Unlock()
@@ -67,6 +55,18 @@ func (m *botMapping) removeBot(b *gotgbot.Bot) (botData, bool) {
 
 	delete(m.mapping, b.Token)
 	return bData, true
+}
+
+func (m *botMapping) removeAllBots() []botData {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	bots := make([]botData, 0, len(m.mapping))
+	for key, bData := range m.mapping {
+		bots = append(bots, bData)
+		delete(m.mapping, key)
+	}
+	return bots
 }
 
 func (m *botMapping) getBots() []botData {

--- a/ext/botmapping.go
+++ b/ext/botmapping.go
@@ -52,16 +52,16 @@ func (m *botMapping) addBot(b *gotgbot.Bot, updateChan chan json.RawMessage, pol
 	return nil
 }
 
-func (m *botMapping) removeBot(b *gotgbot.Bot) (botData, bool) {
+func (m *botMapping) removeBot(token string) (botData, bool) {
 	m.mux.Lock()
 	defer m.mux.Unlock()
 
-	bData, ok := m.mapping[b.Token]
+	bData, ok := m.mapping[token]
 	if !ok {
 		return botData{}, false
 	}
 
-	delete(m.mapping, b.Token)
+	delete(m.mapping, token)
 	return bData, true
 }
 
@@ -88,10 +88,10 @@ func (m *botMapping) getBots() []botData {
 	return bots
 }
 
-func (m *botMapping) getBot(b *gotgbot.Bot) (botData, bool) {
+func (m *botMapping) getBot(token string) (botData, bool) {
 	m.mux.RLock()
 	defer m.mux.RUnlock()
 
-	bData, ok := m.mapping[b.Token]
+	bData, ok := m.mapping[token]
 	return bData, ok
 }

--- a/ext/botmapping.go
+++ b/ext/botmapping.go
@@ -1,0 +1,89 @@
+package ext
+
+import (
+	"encoding/json"
+	"sync"
+
+	"github.com/PaulSonOfLars/gotgbot/v2"
+)
+
+// botData Keeps track of the necessary update channels for each gotgbot.Bot.
+type botData struct {
+	// bot represents the bot for which this data is relevant.
+	bot *gotgbot.Bot
+	// updateChan represents the incoming updates channel.
+	updateChan chan json.RawMessage
+	// polling allows us to close the polling loop.
+	polling chan struct{}
+	// urlPath defines the incoming webhook URL path for this bot.
+	urlPath string
+}
+
+// botMapping Ensures that all botData is stored in a thread-safe manner.
+type botMapping struct {
+	// mapping keeps track of the data required for each bot. The key is the bot token.
+	mapping map[string]botData
+	// mux attempts to keep the botMapping data concurrency-safe.
+	mux sync.RWMutex
+}
+
+// addBot Adds a new bot to the botMapping structure.
+func (m *botMapping) addBot(b *gotgbot.Bot, updateChan chan json.RawMessage, pollChan chan struct{}, urlPath string) {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	if m.mapping == nil {
+		m.mapping = make(map[string]botData)
+	}
+
+	m.mapping[b.Token] = botData{
+		bot:        b,
+		updateChan: updateChan,
+		polling:    pollChan,
+		urlPath:    urlPath,
+	}
+}
+
+// stopAllBots Stops all bots.
+func (m *botMapping) stopAllBots() {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	// Close all the update channels and polling loops
+	for key, bData := range m.mapping {
+		stopBot(bData)
+		delete(m.mapping, key)
+	}
+}
+
+func (m *botMapping) removeBot(b *gotgbot.Bot) (botData, bool) {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	bData, ok := m.mapping[b.Token]
+	if !ok {
+		return botData{}, false
+	}
+
+	delete(m.mapping, b.Token)
+	return bData, true
+}
+
+func (m *botMapping) getBots() []botData {
+	m.mux.RLock()
+	defer m.mux.RUnlock()
+
+	bots := make([]botData, 0, len(m.mapping))
+	for _, bData := range m.mapping {
+		bots = append(bots, bData)
+	}
+	return bots
+}
+
+func (m *botMapping) getBot(b *gotgbot.Bot) (botData, bool) {
+	m.mux.RLock()
+	defer m.mux.RUnlock()
+
+	bData, ok := m.mapping[b.Token]
+	return bData, ok
+}

--- a/ext/botmapping_test.go
+++ b/ext/botmapping_test.go
@@ -18,53 +18,62 @@ func Test_botMapping(t *testing.T) {
 	updateChan := make(chan json.RawMessage)
 	pollChan := make(chan struct{})
 
-	// check that bots can be added fine
-	err := bm.addBot(b, updateChan, pollChan, "")
-	if err != nil {
-		t.Errorf("expected to be able to add a new bot fine: %s", err.Error())
-		t.FailNow()
-	}
-	if len(bm.getBots()) != 1 {
-		t.Errorf("expected 1 bot, got %d", len(bm.getBots()))
-		t.FailNow()
-	}
+	t.Run("addBot", func(t *testing.T) {
+		// check that bots can be added fine
+		err := bm.addBot(b, updateChan, pollChan, "")
+		if err != nil {
+			t.Errorf("expected to be able to add a new bot fine: %s", err.Error())
+			t.FailNow()
+		}
+		if len(bm.getBots()) != 1 {
+			t.Errorf("expected 1 bot, got %d", len(bm.getBots()))
+			t.FailNow()
+		}
+	})
 
-	// Adding the same bot twice should fail
-	err = bm.addBot(b, updateChan, pollChan, "")
-	if err == nil {
-		t.Errorf("adding the same bot twice should throw an error")
-		t.FailNow()
-	}
-	if len(bm.getBots()) != 1 {
-		t.Errorf("expected only haveing 1 bot when adding a duplicate, but got %d", len(bm.getBots()))
-		t.FailNow()
-	}
+	t.Run("doubleAdd", func(t *testing.T) {
+		// Adding the same bot twice should fail
+		err := bm.addBot(b, updateChan, pollChan, "")
+		if err == nil {
+			t.Errorf("adding the same bot twice should throw an error")
+			t.FailNow()
+		}
+		if len(bm.getBots()) != 1 {
+			t.Errorf("expected only haveing 1 bot when adding a duplicate, but got %d", len(bm.getBots()))
+			t.FailNow()
+		}
+	})
 
-	// check that bot data is correct
-	bdata, ok := bm.getBot(b.Token)
-	if !ok {
-		t.Errorf("failed to get bot with token %s", b.Token)
-		t.FailNow()
-	}
-	if bdata.polling != pollChan {
-		t.Errorf("polling channel was not the same")
-		t.FailNow()
-	}
-	if bdata.updateChan != updateChan {
-		t.Errorf("update channel was not the same")
-		t.FailNow()
-	}
+	t.Run("getBot", func(t *testing.T) {
+		// check that bot data is correct
+		bdata, ok := bm.getBot(b.Token)
+		if !ok {
+			t.Errorf("failed to get bot with token %s", b.Token)
+			t.FailNow()
+		}
+		if bdata.polling != pollChan {
+			t.Errorf("polling channel was not the same")
+			t.FailNow()
+		}
+		if bdata.updateChan != updateChan {
+			t.Errorf("update channel was not the same")
+			t.FailNow()
+		}
+	})
 
-	// check that bot cant be removed
-	_, ok = bm.removeBot(b.Token)
-	if !ok {
-		t.Errorf("failed to remove bot with token %s", b.Token)
-		t.FailNow()
-	}
+	t.Run("removeBot", func(t *testing.T) {
+		// check that bot cant be removed
+		_, ok := bm.removeBot(b.Token)
+		if !ok {
+			t.Errorf("failed to remove bot with token %s", b.Token)
+			t.FailNow()
+		}
 
-	_, ok = bm.getBot(b.Token)
-	if ok {
-		t.Errorf("bot with token %s should be gone", b.Token)
-		t.FailNow()
-	}
+		_, ok = bm.getBot(b.Token)
+		if ok {
+			t.Errorf("bot with token %s should be gone", b.Token)
+			t.FailNow()
+		}
+	})
+
 }

--- a/ext/botmapping_test.go
+++ b/ext/botmapping_test.go
@@ -41,7 +41,7 @@ func Test_botMapping(t *testing.T) {
 	}
 
 	// check that bot data is correct
-	bdata, ok := bm.getBot(b)
+	bdata, ok := bm.getBot(b.GetToken())
 	if !ok {
 		t.Errorf("failed to get bot with token %s", b.Token)
 		t.FailNow()
@@ -56,13 +56,13 @@ func Test_botMapping(t *testing.T) {
 	}
 
 	// check that bot cant be removed
-	_, ok = bm.removeBot(b)
+	_, ok = bm.removeBot(b.GetToken())
 	if !ok {
 		t.Errorf("failed to remove bot with token %s", b.Token)
 		t.FailNow()
 	}
 
-	_, ok = bm.getBot(b)
+	_, ok = bm.getBot(b.GetToken())
 	if ok {
 		t.Errorf("bot with token %s should be gone", b.Token)
 		t.FailNow()

--- a/ext/botmapping_test.go
+++ b/ext/botmapping_test.go
@@ -1,0 +1,55 @@
+package ext
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/PaulSonOfLars/gotgbot/v2"
+)
+
+func Test_botMapping(t *testing.T) {
+	bm := botMapping{}
+	b := &gotgbot.Bot{
+		User:      gotgbot.User{},
+		Token:     "SOME_TOKEN",
+		BotClient: &gotgbot.BaseBotClient{},
+	}
+
+	updateChan := make(chan json.RawMessage)
+	pollChan := make(chan struct{})
+
+	// check that bots can be added fine
+	bm.addBot(b, updateChan, pollChan, "")
+	if len(bm.getBots()) != 1 {
+		t.Errorf("expected 1 bot, got %d", len(bm.getBots()))
+		t.FailNow()
+	}
+
+	// check that bot data is correct
+	bdata, ok := bm.getBot(b)
+	if !ok {
+		t.Errorf("failed to get bot with token %s", b.Token)
+		t.FailNow()
+	}
+	if bdata.polling != pollChan {
+		t.Errorf("polling channel was not the same")
+		t.FailNow()
+	}
+	if bdata.updateChan != updateChan {
+		t.Errorf("update channel was not the same")
+		t.FailNow()
+	}
+
+	// check that bot cant be removed
+	_, ok = bm.removeBot(b)
+	if !ok {
+		t.Errorf("failed to remove bot with token %s", b.Token)
+		t.FailNow()
+	}
+
+	_, ok = bm.getBot(b)
+	if ok {
+		t.Errorf("bot with token %s should be gone", b.Token)
+		t.FailNow()
+	}
+}

--- a/ext/botmapping_test.go
+++ b/ext/botmapping_test.go
@@ -41,7 +41,7 @@ func Test_botMapping(t *testing.T) {
 	}
 
 	// check that bot data is correct
-	bdata, ok := bm.getBot(b.GetToken())
+	bdata, ok := bm.getBot(b.Token)
 	if !ok {
 		t.Errorf("failed to get bot with token %s", b.Token)
 		t.FailNow()
@@ -56,13 +56,13 @@ func Test_botMapping(t *testing.T) {
 	}
 
 	// check that bot cant be removed
-	_, ok = bm.removeBot(b.GetToken())
+	_, ok = bm.removeBot(b.Token)
 	if !ok {
 		t.Errorf("failed to remove bot with token %s", b.Token)
 		t.FailNow()
 	}
 
-	_, ok = bm.getBot(b.GetToken())
+	_, ok = bm.getBot(b.Token)
 	if ok {
 		t.Errorf("bot with token %s should be gone", b.Token)
 		t.FailNow()

--- a/ext/botmapping_test.go
+++ b/ext/botmapping_test.go
@@ -19,9 +19,24 @@ func Test_botMapping(t *testing.T) {
 	pollChan := make(chan struct{})
 
 	// check that bots can be added fine
-	bm.addBot(b, updateChan, pollChan, "")
+	err := bm.addBot(b, updateChan, pollChan, "")
+	if err != nil {
+		t.Errorf("expected to be able to add a new bot fine: %s", err.Error())
+		t.FailNow()
+	}
 	if len(bm.getBots()) != 1 {
 		t.Errorf("expected 1 bot, got %d", len(bm.getBots()))
+		t.FailNow()
+	}
+
+	// Adding the same bot twice should fail
+	err = bm.addBot(b, updateChan, pollChan, "")
+	if err == nil {
+		t.Errorf("adding the same bot twice should throw an error")
+		t.FailNow()
+	}
+	if len(bm.getBots()) != 1 {
+		t.Errorf("expected only haveing 1 bot when adding a duplicate, but got %d", len(bm.getBots()))
 		t.FailNow()
 	}
 

--- a/ext/common_test.go
+++ b/ext/common_test.go
@@ -1,0 +1,30 @@
+package ext
+
+import (
+	"github.com/PaulSonOfLars/gotgbot/v2"
+)
+
+type DummyHandler struct {
+	F func(b *gotgbot.Bot, ctx *Context) error
+}
+
+func (d DummyHandler) CheckUpdate(b *gotgbot.Bot, ctx *Context) bool {
+	return true
+}
+
+func (d DummyHandler) HandleUpdate(b *gotgbot.Bot, ctx *Context) error {
+	return d.F(b, ctx)
+}
+
+func (d DummyHandler) Name() string {
+	return "dummy"
+}
+
+func (u *Updater) InjectUpdate(token string, upd gotgbot.Update) error {
+	bData, ok := u.botMapping.getBot(token)
+	if !ok {
+		return ErrNotFound
+	}
+
+	return u.Dispatcher.ProcessUpdate(bData.bot, &upd, nil)
+}

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -272,17 +272,17 @@ func (u *Updater) StopBot(b *gotgbot.Bot) bool {
 		return false
 	}
 
-	stopBot(bData)
+	bData.stop()
 	return true
 }
 
 func (u *Updater) StopAllBots() {
 	for _, bData := range u.botMapping.removeAllBots() {
-		stopBot(bData)
+		bData.stop()
 	}
 }
 
-func stopBot(data botData) {
+func (data botData) stop() {
 	// Close polling loops first, to ensure any updates currently being polled have the time to be sent to the
 	// updateChan.
 	if data.polling != nil {

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -269,8 +269,8 @@ func (u *Updater) Stop() error {
 	return nil
 }
 
-func (u *Updater) StopBot(b *gotgbot.Bot) bool {
-	bData, ok := u.botMapping.removeBot(b)
+func (u *Updater) StopBot(token string) bool {
+	bData, ok := u.botMapping.removeBot(token)
 	if !ok {
 		return false
 	}

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -253,7 +253,8 @@ func (u *Updater) Stop() error {
 		}
 	}
 
-	u.botMapping.stopAllBots()
+	// Close all existing bot channels.
+	u.StopAllBots()
 
 	// Stop the dispatcher from processing any further updates.
 	u.Dispatcher.Stop()
@@ -273,6 +274,12 @@ func (u *Updater) StopBot(b *gotgbot.Bot) bool {
 
 	stopBot(bData)
 	return true
+}
+
+func (u *Updater) StopAllBots() {
+	for _, bData := range u.botMapping.removeAllBots() {
+		stopBot(bData)
+	}
 }
 
 func stopBot(data botData) {

--- a/ext/updater_test.go
+++ b/ext/updater_test.go
@@ -40,9 +40,8 @@ func benchmarkUpdaterWithNBots(b *testing.B, numBot int) {
 	for i := 0; i < numBot; i++ {
 		token := strconv.Itoa(i)
 		err := u.AddWebhook(&gotgbot.Bot{
-			BotClient: &gotgbot.BaseBotClient{
-				Token: token,
-			},
+			Token:     token,
+			BotClient: &gotgbot.BaseBotClient{},
 		}, token, opts)
 		if err != nil {
 			b.Fatalf("failed to add webhook for bot: %s", err.Error())

--- a/ext/updater_test.go
+++ b/ext/updater_test.go
@@ -1,0 +1,67 @@
+package ext_test
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/PaulSonOfLars/gotgbot/v2"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext"
+)
+
+func BenchmarkUpdaterMultibots(b *testing.B) {
+	// Note: This benchmark skips the JSON marshal/unmarshal steps to get an accurate idea of how well the multibot
+	//  features work.
+	b.Run("single", func(b *testing.B) {
+		benchmarkUpdaterWithNBots(b, 1)
+	})
+	b.Run("ten", func(b *testing.B) {
+		benchmarkUpdaterWithNBots(b, 10)
+	})
+	b.Run("hundred", func(b *testing.B) {
+		benchmarkUpdaterWithNBots(b, 100)
+	})
+	b.Run("thousand", func(b *testing.B) {
+		benchmarkUpdaterWithNBots(b, 1000)
+	})
+}
+
+func benchmarkUpdaterWithNBots(b *testing.B, numBot int) {
+	d := ext.NewDispatcher(nil)
+	u := ext.NewUpdater(&ext.UpdaterOpts{Dispatcher: d})
+
+	wg := sync.WaitGroup{}
+	d.AddHandler(ext.DummyHandler{F: func(b *gotgbot.Bot, ctx *ext.Context) error {
+		wg.Done()
+		return nil
+	}})
+
+	opts := ext.WebhookOpts{}
+	for i := 0; i < numBot; i++ {
+		token := strconv.Itoa(i)
+		err := u.AddWebhook(&gotgbot.Bot{
+			BotClient: &gotgbot.BaseBotClient{
+				Token: token,
+			},
+		}, token, opts)
+		if err != nil {
+			b.Fatalf("failed to add webhook for bot: %s", err.Error())
+		}
+	}
+
+	for i := 0; i < b.N; i++ {
+		wg.Add(1)
+		token := strconv.Itoa(i % numBot)
+
+		go func() {
+			err := u.InjectUpdate(token, gotgbot.Update{Message: &gotgbot.Message{Text: "test"}})
+			if err != nil {
+				b.Error("failed to send manual update: %w", err)
+				b.Fail()
+			}
+		}()
+	}
+
+	wg.Wait()
+	d.Stop()
+}

--- a/samples/echoMultiBot/main.go
+++ b/samples/echoMultiBot/main.go
@@ -125,7 +125,11 @@ func startWebhookBots(updater *ext.Updater, bots []*gotgbot.Bot, domain string, 
 
 	// We add all the bots to the updater.
 	for idx, b := range bots {
-		updater.AddWebhook(b, b.Token, opts)
+		err = updater.AddWebhook(b, b.Token, opts)
+		if err != nil {
+			return fmt.Errorf("failed to add bot: %w", err)
+		}
+
 		log.Printf("bot %d: %s has been added to the updater\n", idx, b.User.Username)
 	}
 


### PR DESCRIPTION
# What

This PR makes it possible to add/remove bots to the `Updater` on the fly, rather than the previous option which only allowed for adding bots, without being able to remove them.

# Impact
- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
