### PR TITLE
Make sure that GetFileURL can correctly handle test environments bots

### DIFF
--- a/custom_helpers.go
+++ b/custom_helpers.go
@@ -48,6 +48,6 @@ func (c Chat) Promote(b *Bot, userId int64, opts *PromoteChatMemberOpts) (bool, 
 }
 
 // GetURL gets the URL the file can be downloaded from.
-func (f File) GetURL(b *Bot) string {
-	return fmt.Sprintf("%s/file/bot%s/%s", b.GetAPIURL(), b.GetToken(), f.FilePath)
+func (f File) URL(b *Bot, opts *RequestOpts) string {
+	return b.GetFileURL(f.FilePath, opts)
 }

--- a/custom_helpers.go
+++ b/custom_helpers.go
@@ -47,7 +47,7 @@ func (c Chat) Promote(b *Bot, userId int64, opts *PromoteChatMemberOpts) (bool, 
 	return b.PromoteChatMember(c.Id, userId, opts)
 }
 
-// GetURL gets the URL the file can be downloaded from.
+// URL gets the URL the file can be downloaded from.
 func (f File) URL(b *Bot, opts *RequestOpts) string {
-	return b.GetFileURL(f.FilePath, opts)
+	return b.FileURL(f.FilePath, opts)
 }

--- a/request.go
+++ b/request.go
@@ -24,10 +24,10 @@ type BotClient interface {
 	RequestWithContext(ctx context.Context, method string, params map[string]string, data map[string]NamedReader, opts *RequestOpts) (json.RawMessage, error)
 	// TimeoutContext calculates the required timeout contect required given the passed RequestOpts, and any default opts defined by the BotClient.
 	TimeoutContext(opts *RequestOpts) (context.Context, context.CancelFunc)
-	// GetAPIURL gets the URL of the API the bot is interacting with.
-	GetAPIURL() string
-	// GetFileURL gets the URL of a file at the API address that the bot is interacting with.
-	GetFileURL(filePath string, opts *RequestOpts) string
+	// GetAPIURL gets the URL of the API either in use by the bot or defined in the request opts.
+	GetAPIURL(opts *RequestOpts) string
+	// FileURL gets the URL of a file at the API address that the bot is interacting with.
+	FileURL(filePath string, opts *RequestOpts) string
 	// GetToken gets the bot token.
 	GetToken() string
 }
@@ -224,22 +224,7 @@ func fillBuffer(b *bytes.Buffer, params map[string]string, data map[string]Named
 }
 
 // GetAPIURL returns the currently used API endpoint.
-func (bot *BaseBotClient) GetAPIURL() string {
-	return bot.getAPIURL(nil)
-}
-
-// GetToken returns the currently used token.
-func (bot *BaseBotClient) GetFileURL(filePath string, opts *RequestOpts) string {
-	return fmt.Sprintf("%s/file/%s/%s", bot.getAPIURL(opts), bot.getEnvAuth(), filePath)
-}
-
-// GetToken returns the currently used token.
-func (bot *BaseBotClient) GetToken() string {
-	return bot.Token
-}
-
-// getAPIURL returns the currently used API endpoint.
-func (bot *BaseBotClient) getAPIURL(opts *RequestOpts) string {
+func (bot *BaseBotClient) GetAPIURL(opts *RequestOpts) string {
 	if opts != nil && opts.APIURL != "" {
 		return strings.TrimSuffix(opts.APIURL, "/")
 	}
@@ -247,6 +232,16 @@ func (bot *BaseBotClient) getAPIURL(opts *RequestOpts) string {
 		return strings.TrimSuffix(bot.DefaultRequestOpts.APIURL, "/")
 	}
 	return DefaultAPIURL
+}
+
+// GetToken returns the currently used token.
+func (bot *BaseBotClient) FileURL(filePath string, opts *RequestOpts) string {
+	return fmt.Sprintf("%s/file/%s/%s", bot.GetAPIURL(opts), bot.getEnvAuth(), filePath)
+}
+
+// GetToken returns the currently used token.
+func (bot *BaseBotClient) GetToken() string {
+	return bot.Token
 }
 
 func (bot *BaseBotClient) getEnvAuth() string {
@@ -257,5 +252,5 @@ func (bot *BaseBotClient) getEnvAuth() string {
 }
 
 func (bot *BaseBotClient) methodEndpoint(method string, opts *RequestOpts) string {
-	return fmt.Sprintf("%s/bot%s/%s", bot.getAPIURL(opts), bot.getEnvAuth(), method)
+	return fmt.Sprintf("%s/bot%s/%s", bot.GetAPIURL(opts), bot.getEnvAuth(), method)
 }

--- a/request.go
+++ b/request.go
@@ -26,7 +26,9 @@ type BotClient interface {
 	TimeoutContext(opts *RequestOpts) (context.Context, context.CancelFunc)
 	// GetAPIURL gets the URL of the API the bot is interacting with.
 	GetAPIURL() string
-	// GetToken gets the current bots' token.
+	// GetFileURL gets the URL of a file at the API address that the bot is interacting with.
+	GetFileURL(filePath string, opts *RequestOpts) string
+	// GetToken gets the bot token.
 	GetToken() string
 }
 
@@ -157,7 +159,7 @@ func (bot *BaseBotClient) RequestWithContext(ctx context.Context, method string,
 		}
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, bot.methodEnpoint(method, opts), b)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, bot.methodEndpoint(method, opts), b)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build POST request to %s: %w", method, err)
 	}
@@ -221,17 +223,14 @@ func fillBuffer(b *bytes.Buffer, params map[string]string, data map[string]Named
 	return w.FormDataContentType(), nil
 }
 
-func getCleanAPIURL(url string) string {
-	if url == "" {
-		return DefaultAPIURL
-	}
-	// Trim suffix to ensure consistent output
-	return strings.TrimSuffix(url, "/")
-}
-
 // GetAPIURL returns the currently used API endpoint.
 func (bot *BaseBotClient) GetAPIURL() string {
 	return bot.getAPIURL(nil)
+}
+
+// GetToken returns the currently used token.
+func (bot *BaseBotClient) GetFileURL(filePath string, opts *RequestOpts) string {
+	return fmt.Sprintf("%s/file/%s/%s", bot.getAPIURL(opts), bot.getEnvAuth(), filePath)
 }
 
 // GetToken returns the currently used token.
@@ -242,17 +241,21 @@ func (bot *BaseBotClient) GetToken() string {
 // getAPIURL returns the currently used API endpoint.
 func (bot *BaseBotClient) getAPIURL(opts *RequestOpts) string {
 	if opts != nil && opts.APIURL != "" {
-		return getCleanAPIURL(opts.APIURL)
+		return strings.TrimSuffix(opts.APIURL, "/")
 	}
 	if bot.DefaultRequestOpts != nil && bot.DefaultRequestOpts.APIURL != "" {
-		return getCleanAPIURL(bot.DefaultRequestOpts.APIURL)
+		return strings.TrimSuffix(bot.DefaultRequestOpts.APIURL, "/")
 	}
 	return DefaultAPIURL
 }
 
-func (bot *BaseBotClient) methodEnpoint(method string, opts *RequestOpts) string {
+func (bot *BaseBotClient) getEnvAuth() string {
 	if bot.UseTestEnvironment {
-		return fmt.Sprintf("%s/bot%s/test/%s", bot.getAPIURL(opts), bot.Token, method)
+		return "bot" + bot.Token + "/test"
 	}
-	return fmt.Sprintf("%s/bot%s/%s", bot.getAPIURL(opts), bot.Token, method)
+	return "bot" + bot.Token
+}
+
+func (bot *BaseBotClient) methodEndpoint(method string, opts *RequestOpts) string {
+	return fmt.Sprintf("%s/bot%s/%s", bot.getAPIURL(opts), bot.getEnvAuth(), method)
 }


### PR DESCRIPTION
# What

Change the GetURL method on the File object to ensure that it supports getting files from the test env.
Addresses #101.

# Impact

- Are your changes backwards compatible? No - method definition changes as well as new methods and method renames on the BotClient interface.
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
