### PR TITLE
Update supported go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/PaulSonOfLars/gotgbot/v2
 
-go 1.15
+go 1.19

--- a/samples/callbackqueryBot/go.mod
+++ b/samples/callbackqueryBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/callbackqueryBot
 
-go 1.15
+go 1.19
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/commandBot/go.mod
+++ b/samples/commandBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/commandBot
 
-go 1.15
+go 1.19
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/conversationBot/go.mod
+++ b/samples/conversationBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/conversationBot
 
-go 1.15
+go 1.19
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/echoBot/go.mod
+++ b/samples/echoBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/echoBot
 
-go 1.15
+go 1.19
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/echoMultiBot/go.mod
+++ b/samples/echoMultiBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/echoMultiBot
 
-go 1.15
+go 1.19
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/echoWebhookBot/go.mod
+++ b/samples/echoWebhookBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/echoWebhookBot
 
-go 1.15
+go 1.19
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/inlinequeryBot/go.mod
+++ b/samples/inlinequeryBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/inlinequeryBot
 
-go 1.15
+go 1.19
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/middlewareBot/go.mod
+++ b/samples/middlewareBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/middlewareBot
 
-go 1.15
+go 1.19
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/webappBot/go.mod
+++ b/samples/webappBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/webappBot
 
-go 1.15
+go 1.19
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/scripts/ci/ensure-consistent-sample-mod-files.sh
+++ b/scripts/ci/ensure-consistent-sample-mod-files.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SAMPLES_DIR="samples"
 
 REPO="github.com/PaulSonOfLars/gotgbot" # Current library import path
-GO_VERSION="1.15"                       # Go version we expect our samples to be using
+GO_VERSION="1.19"                       # Go version we expect our samples to be using
 V_MAJOR="v2"                            # Current major version for the library
 V_DUMMY="v2.99.99"                      # dummy version for the library
 


### PR DESCRIPTION
# What

Update latest supported go version to 1.19 instead of 1.15

# Impact

- Are your changes backwards compatible? No - but old clients should be upgrading.
- Have you included documentation, or updated existing documentation? N/A
- Do errors and log messages provide enough context? N/A
