### PR TITLE
fix redundant `bot` in `methodEndpoint`

### DIFF
--- a/request.go
+++ b/request.go
@@ -259,5 +259,5 @@ func (bot *BaseBotClient) getEnvAuth() string {
 }
 
 func (bot *BaseBotClient) methodEndpoint(method string, opts *RequestOpts) string {
-	return fmt.Sprintf("%s/bot%s/%s", bot.GetAPIURL(opts), bot.getEnvAuth(), method)
+	return fmt.Sprintf("%s/%s/%s", bot.GetAPIURL(opts), bot.getEnvAuth(), method)
 }


### PR DESCRIPTION

since https://github.com/PaulSonOfLars/gotgbot/blob/138d7fab97003f1edc275e033ae601ab1251b6b8/request.go#L254-L259 has the prefix "bot"