### PR TITLE
Move token up to the bot struct rather than the client

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -12,6 +12,9 @@ import (
 
 // Bot is the default Bot struct used to send and receive messages to the telegram API.
 type Bot struct {
+	// Token stores the bot's secret token obtained from t.me/BotFather, and used to interact with telegram's API.
+	Token string
+
 	// The bot's User info, as returned by Bot.GetMe. Populated when created through the NewBot method.
 	User
 	// The bot client to use to make requests
@@ -41,7 +44,6 @@ type BotOpts struct {
 // NewBot returns a new Bot struct populated with the necessary defaults.
 func NewBot(token string, opts *BotOpts) (*Bot, error) {
 	botClient := &BaseBotClient{
-		Token:              token,
 		Client:             http.Client{},
 		DefaultRequestOpts: nil,
 	}
@@ -66,6 +68,7 @@ func NewBot(token string, opts *BotOpts) (*Bot, error) {
 	}
 
 	b := Bot{
+		Token:     token,
 		BotClient: botClient,
 	}
 
@@ -98,5 +101,5 @@ func (bot *Bot) Request(method string, params map[string]string, data map[string
 	ctx, cancel := bot.BotClient.TimeoutContext(opts)
 	defer cancel()
 
-	return bot.BotClient.RequestWithContext(ctx, method, params, data, opts)
+	return bot.BotClient.RequestWithContext(ctx, bot.Token, method, params, data, opts)
 }

--- a/custom_helpers.go
+++ b/custom_helpers.go
@@ -49,5 +49,5 @@ func (c Chat) Promote(b *Bot, userId int64, opts *PromoteChatMemberOpts) (bool, 
 
 // URL gets the URL the file can be downloaded from.
 func (f File) URL(b *Bot, opts *RequestOpts) string {
-	return b.FileURL(f.FilePath, opts)
+	return b.FileURL(b.Token, f.FilePath, opts)
 }

--- a/ext/handlers/common_test.go
+++ b/ext/handlers/common_test.go
@@ -15,6 +15,7 @@ import (
 func NewTestBot() *gotgbot.Bot {
 	server := httptest.NewServer(nil)
 	return &gotgbot.Bot{
+		Token: "use-me",
 		User: gotgbot.User{
 			Id:        0,
 			IsBot:     false,
@@ -23,7 +24,6 @@ func NewTestBot() *gotgbot.Bot {
 			Username:  "gotgbot",
 		},
 		BotClient: &gotgbot.BaseBotClient{
-			Token:  "use-me",
 			Client: http.Client{},
 			DefaultRequestOpts: &gotgbot.RequestOpts{
 				Timeout: 0,

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -180,7 +180,7 @@ func (u *Updater) StartPolling(b *gotgbot.Bot, opts *PollingOpts) error {
 	updateChan := make(chan json.RawMessage)
 	pollChan := make(chan struct{})
 
-	u.botMapping[b.GetToken()] = &botData{
+	u.botMapping[b.Token] = &botData{
 		bot:        b,
 		updateChan: updateChan,
 		polling:    pollChan,
@@ -327,7 +327,7 @@ func (u *Updater) AddWebhook(b *gotgbot.Bot, urlPath string, opts WebhookOpts) {
 		updateChan <- bytes
 	})
 
-	u.botMapping[b.GetToken()] = &botData{
+	u.botMapping[b.Token] = &botData{
 		bot:        b,
 		updateChan: updateChan,
 		urlPath:    urlPath,
@@ -343,7 +343,7 @@ func (u *Updater) SetAllBotWebhooks(domain string, opts *gotgbot.SetWebhookOpts)
 		_, err := data.bot.SetWebhook(strings.Join([]string{strings.TrimSuffix(domain, "/"), data.urlPath}, "/"), opts)
 		if err != nil {
 			// Extract the botID, so we don't intentionally log the token
-			botId := strings.Split(data.bot.GetToken(), ":")[0]
+			botId := strings.Split(data.bot.Token, ":")[0]
 			return fmt.Errorf("failed to set webhook for %s: %w", botId, err)
 		}
 	}

--- a/samples/echoMultiBot/main.go
+++ b/samples/echoMultiBot/main.go
@@ -132,7 +132,7 @@ func startWebhookBots(updater *ext.Updater, bots []*gotgbot.Bot, domain string, 
 
 	// We add all the bots to the updater.
 	for idx, b := range bots {
-		updater.AddWebhook(b, b.GetToken(), opts)
+		updater.AddWebhook(b, b.Token, opts)
 		log.Printf("bot %d: %s has been added to the updater\n", idx, b.User.Username)
 	}
 

--- a/samples/middlewareBot/middleware.go
+++ b/samples/middlewareBot/middleware.go
@@ -18,7 +18,7 @@ type sendWithoutReplyBotClient struct {
 
 // Define wrapper around existing RequestWithContext method.
 // Note: this is the only method that needs redefining.
-func (b *sendWithoutReplyBotClient) RequestWithContext(ctx context.Context, method string, params map[string]string, data map[string]gotgbot.NamedReader, opts *gotgbot.RequestOpts) (json.RawMessage, error) {
+func (b *sendWithoutReplyBotClient) RequestWithContext(ctx context.Context, token string, method string, params map[string]string, data map[string]gotgbot.NamedReader, opts *gotgbot.RequestOpts) (json.RawMessage, error) {
 	// For all sendable methods, we want to allow sending if the message has been deleted.
 	// So, we edit the params to allow for that.
 	// We also log this, for the sake of the example. :)
@@ -28,7 +28,7 @@ func (b *sendWithoutReplyBotClient) RequestWithContext(ctx context.Context, meth
 	}
 
 	// Call the next bot client instance in the middleware chain.
-	val, err := b.BotClient.RequestWithContext(ctx, method, params, data, opts)
+	val, err := b.BotClient.RequestWithContext(ctx, token, method, params, data, opts)
 	if err != nil {
 		// Middlewares can also be used to increase error visibility, in case they aren't logged elsewhere.
 		log.Println("warning, got an error:", err)


### PR DESCRIPTION
# What

Move the bot Token up to the bot struct rather than the bot client

# Impact

- Are your changes backwards compatible? No - this will cause compilation errors on outdated code. Majority of users should not be affected - only users of middlewares, due to interface changes.
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
