### PR TITLE
Fix the hasprefix filter for captions

### DIFF
--- a/ext/handlers/filters/message/message.go
+++ b/ext/handlers/filters/message/message.go
@@ -100,7 +100,7 @@ func Text(msg *gotgbot.Message) bool {
 
 func HasPrefix(prefix string) filters.Message {
 	return func(msg *gotgbot.Message) bool {
-		return strings.HasPrefix(msg.Text, prefix) || strings.HasSuffix(msg.Caption, prefix)
+		return strings.HasPrefix(msg.Text, prefix) || strings.HasPrefix(msg.Caption, prefix)
 
 	}
 }


### PR DESCRIPTION
# What
Fix incorrect behaviour in the HasPrefix filter which occurred when handling message captions

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
