### PR TITLE
Allow for removing bots from the webhook server

### DIFF
--- a/ext/botmapping.go
+++ b/ext/botmapping.go
@@ -45,7 +45,7 @@ var ErrBotAlreadyExists = errors.New("bot already exists in bot mapping")
 var ErrBotUrlPathAlreadyExists = errors.New("url path already exists in bot mapping")
 
 // addBot Adds a new bot to the botMapping structure.
-func (m *botMapping) addBot(b *gotgbot.Bot, updateChan chan json.RawMessage, pollChan chan struct{}, urlPath string, webhookSecret string) error {
+func (m *botMapping) addBot(bData botData) error {
 	m.mux.Lock()
 	defer m.mux.Unlock()
 
@@ -56,21 +56,15 @@ func (m *botMapping) addBot(b *gotgbot.Bot, updateChan chan json.RawMessage, pol
 		m.urlMapping = make(map[string]string)
 	}
 
-	if _, ok := m.mapping[b.Token]; ok {
+	if _, ok := m.mapping[bData.bot.Token]; ok {
 		return ErrBotAlreadyExists
 	}
-	if _, ok := m.urlMapping[urlPath]; urlPath != "" && ok {
+	if _, ok := m.urlMapping[bData.urlPath]; bData.urlPath != "" && ok {
 		return ErrBotUrlPathAlreadyExists
 	}
 
-	m.mapping[b.Token] = botData{
-		bot:           b,
-		updateChan:    updateChan,
-		polling:       pollChan,
-		urlPath:       urlPath,
-		webhookSecret: webhookSecret,
-	}
-	m.urlMapping[urlPath] = b.Token
+	m.mapping[bData.bot.Token] = bData
+	m.urlMapping[bData.urlPath] = bData.bot.Token
 	return nil
 }
 

--- a/ext/botmapping.go
+++ b/ext/botmapping.go
@@ -59,7 +59,7 @@ func (m *botMapping) addBot(b *gotgbot.Bot, updateChan chan json.RawMessage, pol
 	if _, ok := m.mapping[b.Token]; ok {
 		return ErrBotAlreadyExists
 	}
-	if _, ok := m.urlMapping[urlPath]; ok {
+	if _, ok := m.urlMapping[urlPath]; urlPath != "" && ok {
 		return ErrBotUrlPathAlreadyExists
 	}
 

--- a/ext/botmapping.go
+++ b/ext/botmapping.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/PaulSonOfLars/gotgbot/v2"
@@ -118,8 +119,8 @@ func (m *botMapping) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Check if this needs to be cleaned
-	b, ok := m.getBot(r.URL.Path)
+	potentialToken := strings.TrimPrefix(r.URL.Path, "/")
+	b, ok := m.getBot(potentialToken)
 	if !ok {
 		w.WriteHeader(http.StatusNotFound)
 		return

--- a/ext/botmapping.go
+++ b/ext/botmapping.go
@@ -124,7 +124,7 @@ func (m *botMapping) getBotFromURL(urlPath string) (botData, bool) {
 	m.mux.RLock()
 	defer m.mux.RUnlock()
 
-	token, ok := m.urlMapping[strings.TrimPrefix(urlPath, "/")]
+	token, ok := m.urlMapping[urlPath]
 	if !ok {
 		return botData{}, ok
 	}
@@ -144,7 +144,7 @@ func (m *botMapping) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	b, ok := m.getBotFromURL(r.URL.Path)
+	b, ok := m.getBotFromURL(strings.TrimPrefix(r.URL.Path, "/"))
 	if !ok {
 		// If we don't recognise the URL, we return a 404.
 		w.WriteHeader(http.StatusNotFound)

--- a/ext/botmapping_test.go
+++ b/ext/botmapping_test.go
@@ -20,7 +20,11 @@ func Test_botMapping(t *testing.T) {
 
 	t.Run("addBot", func(t *testing.T) {
 		// check that bots can be added fine
-		err := bm.addBot(b, updateChan, pollChan, "", "")
+		err := bm.addBot(botData{
+			bot:        b,
+			updateChan: updateChan,
+			polling:    pollChan,
+		})
 		if err != nil {
 			t.Errorf("expected to be able to add a new bot fine: %s", err.Error())
 			t.FailNow()
@@ -33,7 +37,11 @@ func Test_botMapping(t *testing.T) {
 
 	t.Run("doubleAdd", func(t *testing.T) {
 		// Adding the same bot twice should fail
-		err := bm.addBot(b, updateChan, pollChan, "", "")
+		err := bm.addBot(botData{
+			bot:        b,
+			updateChan: updateChan,
+			polling:    pollChan,
+		})
 		if err == nil {
 			t.Errorf("adding the same bot twice should throw an error")
 			t.FailNow()

--- a/ext/botmapping_test.go
+++ b/ext/botmapping_test.go
@@ -20,7 +20,7 @@ func Test_botMapping(t *testing.T) {
 
 	t.Run("addBot", func(t *testing.T) {
 		// check that bots can be added fine
-		err := bm.addBot(b, updateChan, pollChan, "")
+		err := bm.addBot(b, updateChan, pollChan, "", "")
 		if err != nil {
 			t.Errorf("expected to be able to add a new bot fine: %s", err.Error())
 			t.FailNow()
@@ -33,7 +33,7 @@ func Test_botMapping(t *testing.T) {
 
 	t.Run("doubleAdd", func(t *testing.T) {
 		// Adding the same bot twice should fail
-		err := bm.addBot(b, updateChan, pollChan, "")
+		err := bm.addBot(b, updateChan, pollChan, "", "")
 		if err == nil {
 			t.Errorf("adding the same bot twice should throw an error")
 			t.FailNow()

--- a/ext/dispatcher.go
+++ b/ext/dispatcher.go
@@ -71,7 +71,7 @@ type Dispatcher struct {
 	ErrorLog *log.Logger
 
 	// handlers represents all available handlers.
-	handlers handlerMappings
+	handlers handlerMapping
 
 	// limiter is how we limit the maximum number of goroutines for handling updates.
 	// if nil, this is a limitless dispatcher.
@@ -149,7 +149,7 @@ func NewDispatcher(opts *DispatcherOpts) *Dispatcher {
 		Panic:            panicHandler,
 		UnhandledErrFunc: unhandledErrFunc,
 		ErrorLog:         errLog,
-		handlers:         handlerMappings{},
+		handlers:         handlerMapping{},
 		limiter:          limiter,
 		waitGroup:        sync.WaitGroup{},
 	}

--- a/ext/handler_mapping.go
+++ b/ext/handler_mapping.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 )
 
-type handlerMappings struct {
+type handlerMapping struct {
 	// mutex is used to ensure everything threadsafe.
 	mutex sync.RWMutex
 
@@ -15,7 +15,7 @@ type handlerMappings struct {
 	handlers map[int][]Handler
 }
 
-func (m *handlerMappings) add(h Handler, group int) {
+func (m *handlerMapping) add(h Handler, group int) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -30,7 +30,7 @@ func (m *handlerMappings) add(h Handler, group int) {
 	m.handlers[group] = append(currHandlers, h)
 }
 
-func (m *handlerMappings) remove(name string, group int) bool {
+func (m *handlerMapping) remove(name string, group int) bool {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -77,7 +77,7 @@ func getIndex(find int, is []int) int {
 	return -1
 }
 
-func (m *handlerMappings) removeGroup(group int) bool {
+func (m *handlerMapping) removeGroup(group int) bool {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -100,7 +100,7 @@ func (m *handlerMappings) removeGroup(group int) bool {
 	return false
 }
 
-func (m *handlerMappings) getGroups() [][]Handler {
+func (m *handlerMapping) getGroups() [][]Handler {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 

--- a/ext/handler_mapping_test.go
+++ b/ext/handler_mapping_test.go
@@ -6,7 +6,7 @@ import (
 
 // This test should demonstrate that once obtained, a list will not be changed by any additions/removals to that list by another call.
 func Test_handlerMappings_getGroupsConcurrentSafe(t *testing.T) {
-	m := handlerMappings{}
+	m := handlerMapping{}
 	firstHandler := DummyHandler{N: "first"}
 	secondHandler := DummyHandler{N: "second"}
 
@@ -73,7 +73,7 @@ func checkList(t *testing.T, name string, got []Handler, expected ...Handler) {
 }
 
 func Test_handlerMappings_remove(t *testing.T) {
-	m := &handlerMappings{}
+	m := &handlerMapping{}
 	handler := DummyHandler{N: "test"}
 
 	t.Run("nonExistent", func(t *testing.T) {

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -19,6 +19,7 @@ var (
 	ErrMissingCertOrKeyFile = errors.New("missing certfile or keyfile")
 	ErrExpectedEmptyServer  = errors.New("expected server to be nil")
 	ErrNotFound             = errors.New("not found")
+	ErrEmptyPath            = errors.New("empty path")
 )
 
 type ErrorFunc func(error)
@@ -316,6 +317,12 @@ func (u *Updater) StartWebhook(b *gotgbot.Bot, urlPath string, opts WebhookOpts)
 
 // AddWebhook prepares the webhook server to receive webhook updates for one bot, on a specific path.
 func (u *Updater) AddWebhook(b *gotgbot.Bot, urlPath string, opts WebhookOpts) error {
+	// We expect webhooks to use unique URL paths; otherwise, we wouldnt be able to differentiate them from polling, or
+	// from each other.
+	if urlPath == "" {
+		return fmt.Errorf("expected a non-empty url path: %w", ErrEmptyPath)
+	}
+
 	updateChan := make(chan json.RawMessage)
 
 	err := u.botMapping.addBot(b, updateChan, nil, urlPath, opts.SecretToken)

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -306,7 +306,7 @@ func (u *Updater) StartWebhook(b *gotgbot.Bot, urlPath string, opts WebhookOpts)
 		return ErrExpectedEmptyServer
 	}
 
-	err := u.AddWebhook(b, urlPath, &opts)
+	err := u.AddWebhook(b, urlPath, opts)
 	if err != nil {
 		return fmt.Errorf("failed to add webhook: %w", err)
 	}
@@ -315,15 +315,10 @@ func (u *Updater) StartWebhook(b *gotgbot.Bot, urlPath string, opts WebhookOpts)
 }
 
 // AddWebhook prepares the webhook server to receive webhook updates for one bot, on a specific path.
-func (u *Updater) AddWebhook(b *gotgbot.Bot, urlPath string, opts *WebhookOpts) error {
-	secretToken := ""
-	if opts != nil {
-		secretToken = opts.SecretToken
-	}
-
+func (u *Updater) AddWebhook(b *gotgbot.Bot, urlPath string, opts WebhookOpts) error {
 	updateChan := make(chan json.RawMessage)
 
-	err := u.botMapping.addBot(b, updateChan, nil, urlPath, secretToken)
+	err := u.botMapping.addBot(b, updateChan, nil, urlPath, opts.SecretToken)
 	if err != nil {
 		return fmt.Errorf("failed to add webhook for bot: %w", err)
 	}

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -167,7 +167,11 @@ func (u *Updater) StartPolling(b *gotgbot.Bot, opts *PollingOpts) error {
 	updateChan := make(chan json.RawMessage)
 	pollChan := make(chan struct{})
 
-	err := u.botMapping.addBot(b, updateChan, pollChan, "", "")
+	err := u.botMapping.addBot(botData{
+		bot:        b,
+		updateChan: updateChan,
+		polling:    pollChan,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to add bot with long polling: %w", err)
 	}
@@ -325,7 +329,12 @@ func (u *Updater) AddWebhook(b *gotgbot.Bot, urlPath string, opts WebhookOpts) e
 
 	updateChan := make(chan json.RawMessage)
 
-	err := u.botMapping.addBot(b, updateChan, nil, urlPath, opts.SecretToken)
+	err := u.botMapping.addBot(botData{
+		bot:           b,
+		updateChan:    updateChan,
+		urlPath:       urlPath,
+		webhookSecret: opts.SecretToken,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to add webhook for bot: %w", err)
 	}

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -321,11 +321,6 @@ func (u *Updater) AddWebhook(b *gotgbot.Bot, urlPath string, opts *WebhookOpts) 
 		secretToken = opts.SecretToken
 	}
 
-	_, ok := u.botMapping.getBot(b.Token)
-	if ok {
-		return fmt.Errorf("bot with token %s already exists", b.Token)
-	}
-
 	updateChan := make(chan json.RawMessage)
 
 	err := u.botMapping.addBot(b, updateChan, nil, urlPath, secretToken)

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -305,7 +305,7 @@ func (u *Updater) StartWebhook(b *gotgbot.Bot, urlPath string, opts WebhookOpts)
 		return ErrExpectedEmptyServer
 	}
 
-	err := u.AddWebhook(b, urlPath, opts)
+	err := u.AddWebhook(b, urlPath, &opts)
 	if err != nil {
 		return fmt.Errorf("failed to add webhook: %w", err)
 	}
@@ -314,14 +314,14 @@ func (u *Updater) StartWebhook(b *gotgbot.Bot, urlPath string, opts WebhookOpts)
 }
 
 // AddWebhook prepares the webhook server to receive webhook updates for one bot, on a specific path.
-func (u *Updater) AddWebhook(b *gotgbot.Bot, urlPath string, opts WebhookOpts) error {
+func (u *Updater) AddWebhook(b *gotgbot.Bot, urlPath string, opts *WebhookOpts) error {
 	if u.serveMux == nil {
 		u.serveMux = http.NewServeMux()
 	}
 
 	updateChan := make(chan json.RawMessage)
 	u.serveMux.HandleFunc("/"+urlPath, func(w http.ResponseWriter, r *http.Request) {
-		if opts.SecretToken != "" && opts.SecretToken != r.Header.Get("X-Telegram-Bot-Api-Secret-Token") {
+		if opts != nil && opts.SecretToken != "" && opts.SecretToken != r.Header.Get("X-Telegram-Bot-Api-Secret-Token") {
 			// Drop any updates from invalid secret tokens.
 			w.WriteHeader(http.StatusUnauthorized)
 			return

--- a/ext/updater_test.go
+++ b/ext/updater_test.go
@@ -24,7 +24,8 @@ func TestUpdaterThrowsErrorWhenSameWebhookAddedTwice(t *testing.T) {
 		t.Errorf("failed to add webhook: %v", err)
 		return
 	}
-	// Adding a second time should fail
+
+	// Adding a second time should throw an error
 	err = u.AddWebhook(b, "test", nil)
 	if err == nil {
 		t.Errorf("should have failed to add the same webhook twice, but didnt")

--- a/ext/updater_test.go
+++ b/ext/updater_test.go
@@ -19,14 +19,14 @@ func TestUpdaterThrowsErrorWhenSameWebhookAddedTwice(t *testing.T) {
 	d := ext.NewDispatcher(&ext.DispatcherOpts{})
 	u := ext.NewUpdater(&ext.UpdaterOpts{Dispatcher: d})
 
-	err := u.AddWebhook(b, "test", nil)
+	err := u.AddWebhook(b, "test", ext.WebhookOpts{})
 	if err != nil {
 		t.Errorf("failed to add webhook: %v", err)
 		return
 	}
 
 	// Adding a second time should throw an error
-	err = u.AddWebhook(b, "test", nil)
+	err = u.AddWebhook(b, "test", ext.WebhookOpts{})
 	if err == nil {
 		t.Errorf("should have failed to add the same webhook twice, but didnt")
 		return
@@ -43,7 +43,7 @@ func TestUpdaterSupportsReAdding(t *testing.T) {
 	d := ext.NewDispatcher(&ext.DispatcherOpts{})
 	u := ext.NewUpdater(&ext.UpdaterOpts{Dispatcher: d})
 
-	err := u.AddWebhook(b, "test", nil)
+	err := u.AddWebhook(b, "test", ext.WebhookOpts{})
 	if err != nil {
 		t.Errorf("failed to add webhook: %v", err)
 		return
@@ -56,7 +56,7 @@ func TestUpdaterSupportsReAdding(t *testing.T) {
 	}
 
 	// Should be able to re-add the bot now
-	err = u.AddWebhook(b, "test", nil)
+	err = u.AddWebhook(b, "test", ext.WebhookOpts{})
 	if err != nil {
 		t.Errorf("Failed to re-add a previously removed bot: %v", err)
 		return
@@ -90,12 +90,13 @@ func benchmarkUpdaterWithNBots(b *testing.B, numBot int) {
 		return nil
 	}})
 
+	opts := ext.WebhookOpts{}
 	for i := 0; i < numBot; i++ {
 		token := strconv.Itoa(i)
 		err := u.AddWebhook(&gotgbot.Bot{
 			Token:     token,
 			BotClient: &gotgbot.BaseBotClient{},
-		}, token, nil)
+		}, token, opts)
 		if err != nil {
 			b.Fatalf("failed to add webhook for bot: %s", err.Error())
 		}

--- a/ext/updater_test.go
+++ b/ext/updater_test.go
@@ -2,6 +2,7 @@ package ext_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -64,6 +65,22 @@ func TestUpdaterSupportsWebhookReAdding(t *testing.T) {
 	err = u.AddWebhook(b, "test", ext.WebhookOpts{})
 	if err != nil {
 		t.Errorf("Failed to re-add a previously removed bot: %v", err)
+		return
+	}
+}
+
+func TestUpdaterDisallowsEmptyWebhooks(t *testing.T) {
+	b := &gotgbot.Bot{
+		Token:     "SOME_TOKEN",
+		BotClient: &gotgbot.BaseBotClient{},
+	}
+
+	d := ext.NewDispatcher(&ext.DispatcherOpts{})
+	u := ext.NewUpdater(&ext.UpdaterOpts{Dispatcher: d})
+
+	err := u.AddWebhook(b, "", ext.WebhookOpts{})
+	if !errors.Is(err, ext.ErrEmptyPath) {
+		t.Errorf("Expected an empty path error trying to add an empty webhook : %v", err)
 		return
 	}
 }

--- a/samples/echoMultiBot/main.go
+++ b/samples/echoMultiBot/main.go
@@ -125,7 +125,7 @@ func startWebhookBots(updater *ext.Updater, bots []*gotgbot.Bot, domain string, 
 
 	// We add all the bots to the updater.
 	for idx, b := range bots {
-		err = updater.AddWebhook(b, b.Token, &opts)
+		err = updater.AddWebhook(b, b.Token, opts)
 		if err != nil {
 			return fmt.Errorf("failed to add bot: %w", err)
 		}

--- a/samples/echoMultiBot/main.go
+++ b/samples/echoMultiBot/main.go
@@ -125,7 +125,7 @@ func startWebhookBots(updater *ext.Updater, bots []*gotgbot.Bot, domain string, 
 
 	// We add all the bots to the updater.
 	for idx, b := range bots {
-		err = updater.AddWebhook(b, b.Token, opts)
+		err = updater.AddWebhook(b, b.Token, &opts)
 		if err != nil {
 			return fmt.Errorf("failed to add bot: %w", err)
 		}

--- a/samples/echoWebhookBot/main.go
+++ b/samples/echoWebhookBot/main.go
@@ -66,8 +66,11 @@ func main() {
 		ListenAddr:  "localhost:8080", // This example assumes you're in a dev environment running ngrok on 8080.
 		SecretToken: webhookSecret,    // Setting a webhook secret here allows you to ensure the webhook is set by you (must be set here AND in SetWebhook!).
 	}
-	// We use the token as the urlPath for the webhook, as using a secret ensures that strangers aren't crafting fake updates.
-	err = updater.StartWebhook(b, token, webhookOpts)
+
+	// The bot's urlPath can be anything. Here, we use "custom-path/<TOKEN>" as an example.
+	// It can be a good idea for the urlPath to contain the bot token, as that makes it very difficult for outside
+	// parties to find the update endpoint (which would allow them to inject their own updates).
+	err = updater.StartWebhook(b, "custom-path/"+token, webhookOpts)
 	if err != nil {
 		panic("failed to start webhook: " + err.Error())
 	}


### PR DESCRIPTION
# What

This PR fixes an issue where adding a bot twice with the same token would cause a panic at the HTTP Handler level. This was caused by the fact that we never remove routes for bots that get removed, because the http router only supports adding routes, not removing them.

So, rather than continuously increase the number of bots (some of them dead) on the mux, it would be helpful to remove them completely. Luckily, this can easily be achieved by simply reusing the existing botMapping functionality, which actually handles exactly that usecase. Voila.

# Impact

- Are your changes backwards compatible? Yes
- Have you included documentation, or updated existing documentation? Yes
- Do errors and log messages provide enough context? Yes
