### PR TITLE
Fix webhook handler prefix issue

### DIFF
--- a/ext/updater_test.go
+++ b/ext/updater_test.go
@@ -241,6 +241,12 @@ func TestUpdaterAllowsWebhookDeletion(t *testing.T) {
 		t.Errorf("failed to start long poll on first bot: %v", err)
 		return
 	}
+
+	err = u.Stop()
+	if err != nil {
+		t.Errorf("failed to stop updater: %v", err)
+		return
+	}
 }
 
 func TestUpdaterSupportsTwoPollingBots(t *testing.T) {
@@ -290,6 +296,12 @@ func TestUpdaterSupportsTwoPollingBots(t *testing.T) {
 		t.Errorf("should be able to add two different polling bots")
 		return
 	}
+
+	err = u.Stop()
+	if err != nil {
+		t.Errorf("failed to stop updater: %v", err)
+		return
+	}
 }
 
 func TestUpdaterThrowsErrorWhenSameLongPollAddedTwice(t *testing.T) {
@@ -330,6 +342,12 @@ func TestUpdaterThrowsErrorWhenSameLongPollAddedTwice(t *testing.T) {
 	})
 	if err == nil {
 		t.Errorf("should have failed to start the same long poll twice, but didnt")
+		return
+	}
+
+	err = u.Stop()
+	if err != nil {
+		t.Errorf("failed to stop updater: %v", err)
 		return
 	}
 }
@@ -375,6 +393,12 @@ func TestUpdaterSupportsLongPollReAdding(t *testing.T) {
 	})
 	if err != nil {
 		t.Errorf("Failed to re-start a previously removed bot: %v", err)
+		return
+	}
+
+	err = u.Stop()
+	if err != nil {
+		t.Errorf("failed to stop updater: %v", err)
 		return
 	}
 }

--- a/ext/updater_test.go
+++ b/ext/updater_test.go
@@ -105,7 +105,7 @@ func TestUpdater_GetHandlerFunc(t *testing.T) {
 		args args
 	}{
 		{
-			name: "With simple path",
+			name: "simple path",
 			args: args{
 				urlPath:       "123:hello",
 				httpResponse:  http.StatusOK,
@@ -113,7 +113,7 @@ func TestUpdater_GetHandlerFunc(t *testing.T) {
 				requestPath:   "/123:hello",
 			},
 		}, {
-			name: "With slash prefixed path",
+			name: "slash prefixed path",
 			args: args{
 				urlPath:       "/123:hello",
 				httpResponse:  http.StatusOK,
@@ -121,7 +121,7 @@ func TestUpdater_GetHandlerFunc(t *testing.T) {
 				requestPath:   "/123:hello",
 			},
 		}, {
-			name: "With subpath",
+			name: "using subpath",
 			args: args{
 				urlPath:       "123:hello",
 				httpResponse:  http.StatusOK,
@@ -129,7 +129,7 @@ func TestUpdater_GetHandlerFunc(t *testing.T) {
 				requestPath:   "/test/123:hello",
 			},
 		}, {
-			name: "With unknown path",
+			name: "unknown path",
 			args: args{
 				urlPath:       "123:hello",
 				httpResponse:  http.StatusNotFound,
@@ -137,7 +137,7 @@ func TestUpdater_GetHandlerFunc(t *testing.T) {
 				requestPath:   "/this-path-doesnt-exist",
 			},
 		}, {
-			name: "With missing secret token",
+			name: "missing secret token",
 			args: args{
 				urlPath: "123:hello",
 				opts: ext.WebhookOpts{


### PR DESCRIPTION
# What

Fix a bug where adding a webhook for a url path start with a / would cause 404 errors from the webhook. 

Also, add lots of regression tests.

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
