### PR TITLE
Improve concurrent safety

### DIFF
--- a/ext/botmapping.go
+++ b/ext/botmapping.go
@@ -16,13 +16,19 @@ import (
 type botData struct {
 	// bot represents the bot for which this data is relevant.
 	bot *gotgbot.Bot
+
 	// updateChan represents the incoming updates channel.
 	updateChan chan json.RawMessage
-	// polling allows us to close the polling loop.
-	polling chan struct{}
+	// updateWriterControl is used to count the number of current writers on the update channel.
+	// This is required to ensure that we can safely close the channel, and thus stop processing incoming updates.
+	// While this remains non-zero, it is unsafe to close the update channel.
+	updateWriterControl *sync.WaitGroup
+	// stopUpdates allows us to close the stopUpdates loop.
+	stopUpdates chan struct{}
+
 	// urlPath defines the incoming webhook URL path for this bot.
 	urlPath string
-	// webhookSecret stores the webhook secret for this bot
+	// webhookSecret stores the webhook secret for this bot.
 	webhookSecret string
 }
 
@@ -45,7 +51,8 @@ var ErrBotAlreadyExists = errors.New("bot already exists in bot mapping")
 var ErrBotUrlPathAlreadyExists = errors.New("url path already exists in bot mapping")
 
 // addBot Adds a new bot to the botMapping structure.
-func (m *botMapping) addBot(bData botData) error {
+// Pass an empty urlPath/webhookSecret if using polling instead of webhooks.
+func (m *botMapping) addBot(b *gotgbot.Bot, urlPath string, webhookSecret string) (*botData, error) {
 	m.mux.Lock()
 	defer m.mux.Unlock()
 
@@ -56,16 +63,26 @@ func (m *botMapping) addBot(bData botData) error {
 		m.urlMapping = make(map[string]string)
 	}
 
-	if _, ok := m.mapping[bData.bot.Token]; ok {
-		return ErrBotAlreadyExists
+	if _, ok := m.mapping[b.Token]; ok {
+		return nil, ErrBotAlreadyExists
 	}
-	if _, ok := m.urlMapping[bData.urlPath]; bData.urlPath != "" && ok {
-		return ErrBotUrlPathAlreadyExists
+
+	if _, ok := m.urlMapping[urlPath]; urlPath != "" && ok {
+		return nil, ErrBotUrlPathAlreadyExists
+	}
+
+	bData := botData{
+		bot:                 b,
+		updateChan:          make(chan json.RawMessage),
+		stopUpdates:         make(chan struct{}),
+		updateWriterControl: &sync.WaitGroup{},
+		urlPath:             urlPath,
+		webhookSecret:       webhookSecret,
 	}
 
 	m.mapping[bData.bot.Token] = bData
 	m.urlMapping[bData.urlPath] = bData.bot.Token
-	return nil
+	return &bData, nil
 }
 
 func (m *botMapping) removeBot(token string) (botData, bool) {
@@ -143,6 +160,8 @@ func (m *botMapping) getHandlerFunc(prefix string) func(writer http.ResponseWrit
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
+		b.updateWriterControl.Add(1)
+		defer b.updateWriterControl.Done()
 
 		headerSecret := r.Header.Get("X-Telegram-Bot-Api-Secret-Token")
 		if b.webhookSecret != "" && b.webhookSecret != headerSecret {
@@ -161,6 +180,11 @@ func (m *botMapping) getHandlerFunc(prefix string) func(writer http.ResponseWrit
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
+
+		if b.isUpdateChannelStopped() {
+			return
+		}
+
 		b.updateChan <- bytes
 	}
 }
@@ -170,5 +194,29 @@ func (m *botMapping) logf(format string, args ...interface{}) {
 		m.errorLog.Printf(format, args...)
 	} else {
 		log.Printf(format, args...)
+	}
+}
+
+func (b *botData) stop() {
+	// Close stopUpdates loops first, to ensure any updates currently being polled have the time to be sent to the updateChan.
+	if b.stopUpdates != nil {
+		close(b.stopUpdates)
+	}
+
+	// Wait for all writers to finish writing to the updateChannel
+	b.updateWriterControl.Wait()
+
+	// Then, close the updates channel.
+	close(b.updateChan)
+}
+
+func (b *botData) isUpdateChannelStopped() bool {
+	select {
+	case <-b.stopUpdates:
+		// if anything comes in on the closing channel, we know the channel is closed.
+		return true
+	default:
+		// otherwise, continue as usual
+		return false
 	}
 }

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -157,37 +157,25 @@ func (u *Updater) StartPolling(b *gotgbot.Bot, opts *PollingOpts) error {
 		}
 	}
 
-	updateChan := make(chan json.RawMessage)
-	pollChan := make(chan struct{})
-
-	err := u.botMapping.addBot(botData{
-		bot:        b,
-		updateChan: updateChan,
-		polling:    pollChan,
-	})
+	bData, err := u.botMapping.addBot(b, "", "")
 	if err != nil {
 		return fmt.Errorf("failed to add bot with long polling: %w", err)
 	}
 
-	go u.Dispatcher.Start(b, updateChan)
-	go u.pollingLoop(b, reqOpts, pollChan, updateChan, v)
+	go u.Dispatcher.Start(b, bData.updateChan)
+	go u.pollingLoop(bData, reqOpts, v)
 
 	return nil
 }
 
-func (u *Updater) pollingLoop(b *gotgbot.Bot, opts *gotgbot.RequestOpts, stopPolling <-chan struct{}, updateChan chan<- json.RawMessage, v map[string]string) {
-	for {
-		select {
-		case <-stopPolling:
-			// if anything comes in, stop polling.
-			return
-		default:
-			// otherwise, continue as usual
-		}
+func (u *Updater) pollingLoop(bData *botData, opts *gotgbot.RequestOpts, v map[string]string) {
+	bData.updateWriterControl.Add(1)
+	defer bData.updateWriterControl.Done()
 
+	for {
 		// Manually craft the getUpdate calls to improve memory management, reduce json parsing overheads, and
 		// unnecessary reallocation of url.Values in the polling loop.
-		r, err := b.Request("getUpdates", v, nil, opts)
+		r, err := bData.bot.Request("getUpdates", v, nil, opts)
 		if err != nil {
 			if u.UnhandledErrFunc != nil {
 				u.UnhandledErrFunc(err)
@@ -230,9 +218,14 @@ func (u *Updater) pollingLoop(b *gotgbot.Bot, opts *gotgbot.RequestOpts, stopPol
 		}
 
 		v["offset"] = strconv.FormatInt(lastUpdate.UpdateId+1, 10)
+
+		if bData.isUpdateChannelStopped() {
+			return
+		}
+
 		for _, updData := range rawUpdates {
 			temp := updData // use new mem address to avoid loop conflicts
-			updateChan <- temp
+			bData.updateChan <- temp
 		}
 	}
 }
@@ -285,17 +278,6 @@ func (u *Updater) StopAllBots() {
 	}
 }
 
-func (data botData) stop() {
-	// Close polling loops first, to ensure any updates currently being polled have the time to be sent to the
-	// updateChan.
-	if data.polling != nil {
-		close(data.polling)
-	}
-
-	// Then, close the updates channel.
-	close(data.updateChan)
-}
-
 // StartWebhook starts the webhook server for a single bot instance.
 // This does NOT set the webhook on telegram - this should be done by the caller.
 // The opts parameter allows for specifying various webhook settings.
@@ -320,20 +302,13 @@ func (u *Updater) AddWebhook(b *gotgbot.Bot, urlPath string, opts WebhookOpts) e
 		return fmt.Errorf("expected a non-empty url path: %w", ErrEmptyPath)
 	}
 
-	updateChan := make(chan json.RawMessage)
-
-	err := u.botMapping.addBot(botData{
-		bot:           b,
-		updateChan:    updateChan,
-		urlPath:       urlPath,
-		webhookSecret: opts.SecretToken,
-	})
+	bData, err := u.botMapping.addBot(b, urlPath, opts.SecretToken)
 	if err != nil {
 		return fmt.Errorf("failed to add webhook for bot: %w", err)
 	}
 
 	// Webhook has been added; relevant dispatcher should also be started.
-	go u.Dispatcher.Start(b, updateChan)
+	go u.Dispatcher.Start(b, bData.updateChan)
 	return nil
 }
 

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -298,7 +298,7 @@ func (u *Updater) AddWebhook(b *gotgbot.Bot, urlPath string, opts WebhookOpts) e
 		return fmt.Errorf("expected a non-empty url path: %w", ErrEmptyPath)
 	}
 
-  bData, err := u.botMapping.addBot(b, strings.TrimPrefix(urlPath, "/"), opts.SecretToken)
+	bData, err := u.botMapping.addBot(b, strings.TrimPrefix(urlPath, "/"), opts.SecretToken)
 	if err != nil {
 		return fmt.Errorf("failed to add webhook for bot: %w", err)
 	}

--- a/ext/updater_test.go
+++ b/ext/updater_test.go
@@ -10,9 +10,12 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/PaulSonOfLars/gotgbot/v2"
 	"github.com/PaulSonOfLars/gotgbot/v2/ext"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext/handlers"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext/handlers/filters/message"
 )
 
 func TestUpdaterThrowsErrorWhenSameWebhookAddedTwice(t *testing.T) {
@@ -69,6 +72,78 @@ func TestUpdaterSupportsWebhookReAdding(t *testing.T) {
 	}
 }
 
+// This test is a bit strange, as it tries to test concurrency events. Which means it relies on awkward timing
+// situations. To try and mitigate this, we run it multiple times in parallel; hoping this will help catch any issues.
+// The idea is that we want to be able to test getUpdates both BEFORE as well as AFTER the bot has been stopped.
+// Execution flow is:
+// - polling is started
+// - getUpdates receives "stop" message. Keeps running on loop with a 1s delay.
+// - dispatcher processes stop message; calls updater.stopBot, thus closing channels, removing from bot map, and stopping dispatcher.
+// - getUpdates receives message again, 1s later; but updater+dispatcher channels are already closed by then.
+// - IF not concurrently safe; we get a panic. Else, works fine!
+// - Since updater channels are closed, messages should not be processed.
+//
+// NOTE: IF THIS FAILS, IT IS NOT A FLAKE! Investigate!
+func TestUpdaterPollingConcurrency(t *testing.T) {
+	for i := 0; i < 5; i++ {
+		t.Run(fmt.Sprintf("run_%d", i), func(t *testing.T) {
+			concurrentTest(t)
+		})
+	}
+}
+
+func concurrentTest(t *testing.T) {
+	// we run it in parallel so that we get all the perks
+	t.Parallel()
+
+	delay := time.Second
+	server := basicTestServer(t, map[string]testEndpoint{
+		"getUpdates":    {delay: delay, reply: `{"ok": true, "result": [{"message": {"text": "stop"}}]}`},
+		"deleteWebhook": {reply: `{"ok": true, "result": true}`},
+	})
+	defer server.Close()
+
+	reqOpts := &gotgbot.RequestOpts{
+		APIURL:  server.URL,
+		Timeout: delay * 2,
+	}
+
+	b := &gotgbot.Bot{
+		User:      gotgbot.User{},
+		Token:     "SOME_TOKEN",
+		BotClient: &gotgbot.BaseBotClient{},
+	}
+
+	d := ext.NewDispatcher(&ext.DispatcherOpts{MaxRoutines: 1})
+	u := ext.NewUpdater(d, nil)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	d.AddHandler(handlers.NewMessage(message.Contains("stop"), func(b *gotgbot.Bot, ctx *ext.Context) error {
+		if !u.StopBot(b.Token) {
+			t.Errorf("Could not stop bot!")
+		}
+		// Make sure we mark this method as having run only once.
+		// (if run twice, we get a panic)
+		wg.Done()
+		return nil
+	}))
+
+	err := u.StartPolling(b, &ext.PollingOpts{
+		GetUpdatesOpts: &gotgbot.GetUpdatesOpts{
+			RequestOpts: reqOpts,
+		},
+	})
+	if err != nil {
+		t.Errorf("failed to start polling: %v", err)
+		return
+	}
+
+	wg.Wait()
+	time.Sleep(delay * 2)
+}
+
 func TestUpdaterDisallowsEmptyWebhooks(t *testing.T) {
 	b := &gotgbot.Bot{
 		Token:     "SOME_TOKEN",
@@ -86,9 +161,9 @@ func TestUpdaterDisallowsEmptyWebhooks(t *testing.T) {
 }
 
 func TestUpdaterAllowsWebhookDeletion(t *testing.T) {
-	server := basicTestServer(t, map[string]string{
-		"getUpdates":    `{}`,
-		"deleteWebhook": `{"ok": true, "result": true}`,
+	server := basicTestServer(t, map[string]testEndpoint{
+		"getUpdates":    {reply: `{"ok": true}`},
+		"deleteWebhook": {reply: `{"ok": true, "result": true}`},
 	})
 	defer server.Close()
 
@@ -119,8 +194,8 @@ func TestUpdaterAllowsWebhookDeletion(t *testing.T) {
 }
 
 func TestUpdaterSupportsTwoPollingBots(t *testing.T) {
-	server := basicTestServer(t, map[string]string{
-		"getUpdates": `{"ok": true, "result": []}`,
+	server := basicTestServer(t, map[string]testEndpoint{
+		"getUpdates": {reply: `{"ok": true, "result": []}`},
 	})
 	defer server.Close()
 
@@ -168,8 +243,8 @@ func TestUpdaterSupportsTwoPollingBots(t *testing.T) {
 }
 
 func TestUpdaterThrowsErrorWhenSameLongPollAddedTwice(t *testing.T) {
-	server := basicTestServer(t, map[string]string{
-		"getUpdates": `{"ok": true, "result": []}`,
+	server := basicTestServer(t, map[string]testEndpoint{
+		"getUpdates": {reply: `{"ok": true, "result": []}`},
 	})
 	defer server.Close()
 
@@ -210,8 +285,8 @@ func TestUpdaterThrowsErrorWhenSameLongPollAddedTwice(t *testing.T) {
 }
 
 func TestUpdaterSupportsLongPollReAdding(t *testing.T) {
-	server := basicTestServer(t, map[string]string{
-		"getUpdates": `{"ok": true, "result": []}`,
+	server := basicTestServer(t, map[string]testEndpoint{
+		"getUpdates": {reply: `{"ok": true, "result": []}`},
 	})
 	defer server.Close()
 
@@ -254,7 +329,12 @@ func TestUpdaterSupportsLongPollReAdding(t *testing.T) {
 	}
 }
 
-func basicTestServer(t *testing.T, methods map[string]string) *httptest.Server {
+type testEndpoint struct {
+	delay time.Duration
+	reply string
+}
+
+func basicTestServer(t *testing.T, methods map[string]testEndpoint) *httptest.Server {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		pathItems := strings.Split(r.URL.Path, "/")
 		lastItem := pathItems[len(pathItems)-1]
@@ -262,7 +342,10 @@ func basicTestServer(t *testing.T, methods map[string]string) *httptest.Server {
 
 		out, ok := methods[lastItem]
 		if ok {
-			fmt.Fprint(w, out)
+			if out.delay != 0 {
+				time.Sleep(out.delay)
+			}
+			fmt.Fprint(w, out.reply)
 			return
 		}
 


### PR DESCRIPTION
# What

Fix panics due to writes on closed channels reported in the [support chat](https://t.me/GotgbotChat/11452).

This was caused by a previous refactor which removed a write to the closing channel in favour of simply closing the channel. It has now been improved to be thread safe on both polling and webhooks.

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
