### PR TITLE
Add handler helpers

### DIFF
--- a/ext/handlers/callbackquery.go
+++ b/ext/handlers/callbackquery.go
@@ -21,6 +21,7 @@ func NewCallback(filter filters.CallbackQuery, r Response) CallbackQuery {
 	}
 }
 
+// SetAllowChannel Enables channel messages for this handler.
 func (cb CallbackQuery) SetAllowChannel(allow bool) CallbackQuery {
 	cb.AllowChannel = allow
 	return cb

--- a/ext/handlers/callbackquery.go
+++ b/ext/handlers/callbackquery.go
@@ -21,6 +21,11 @@ func NewCallback(filter filters.CallbackQuery, r Response) CallbackQuery {
 	}
 }
 
+func (cb CallbackQuery) SetAllowChannel(allow bool) CallbackQuery {
+	cb.AllowChannel = allow
+	return cb
+}
+
 func (cb CallbackQuery) HandleUpdate(b *gotgbot.Bot, ctx *ext.Context) error {
 	return cb.Response(b, ctx)
 }

--- a/ext/handlers/command.go
+++ b/ext/handlers/command.go
@@ -26,11 +26,13 @@ func NewCommand(c string, r Response) Command {
 	}
 }
 
+// SetAllowEdited Enables edited messages for this handler.
 func (c Command) SetAllowEdited(allow bool) Command {
 	c.AllowEdited = allow
 	return c
 }
 
+// SetAllowChannel Enables channel messages for this handler.
 func (c Command) SetAllowChannel(allow bool) Command {
 	c.AllowChannel = allow
 	return c

--- a/ext/handlers/command.go
+++ b/ext/handlers/command.go
@@ -26,6 +26,16 @@ func NewCommand(c string, r Response) Command {
 	}
 }
 
+func (c Command) SetAllowEdited(allow bool) Command {
+	c.AllowEdited = allow
+	return c
+}
+
+func (c Command) SetAllowChannel(allow bool) Command {
+	c.AllowChannel = allow
+	return c
+}
+
 func (c Command) CheckUpdate(b *gotgbot.Bot, ctx *ext.Context) bool {
 	if ctx.Message != nil {
 		if ctx.Message.Text == "" && ctx.Message.Caption == "" {

--- a/ext/handlers/message.go
+++ b/ext/handlers/message.go
@@ -24,6 +24,16 @@ func NewMessage(f filters.Message, r Response) Message {
 	}
 }
 
+func (m Message) SetAllowEdited(allow bool) Message {
+	m.AllowEdited = allow
+	return m
+}
+
+func (m Message) SetAllowChannel(allow bool) Message {
+	m.AllowChannel = allow
+	return m
+}
+
 func (m Message) CheckUpdate(b *gotgbot.Bot, ctx *ext.Context) bool {
 	if ctx.Message != nil {
 		return m.Filter == nil || m.Filter(ctx.Message)

--- a/ext/handlers/message.go
+++ b/ext/handlers/message.go
@@ -24,11 +24,13 @@ func NewMessage(f filters.Message, r Response) Message {
 	}
 }
 
+// SetAllowEdited Enables edited messages for this handler.
 func (m Message) SetAllowEdited(allow bool) Message {
 	m.AllowEdited = allow
 	return m
 }
 
+// SetAllowChannel Enables channel messages for this handler.
 func (m Message) SetAllowChannel(allow bool) Message {
 	m.AllowChannel = allow
 	return m


### PR DESCRIPTION
# What

Add new helper methods to make it easier to enable channels or edited messages on commands.

Unsure about this PR as it stands; I notice these things:
- the AllowX fields are inconsistent; why doesnt the ChatMember handler have an `AllowChannel` field? or the ChatJoinRequest handlers?
- I can't really remove them, as this would break existing bots in weird ways ("Why does my bot now do stuff in channels?")

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y