### PR TITLE
Add reactions support.

### DIFF
--- a/ext/handlers/filters/reaction/reaction.go
+++ b/ext/handlers/filters/reaction/reaction.go
@@ -9,18 +9,12 @@ func All(_ *gotgbot.MessageReactionUpdated) bool {
 	return true
 }
 
-func FromUserID(id int64) filters.Reaction {
+func FromPeer(id int64) filters.Reaction {
 	return func(mru *gotgbot.MessageReactionUpdated) bool {
 		if mru.User != nil {
 			return mru.User.Id == id
 		}
 
-		return false
-	}
-}
-
-func FromAnonymousChatID(id int64) filters.Reaction {
-	return func(mru *gotgbot.MessageReactionUpdated) bool {
 		if mru.ActorChat != nil {
 			return mru.ActorChat.Id == id
 		}
@@ -29,13 +23,13 @@ func FromAnonymousChatID(id int64) filters.Reaction {
 	}
 }
 
-func FromChatID(id int64) filters.Reaction {
+func ChatID(id int64) filters.Reaction {
 	return func(mru *gotgbot.MessageReactionUpdated) bool {
 		return mru.Chat.Id == id
 	}
 }
 
-func NewReactionIn(reaction string) filters.Reaction {
+func NewReactionEmoji(reaction string) filters.Reaction {
 	return func(mru *gotgbot.MessageReactionUpdated) bool {
 		for _, r := range mru.NewReaction {
 			if r.MergeReactionType().Emoji == reaction {
@@ -47,7 +41,7 @@ func NewReactionIn(reaction string) filters.Reaction {
 	}
 }
 
-func OldReactionIn(reaction string) filters.Reaction {
+func OldReactionEmoji(reaction string) filters.Reaction {
 	return func(mru *gotgbot.MessageReactionUpdated) bool {
 		for _, r := range mru.OldReaction {
 			if r.MergeReactionType().Emoji == reaction {

--- a/ext/handlers/filters/reaction/reaction.go
+++ b/ext/handlers/filters/reaction/reaction.go
@@ -1,0 +1,60 @@
+package reaction
+
+import (
+	"github.com/PaulSonOfLars/gotgbot/v2"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext/handlers/filters"
+)
+
+func All(_ *gotgbot.MessageReactionUpdated) bool {
+	return true
+}
+
+func FromUserID(id int64) filters.Reaction {
+	return func(mru *gotgbot.MessageReactionUpdated) bool {
+		if mru.User != nil {
+			return mru.User.Id == id
+		}
+
+		return false
+	}
+}
+
+func FromAnonymousChatID(id int64) filters.Reaction {
+	return func(mru *gotgbot.MessageReactionUpdated) bool {
+		if mru.ActorChat != nil {
+			return mru.ActorChat.Id == id
+		}
+
+		return false
+	}
+}
+
+func FromChatID(id int64) filters.Reaction {
+	return func(mru *gotgbot.MessageReactionUpdated) bool {
+		return mru.Chat.Id == id
+	}
+}
+
+func NewReactionIn(reaction string) filters.Reaction {
+	return func(mru *gotgbot.MessageReactionUpdated) bool {
+		for _, r := range mru.NewReaction {
+			if r.MergeReactionType().Emoji == reaction {
+				return true
+			}
+		}
+
+		return false
+	}
+}
+
+func OldReactionIn(reaction string) filters.Reaction {
+	return func(mru *gotgbot.MessageReactionUpdated) bool {
+		for _, r := range mru.OldReaction {
+			if r.MergeReactionType().Emoji == reaction {
+				return true
+			}
+		}
+
+		return false
+	}
+}

--- a/ext/handlers/filters/types.go
+++ b/ext/handlers/filters/types.go
@@ -13,4 +13,5 @@ type (
 	PollAnswer         func(pa *gotgbot.PollAnswer) bool
 	PreCheckoutQuery   func(pcq *gotgbot.PreCheckoutQuery) bool
 	ShippingQuery      func(sq *gotgbot.ShippingQuery) bool
+	Reaction           func(mra *gotgbot.MessageReactionUpdated) bool
 )

--- a/ext/handlers/reaction.go
+++ b/ext/handlers/reaction.go
@@ -1,0 +1,36 @@
+package handlers
+
+import (
+	"fmt"
+
+	"github.com/PaulSonOfLars/gotgbot/v2"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext"
+	"github.com/PaulSonOfLars/gotgbot/v2/ext/handlers/filters"
+)
+
+type Reaction struct {
+	Filter   filters.Reaction
+	Response Response
+}
+
+func NewReaction(f filters.Reaction, r Response) Reaction {
+	return Reaction{
+		Filter:   f,
+		Response: r,
+	}
+}
+
+func (r Reaction) CheckUpdate(b *gotgbot.Bot, ctx *ext.Context) bool {
+	if ctx.MessageReaction == nil {
+		return false
+	}
+	return r.Filter == nil || r.Filter(ctx.MessageReaction)
+}
+
+func (r Reaction) HandleUpdate(b *gotgbot.Bot, ctx *ext.Context) error {
+	return r.Response(b, ctx)
+}
+
+func (r Reaction) Name() string {
+	return fmt.Sprintf("reaction_%p", r.Response)
+}


### PR DESCRIPTION
<!--
Hey, thank you for opening a PR!

Please fill out the details below; they're there to help both you and the maintainers!
-->

# What

This introduces support for handling new reactions that are set on messages.
Adds new filters:
`Reaction.FromUserID(id int64)` - Checks whether the reaction from specified user or not.
`Reaction.FromAnonymousChatID(id int64)` - Checks whether the reaction from specified anonymous channel\admin or not.
`Reaction.FromChatID(id int64)` - Checks if the reaction has been set in specified chat
`Reaction.New(Old)ReactionIn(reaction string)` - Checks if the newly set(removed) reaction contains emoji, which is provided as `reaction` argument.

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? Not required.
- Do errors and log messages provide enough context? Not required.
