### PR TITLE
Improve polling updater.stop() call when long polling

### DIFF
--- a/ext/botmapping_test.go
+++ b/ext/botmapping_test.go
@@ -89,13 +89,13 @@ func Test_botData_isUpdateChannelStopped(t *testing.T) {
 		t.Errorf("bot with token %s should not have failed to be added", b.Token)
 		return
 	}
-	if bData.isUpdateChannelStopped() {
+	if bData.shouldStopUpdates() {
 		t.Errorf("bot with token %s should not be stopped yet", b.Token)
 		return
 	}
 
 	bData.stop()
-	if !bData.isUpdateChannelStopped() {
+	if !bData.shouldStopUpdates() {
 		t.Errorf("bot with token %s should be stopped", b.Token)
 		return
 	}


### PR DESCRIPTION
# What

Polling can cause the updater.stop to hang if no updates are incoming - this should fix that issue.

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
