### PR TITLE
Add new GetText and GetEntities helper methods

### DIFF
--- a/custom_helpers.go
+++ b/custom_helpers.go
@@ -20,6 +20,22 @@ func (m Message) GetLink() string {
 	return fmt.Sprintf("https://t.me/c/%s/%d", rawChatId, m.MessageId)
 }
 
+// GetText returns the message text, for both text messages and media messages. (Why is this not the telegram default!)
+func (m Message) GetText() string {
+	if m.Caption != "" {
+		return m.Caption
+	}
+	return m.Text
+}
+
+// GetEntities returns the message entities, for both text messages and media messages. (Why is this not the telegram default!)
+func (m Message) GetEntities() []MessageEntity {
+	if len(m.CaptionEntities) > 0 {
+		return m.CaptionEntities
+	}
+	return m.Entities
+}
+
 // Reply is a helper function to easily call Bot.SendMessage as a reply to an existing Message.
 func (m Message) Reply(b *Bot, text string, opts *SendMessageOpts) (*Message, error) {
 	if opts == nil {

--- a/ext/context.go
+++ b/ext/context.go
@@ -156,31 +156,9 @@ func NewContext(update *gotgbot.Update, data map[string]interface{}) *Context {
 
 // Args gets the list of whitespace-separated arguments of the message text.
 func (c *Context) Args() []string {
-	var msg *gotgbot.Message
-
-	switch {
-	case c.Update.Message != nil:
-		msg = c.Update.Message
-
-	case c.Update.EditedMessage != nil:
-		msg = c.Update.EditedMessage
-
-	case c.Update.ChannelPost != nil:
-		msg = c.Update.ChannelPost
-
-	case c.Update.EditedChannelPost != nil:
-		msg = c.Update.EditedChannelPost
-
-	case c.Update.CallbackQuery != nil && c.Update.CallbackQuery.Message != nil:
-		m, ok := c.Update.CallbackQuery.Message.(gotgbot.Message)
-		if ok {
-			msg = &m
-		}
-	}
-
-	if msg == nil {
+	if c.EffectiveMessage == nil {
 		return nil
 	}
 
-	return strings.Fields(msg.GetText())
+	return strings.Fields(c.EffectiveMessage.GetText())
 }

--- a/ext/context.go
+++ b/ext/context.go
@@ -182,11 +182,5 @@ func (c *Context) Args() []string {
 		return nil
 	}
 
-	if msg.Text != "" {
-		return strings.Fields(msg.Text)
-	} else if msg.Caption != "" {
-		return strings.Fields(msg.Caption)
-	}
-
-	return nil
+	return strings.Fields(msg.GetText())
 }

--- a/ext/handlers/command.go
+++ b/ext/handlers/command.go
@@ -53,7 +53,7 @@ func (c Command) SetTriggers(triggers []rune) Command {
 
 func (c Command) CheckUpdate(b *gotgbot.Bot, ctx *ext.Context) bool {
 	if ctx.Message != nil {
-		if ctx.Message.Text == "" && ctx.Message.Caption == "" {
+		if ctx.Message.GetText() == "" {
 			return false
 		}
 		return c.checkMessage(b, ctx.Message)
@@ -61,21 +61,21 @@ func (c Command) CheckUpdate(b *gotgbot.Bot, ctx *ext.Context) bool {
 
 	// if no edits and message is edited
 	if c.AllowEdited && ctx.EditedMessage != nil {
-		if ctx.EditedMessage.Text == "" && ctx.EditedMessage.Caption == "" {
+		if ctx.EditedMessage.GetText() == "" {
 			return false
 		}
 		return c.checkMessage(b, ctx.EditedMessage)
 	}
 	// if no channel and message is channel message
 	if c.AllowChannel && ctx.ChannelPost != nil {
-		if ctx.ChannelPost.Text == "" && ctx.ChannelPost.Caption == "" {
+		if ctx.ChannelPost.GetText() == "" {
 			return false
 		}
 		return c.checkMessage(b, ctx.ChannelPost)
 	}
 	// if no channel, no edits, and post is edited
 	if c.AllowChannel && c.AllowEdited && ctx.EditedChannelPost != nil {
-		if ctx.EditedChannelPost.Text == "" && ctx.EditedChannelPost.Caption == "" {
+		if ctx.EditedChannelPost.GetText() == "" {
 			return false
 		}
 		return c.checkMessage(b, ctx.EditedChannelPost)
@@ -93,10 +93,7 @@ func (c Command) Name() string {
 }
 
 func (c Command) checkMessage(b *gotgbot.Bot, msg *gotgbot.Message) bool {
-	text := msg.Text
-	if msg.Caption != "" {
-		text = msg.Caption
-	}
+	text := msg.GetText()
 
 	var cmd string
 	for _, t := range c.Triggers {
@@ -115,7 +112,8 @@ func (c Command) checkMessage(b *gotgbot.Bot, msg *gotgbot.Message) bool {
 		return false
 	}
 
-	if len(msg.Entities) != 0 && msg.Entities[0].Offset == 0 && msg.Entities[0].Type != "bot_command" {
+	ents := msg.GetEntities()
+	if len(ents) != 0 && ents[0].Offset == 0 && ents[0].Type != "bot_command" {
 		return false
 	}
 

--- a/ext/handlers/filters/message/message.go
+++ b/ext/handlers/filters/message/message.go
@@ -63,12 +63,7 @@ func Regex(p string) (filters.Message, error) {
 		return nil, fmt.Errorf("failed to compile regex: %w", err)
 	}
 	return func(m *gotgbot.Message) bool {
-		if m.Text != "" {
-			return r.MatchString(m.Text)
-		} else if m.Caption != "" {
-			return r.MatchString(m.Caption)
-		}
-		return false
+		return r.MatchString(m.GetText())
 	}, nil
 }
 
@@ -108,26 +103,26 @@ func Text(msg *gotgbot.Message) bool {
 
 func HasPrefix(prefix string) filters.Message {
 	return func(msg *gotgbot.Message) bool {
-		return strings.HasPrefix(msg.Text, prefix) || strings.HasPrefix(msg.Caption, prefix)
+		return strings.HasPrefix(msg.GetText(), prefix)
 
 	}
 }
 
 func HasSuffix(suffix string) filters.Message {
 	return func(msg *gotgbot.Message) bool {
-		return strings.HasSuffix(msg.Text, suffix) || strings.HasSuffix(msg.Caption, suffix)
+		return strings.HasSuffix(msg.GetText(), suffix)
 	}
 }
 
 func Contains(contains string) filters.Message {
 	return func(msg *gotgbot.Message) bool {
-		return strings.Contains(msg.Text, contains) || strings.Contains(msg.Caption, contains)
+		return strings.Contains(msg.GetText(), contains)
 	}
 }
 
 func Equal(eq string) filters.Message {
 	return func(msg *gotgbot.Message) bool {
-		return msg.Text == eq || msg.Caption == eq
+		return msg.GetText() == eq
 	}
 }
 
@@ -136,12 +131,8 @@ func Caption(msg *gotgbot.Message) bool {
 }
 
 func Command(msg *gotgbot.Message) bool {
-	if msg.Text != "" {
-		return len(msg.Entities) > 0 && msg.Entities[0].Type == "bot_command" && msg.Entities[0].Offset == 0
-	} else if msg.Caption != "" {
-		return len(msg.CaptionEntities) > 0 && msg.CaptionEntities[0].Type == "bot_command" && msg.CaptionEntities[0].Offset == 0
-	}
-	return false
+	ents := msg.GetEntities()
+	return len(ents) > 0 && ents[0].Type == "bot_command" && ents[0].Offset == 0
 }
 
 func Animation(msg *gotgbot.Message) bool {


### PR DESCRIPTION

# What

Add new GetText and GetEntities helper methods, which handle the logic of discerning between text and media messages.

This also fixes an issue where monospace commands in captions would trigger command handlers; caused by incorrect entity handling.

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
