### PR TITLE
Add constants for chat actions

### DIFF
--- a/gen_consts.go
+++ b/gen_consts.go
@@ -111,6 +111,21 @@ const (
 	ParseModeNone       = ""
 )
 
+// The consts listed below represent all the chat action options that can be sent to telegram.
+const (
+	ChatActionTyping          = "typing"
+	ChatActionUploadPhoto     = "upload_photo"
+	ChatActionRecordVideo     = "record_video"
+	ChatActionUploadVideo     = "upload_video"
+	ChatActionRecordVoice     = "record_voice"
+	ChatActionUploadVoice     = "upload_voice"
+	ChatActionUploadDocument  = "upload_document"
+	ChatActionChooseSticker   = "choose_sticker"
+	ChatActionFindLocation    = "find_location"
+	ChatActionRecordVideoNote = "record_video_note"
+	ChatActionUploadVideoNote = "upload_video_note"
+)
+
 // The consts listed below represent all the sticker types that can be obtained from telegram.
 const (
 	StickerTypeRegular     = "regular"

--- a/scripts/generate/consts.go
+++ b/scripts/generate/consts.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -23,7 +24,12 @@ package gotgbot
 	consts.WriteString(updateConsts)
 
 	consts.WriteString(generateParseModeConsts())
-	consts.WriteString(generateChatActionConsts())
+
+	chatActions, err := generateChatActionConsts(d)
+	if err != nil {
+		return fmt.Errorf("failed to generate consts for chat actions: %w", err)
+	}
+	consts.WriteString(chatActions)
 
 	stickerTypeConsts, err := generateTypeConsts(d, "Sticker")
 	if err != nil {
@@ -123,19 +129,37 @@ func generateParseModeConsts() string {
 	return out.String()
 }
 
-func generateChatActionConsts() string {
-	chatActions := []string{
-		"typing",
-		"upload_photo",
-		"record_video",
-		"upload_video",
-		"record_voice",
-		"upload_voice",
-		"upload_document",
-		"choose_sticker",
-		"find_location",
-		"record_video_note",
-		"upload_video_note",
+func generateChatActionConsts(d APIDescription) (string, error) {
+	methodName := "sendChatAction"
+	fieldName := "action"
+
+	sendChatActionMethod, ok := d.Methods[methodName]
+	if !ok {
+		return "", errors.New("missing '" + methodName + "' method data")
+	}
+
+	var description string
+
+	for _, field := range sendChatActionMethod.Fields {
+		if field.Name == fieldName {
+			description = field.Description
+
+			break
+		}
+	}
+
+	if description == "" {
+		return "", errors.New("missing '" + fieldName + "' method field")
+	}
+
+	// Parse chat action from the description
+	var chatActions []string
+
+	re := regexp.MustCompile(`(?P<action>[a-z_]+) f?or`)
+	results := re.FindAllStringSubmatch(description, -1)
+
+	for _, result := range results {
+		chatActions = append(chatActions, result[1])
 	}
 
 	out := strings.Builder{}
@@ -149,7 +173,7 @@ func generateChatActionConsts() string {
 
 	out.WriteString(")\n\n")
 
-	return out.String()
+	return out.String(), nil
 }
 
 func writeConst(name string, value string) string {

--- a/scripts/generate/consts.go
+++ b/scripts/generate/consts.go
@@ -23,6 +23,7 @@ package gotgbot
 	consts.WriteString(updateConsts)
 
 	consts.WriteString(generateParseModeConsts())
+	consts.WriteString(generateChatActionConsts())
 
 	stickerTypeConsts, err := generateTypeConsts(d, "Sticker")
 	if err != nil {
@@ -119,6 +120,35 @@ func generateParseModeConsts() string {
 		out.WriteString(writeConst(constName, t))
 	}
 	out.WriteString(")\n\n")
+	return out.String()
+}
+
+func generateChatActionConsts() string {
+	chatActions := []string{
+		"typing",
+		"upload_photo",
+		"record_video",
+		"upload_video",
+		"record_voice",
+		"upload_voice",
+		"upload_document",
+		"choose_sticker",
+		"find_location",
+		"record_video_note",
+		"upload_video_note",
+	}
+
+	out := strings.Builder{}
+	out.WriteString("\n// The consts listed below represent all the chat action options that can be sent to telegram.")
+	out.WriteString("\nconst (")
+
+	for _, a := range chatActions {
+		constName := "ChatAction" + snakeToTitle(a)
+		out.WriteString(writeConst(constName, a))
+	}
+
+	out.WriteString(")\n\n")
+
 	return out.String()
 }
 


### PR DESCRIPTION
# What

Add constants for chat actions to avoid typos.
https://core.telegram.org/bots/api#sendchataction

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? N/A
- Do errors and log messages provide enough context? Y
