### PR TITLE
Draft: Add reaction constants

### DIFF
--- a/gen_consts.go
+++ b/gen_consts.go
@@ -111,6 +111,21 @@ const (
 	ParseModeNone       = ""
 )
 
+// The consts listed below represent all the sticker types that can be obtained from telegram.
+const (
+	StickerTypeRegular     = "regular"
+	StickerTypeMask        = "mask"
+	StickerTypeCustomEmoji = "custom_emoji"
+)
+
+// The consts listed below represent all the chat types that can be obtained from telegram.
+const (
+	ChatTypePrivate    = "private"
+	ChatTypeGroup      = "group"
+	ChatTypeSupergroup = "supergroup"
+	ChatTypeChannel    = "channel"
+)
+
 // The consts listed below represent all the chat action options that can be sent to telegram.
 const (
 	ChatActionTyping          = "typing"
@@ -126,17 +141,79 @@ const (
 	ChatActionUploadVideoNote = "upload_video_note"
 )
 
-// The consts listed below represent all the sticker types that can be obtained from telegram.
+// The consts listed below represent all the reaction options that can be sent to telegram as ReactionTypeEmoji.
 const (
-	StickerTypeRegular     = "regular"
-	StickerTypeMask        = "mask"
-	StickerTypeCustomEmoji = "custom_emoji"
-)
-
-// The consts listed below represent all the chat types that can be obtained from telegram.
-const (
-	ChatTypePrivate    = "private"
-	ChatTypeGroup      = "group"
-	ChatTypeSupergroup = "supergroup"
-	ChatTypeChannel    = "channel"
+	ReactionThumbsUp                   = "👍"
+	ReactionThumbsDown                 = "👎"
+	ReactionRedHeart                   = "❤"
+	ReactionFire                       = "🔥"
+	ReactionSmilingFaceWithHearts      = "🥰"
+	ReactionClappingHands              = "👏"
+	ReactionBeamingFaceWithSmilingEyes = "😁"
+	ReactionThinkingFace               = "🤔"
+	ReactionExplodingHead              = "🤯"
+	ReactionFaceScreamingInFear        = "😱"
+	ReactionFaceWithSymbolsOnMouth     = "🤬"
+	ReactionCryingFace                 = "😢"
+	ReactionPartyPopper                = "🎉"
+	ReactionStarStruck                 = "🤩"
+	ReactionFaceVomiting               = "🤮"
+	ReactionPileOfPoo                  = "💩"
+	ReactionFoldedHands                = "🙏"
+	ReactionOkHand                     = "👌"
+	ReactionDove                       = "🕊"
+	ReactionClownFace                  = "🤡"
+	ReactionYawningFace                = "🥱"
+	ReactionWoozyFace                  = "🥴"
+	ReactionSmilingFaceWithHeartEyes   = "😍"
+	ReactionSpoutingWhale              = "🐳"
+	ReactionHeartOnFire                = "❤‍🔥"
+	ReactionNewMoonFace                = "🌚"
+	ReactionHotDog                     = "🌭"
+	ReactionHundredPoints              = "💯"
+	ReactionRollingOnTheFloorLaughing  = "🤣"
+	ReactionHighVoltage                = "⚡"
+	ReactionBanana                     = "🍌"
+	ReactionTrophy                     = "🏆"
+	ReactionBrokenHeart                = "💔"
+	ReactionFaceWithRaisedEyebrow      = "🤨"
+	ReactionNeutralFace                = "😐"
+	ReactionStrawberry                 = "🍓"
+	ReactionBottleWithPoppingCork      = "🍾"
+	ReactionKissMark                   = "💋"
+	ReactionMiddleFinger               = "🖕"
+	ReactionSmilingFaceWithHorns       = "😈"
+	ReactionSleepingFace               = "😴"
+	ReactionLoudlyCryingFace           = "😭"
+	ReactionNerdFace                   = "🤓"
+	ReactionGhost                      = "👻"
+	ReactionManTechnologist            = "👨‍💻"
+	ReactionEyes                       = "👀"
+	ReactionJackOLantern               = "🎃"
+	ReactionSeeNoEvilMonkey            = "🙈"
+	ReactionSmilingFaceWithHalo        = "😇"
+	ReactionFearfulFace                = "😨"
+	ReactionHandshake                  = "🤝"
+	ReactionWritingHand                = "✍"
+	ReactionSmilingFaceWithOpenHands   = "🤗"
+	ReactionSalutingFace               = "🫡"
+	ReactionSantaClaus                 = "🎅"
+	ReactionChristmasTree              = "🎄"
+	ReactionSnowman                    = "☃"
+	ReactionNailPolish                 = "💅"
+	ReactionZanyFace                   = "🤪"
+	ReactionMoai                       = "🗿"
+	ReactionCoolButton                 = "🆒"
+	ReactionHeartWithArrow             = "💘"
+	ReactionHearNoEvilMonkey           = "🙉"
+	ReactionUnicorn                    = "🦄"
+	ReactionFaceBlowingAKiss           = "😘"
+	ReactionPill                       = "💊"
+	ReactionSpeakNoEvilMonkey          = "🙊"
+	ReactionSmilingFaceWithSunglasses  = "😎"
+	ReactionAlienMonster               = "👾"
+	ReactionManShrugging               = "🤷‍♂"
+	ReactionPersonShrugging            = "🤷"
+	ReactionWomanShrugging             = "🤷‍♀"
+	ReactionEnragedFace                = "😡"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/PaulSonOfLars/gotgbot/v2
 
 go 1.19
+
+require github.com/forPelevin/gomoji v1.2.0
+
+require github.com/rivo/uniseg v0.4.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/forPelevin/gomoji v1.2.0 h1:9k4WVSSkE1ARO/BWywxgEUBvR/jMnao6EZzrql5nxJ8=
+github.com/forPelevin/gomoji v1.2.0/go.mod h1:8+Z3KNGkdslmeGZBC3tCrwMrcPy5GRzAD+gL9NAwMXg=
+github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
+github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=

--- a/scripts/generate/consts.go
+++ b/scripts/generate/consts.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/forPelevin/gomoji"
 )
 
 func generateConsts(d APIDescription) error {
@@ -25,12 +27,6 @@ package gotgbot
 
 	consts.WriteString(generateParseModeConsts())
 
-	chatActions, err := generateChatActionConsts(d)
-	if err != nil {
-		return fmt.Errorf("failed to generate consts for chat actions: %w", err)
-	}
-	consts.WriteString(chatActions)
-
 	stickerTypeConsts, err := generateTypeConsts(d, "Sticker")
 	if err != nil {
 		return fmt.Errorf("failed to generate consts for sticker types: %w", err)
@@ -42,6 +38,18 @@ package gotgbot
 		return fmt.Errorf("failed to generate consts for chat types: %w", err)
 	}
 	consts.WriteString(chatTypeConsts)
+
+	chatActions, err := generateChatActionConsts(d)
+	if err != nil {
+		return fmt.Errorf("failed to generate consts for chat actions: %w", err)
+	}
+	consts.WriteString(chatActions)
+
+	reactions, err := generateReactionConsts(d)
+	if err != nil {
+		return fmt.Errorf("failed to generate consts for reactions: %w", err)
+	}
+	consts.WriteString(reactions)
 
 	return writeGenToFile(consts, "gen_consts.go")
 }
@@ -169,6 +177,63 @@ func generateChatActionConsts(d APIDescription) (string, error) {
 	for _, a := range chatActions {
 		constName := "ChatAction" + snakeToTitle(a)
 		out.WriteString(writeConst(constName, a))
+	}
+
+	out.WriteString(")\n\n")
+
+	return out.String(), nil
+}
+
+func generateReactionConsts(d APIDescription) (string, error) {
+	typeName := "ReactionTypeEmoji"
+	fieldName := "emoji"
+
+	reactionEmojiType, ok := d.Types[typeName]
+	if !ok {
+		return "", errors.New("missing '" + typeName + "' type data")
+	}
+
+	var description string
+
+	for _, field := range reactionEmojiType.Fields {
+		if field.Name == fieldName {
+			description = field.Description
+
+			break
+		}
+	}
+
+	if description == "" {
+		return "", errors.New("missing '" + fieldName + "' type field")
+	}
+
+	// Parse emojis from the description
+	var emojis []string
+
+	re := regexp.MustCompile(`"(.+)"`)
+	for _, s := range strings.Split(description, ",") {
+		result := re.FindStringSubmatch(s)
+		if len(result) < 2 {
+			continue
+		}
+
+		e := result[1]
+
+		emojis = append(emojis, e)
+	}
+
+	out := strings.Builder{}
+	out.WriteString("\n// The consts listed below represent all the reaction options that can be sent to telegram as ReactionTypeEmoji.")
+	out.WriteString("\nconst (")
+
+	for _, e := range emojis {
+		emoji, err := gomoji.GetInfo(e)
+		if err != nil {
+			return "", fmt.Errorf("failed to get emoji info for %q: %w", e, err)
+		}
+
+		constName := "Reaction" + snakeToTitle(strings.ReplaceAll(emoji.Slug, "-", "_"))
+		out.WriteString(writeConst(constName, e))
 	}
 
 	out.WriteString(")\n\n")


### PR DESCRIPTION
# What

Just like in #179, it would be great to have constants for all available reactions. 
I've added [new dependency](https://github.com/forPelevin/gomoji) to get reaction name from the emoji string. 

### Alternatives
- Find JSON with all emojis somewhere on github, which has a map with emoji labels. Scrub trough it to find names for emojis
- Generate such file ourselves via scrape script in https://github.com/PaulSonOfLars/telegram-bot-api-spec
- There might be an easier way to do that w/o additional dependencies, but I couldn't find it 😓 

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? N/A
