### PR TITLE
[Draft] Add custom types for string constants

### DIFF
--- a/gen_consts.go
+++ b/gen_consts.go
@@ -108,11 +108,13 @@ func (u Update) GetType() string {
 }
 
 // The consts listed below represent all the parse_mode options that can be sent to telegram.
+type ParseMode string
+
 const (
-	ParseModeHTML       = "HTML"
-	ParseModeMarkdownV2 = "MarkdownV2"
-	ParseModeMarkdown   = "Markdown"
-	ParseModeNone       = ""
+	ParseModeHTML       ParseMode = "HTML"
+	ParseModeMarkdownV2 ParseMode = "MarkdownV2"
+	ParseModeMarkdown   ParseMode = "Markdown"
+	ParseModeNone       ParseMode = ""
 )
 
 // The consts listed below represent all the chat action options that can be sent to telegram.

--- a/gen_methods.go
+++ b/gen_methods.go
@@ -526,7 +526,7 @@ type CopyMessageOpts struct {
 	// New caption for media, 0-1024 characters after entities parsing. If not specified, the original caption is kept
 	Caption *string
 	// Mode for parsing entities in the new caption. See formatting options for more details.
-	ParseMode string
+	ParseMode ParseMode
 	// A JSON-serialized list of special entities that appear in the new caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity
 	// Pass True, if the caption must be shown above the message media. Ignored if a new caption isn't specified.
@@ -569,7 +569,7 @@ func (bot *Bot) CopyMessageWithContext(ctx context.Context, chatId int64, fromCh
 		if opts.Caption != nil {
 			v["caption"] = *opts.Caption
 		}
-		v["parse_mode"] = opts.ParseMode
+		v["parse_mode"] = string(opts.ParseMode)
 		if opts.CaptionEntities != nil {
 			bs, err := json.Marshal(opts.CaptionEntities)
 			if err != nil {
@@ -1551,7 +1551,7 @@ type EditMessageCaptionOpts struct {
 	// New caption of the message, 0-1024 characters after entities parsing
 	Caption string
 	// Mode for parsing entities in the message caption. See formatting options for more details.
-	ParseMode string
+	ParseMode ParseMode
 	// A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity
 	// Pass True, if the caption must be shown above the message media. Supported only for animation, photo and video messages.
@@ -1583,7 +1583,7 @@ func (bot *Bot) EditMessageCaptionWithContext(ctx context.Context, opts *EditMes
 		}
 		v["inline_message_id"] = opts.InlineMessageId
 		v["caption"] = opts.Caption
-		v["parse_mode"] = opts.ParseMode
+		v["parse_mode"] = string(opts.ParseMode)
 		if opts.CaptionEntities != nil {
 			bs, err := json.Marshal(opts.CaptionEntities)
 			if err != nil {
@@ -1858,7 +1858,7 @@ type EditMessageTextOpts struct {
 	// Required if chat_id and message_id are not specified. Identifier of the inline message
 	InlineMessageId string
 	// Mode for parsing entities in the message text. See formatting options for more details.
-	ParseMode string
+	ParseMode ParseMode
 	// A JSON-serialized list of special entities that appear in message text, which can be specified instead of parse_mode
 	Entities []MessageEntity
 	// Link preview generation options for the message
@@ -1891,7 +1891,7 @@ func (bot *Bot) EditMessageTextWithContext(ctx context.Context, text string, opt
 			v["message_id"] = strconv.FormatInt(opts.MessageId, 10)
 		}
 		v["inline_message_id"] = opts.InlineMessageId
-		v["parse_mode"] = opts.ParseMode
+		v["parse_mode"] = string(opts.ParseMode)
 		if opts.Entities != nil {
 			bs, err := json.Marshal(opts.Entities)
 			if err != nil {
@@ -3398,7 +3398,7 @@ type SendAnimationOpts struct {
 	// Animation caption (may also be used when resending animation by file_id), 0-1024 characters after entities parsing
 	Caption string
 	// Mode for parsing entities in the animation caption. See formatting options for more details.
-	ParseMode string
+	ParseMode ParseMode
 	// A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity
 	// Pass True, if the caption must be shown above the message media
@@ -3465,7 +3465,7 @@ func (bot *Bot) SendAnimationWithContext(ctx context.Context, chatId int64, anim
 			v["thumbnail"] = opts.Thumbnail.getValue()
 		}
 		v["caption"] = opts.Caption
-		v["parse_mode"] = opts.ParseMode
+		v["parse_mode"] = string(opts.ParseMode)
 		if opts.CaptionEntities != nil {
 			bs, err := json.Marshal(opts.CaptionEntities)
 			if err != nil {
@@ -3518,7 +3518,7 @@ type SendAudioOpts struct {
 	// Audio caption, 0-1024 characters after entities parsing
 	Caption string
 	// Mode for parsing entities in the audio caption. See formatting options for more details.
-	ParseMode string
+	ParseMode ParseMode
 	// A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity
 	// Duration of the audio in seconds
@@ -3574,7 +3574,7 @@ func (bot *Bot) SendAudioWithContext(ctx context.Context, chatId int64, audio In
 			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
 		}
 		v["caption"] = opts.Caption
-		v["parse_mode"] = opts.ParseMode
+		v["parse_mode"] = string(opts.ParseMode)
 		if opts.CaptionEntities != nil {
 			bs, err := json.Marshal(opts.CaptionEntities)
 			if err != nil {
@@ -3847,7 +3847,7 @@ type SendDocumentOpts struct {
 	// Document caption (may also be used when resending documents by file_id), 0-1024 characters after entities parsing
 	Caption string
 	// Mode for parsing entities in the document caption. See formatting options for more details.
-	ParseMode string
+	ParseMode ParseMode
 	// A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity
 	// Disables automatic server-side content type detection for files uploaded using multipart/form-data
@@ -3903,7 +3903,7 @@ func (bot *Bot) SendDocumentWithContext(ctx context.Context, chatId int64, docum
 			v["thumbnail"] = opts.Thumbnail.getValue()
 		}
 		v["caption"] = opts.Caption
-		v["parse_mode"] = opts.ParseMode
+		v["parse_mode"] = string(opts.ParseMode)
 		if opts.CaptionEntities != nil {
 			bs, err := json.Marshal(opts.CaptionEntities)
 			if err != nil {
@@ -4354,7 +4354,7 @@ type SendMessageOpts struct {
 	// Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
 	MessageThreadId int64
 	// Mode for parsing entities in the message text. See formatting options for more details.
-	ParseMode string
+	ParseMode ParseMode
 	// A JSON-serialized list of special entities that appear in message text, which can be specified instead of parse_mode
 	Entities []MessageEntity
 	// Link preview generation options for the message
@@ -4395,7 +4395,7 @@ func (bot *Bot) SendMessageWithContext(ctx context.Context, chatId int64, text s
 		if opts.MessageThreadId != 0 {
 			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
 		}
-		v["parse_mode"] = opts.ParseMode
+		v["parse_mode"] = string(opts.ParseMode)
 		if opts.Entities != nil {
 			bs, err := json.Marshal(opts.Entities)
 			if err != nil {
@@ -4453,7 +4453,7 @@ type SendPaidMediaOpts struct {
 	// Media caption, 0-1024 characters after entities parsing
 	Caption string
 	// Mode for parsing entities in the media caption. See formatting options for more details.
-	ParseMode string
+	ParseMode ParseMode
 	// A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity
 	// Pass True, if the caption must be shown above the message media
@@ -4508,7 +4508,7 @@ func (bot *Bot) SendPaidMediaWithContext(ctx context.Context, chatId int64, star
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["payload"] = opts.Payload
 		v["caption"] = opts.Caption
-		v["parse_mode"] = opts.ParseMode
+		v["parse_mode"] = string(opts.ParseMode)
 		if opts.CaptionEntities != nil {
 			bs, err := json.Marshal(opts.CaptionEntities)
 			if err != nil {
@@ -4559,7 +4559,7 @@ type SendPhotoOpts struct {
 	// Photo caption (may also be used when resending photos by file_id), 0-1024 characters after entities parsing
 	Caption string
 	// Mode for parsing entities in the photo caption. See formatting options for more details.
-	ParseMode string
+	ParseMode ParseMode
 	// A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity
 	// Pass True, if the caption must be shown above the message media
@@ -4610,7 +4610,7 @@ func (bot *Bot) SendPhotoWithContext(ctx context.Context, chatId int64, photo In
 			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
 		}
 		v["caption"] = opts.Caption
-		v["parse_mode"] = opts.ParseMode
+		v["parse_mode"] = string(opts.ParseMode)
 		if opts.CaptionEntities != nil {
 			bs, err := json.Marshal(opts.CaptionEntities)
 			if err != nil {
@@ -4990,7 +4990,7 @@ type SendVideoOpts struct {
 	// Video caption (may also be used when resending videos by file_id), 0-1024 characters after entities parsing
 	Caption string
 	// Mode for parsing entities in the video caption. See formatting options for more details.
-	ParseMode string
+	ParseMode ParseMode
 	// A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity
 	// Pass True, if the caption must be shown above the message media
@@ -5059,7 +5059,7 @@ func (bot *Bot) SendVideoWithContext(ctx context.Context, chatId int64, video In
 			v["thumbnail"] = opts.Thumbnail.getValue()
 		}
 		v["caption"] = opts.Caption
-		v["parse_mode"] = opts.ParseMode
+		v["parse_mode"] = string(opts.ParseMode)
 		if opts.CaptionEntities != nil {
 			bs, err := json.Marshal(opts.CaptionEntities)
 			if err != nil {
@@ -5215,7 +5215,7 @@ type SendVoiceOpts struct {
 	// Voice message caption, 0-1024 characters after entities parsing
 	Caption string
 	// Mode for parsing entities in the voice message caption. See formatting options for more details.
-	ParseMode string
+	ParseMode ParseMode
 	// A JSON-serialized list of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity
 	// Duration of the voice message in seconds
@@ -5264,7 +5264,7 @@ func (bot *Bot) SendVoiceWithContext(ctx context.Context, chatId int64, voice In
 			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
 		}
 		v["caption"] = opts.Caption
-		v["parse_mode"] = opts.ParseMode
+		v["parse_mode"] = string(opts.ParseMode)
 		if opts.CaptionEntities != nil {
 			bs, err := json.Marshal(opts.CaptionEntities)
 			if err != nil {

--- a/gen_types.go
+++ b/gen_types.go
@@ -3075,7 +3075,7 @@ type MergedInlineQueryResult struct {
 	// Optional. Caption, 0-1024 characters after entities parsing (Only for audio, document, gif, mpeg4_gif, photo, video, voice, audio, document, gif, mpeg4_gif, photo, video, voice)
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the audio caption. See formatting options for more details. (Only for audio, document, gif, mpeg4_gif, photo, video, voice, audio, document, gif, mpeg4_gif, photo, video, voice)
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode (Only for audio, document, gif, mpeg4_gif, photo, video, voice, audio, document, gif, mpeg4_gif, photo, video, voice)
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Inline keyboard attached to the message
@@ -3292,7 +3292,7 @@ type InlineQueryResultAudio struct {
 	// Optional. Caption, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the audio caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Performer
@@ -3359,7 +3359,7 @@ type InlineQueryResultCachedAudio struct {
 	// Optional. Caption, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the audio caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Inline keyboard attached to the message
@@ -3423,7 +3423,7 @@ type InlineQueryResultCachedDocument struct {
 	// Optional. Caption of the document to be sent, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the document caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Inline keyboard attached to the message
@@ -3487,7 +3487,7 @@ type InlineQueryResultCachedGif struct {
 	// Optional. Caption of the GIF file to be sent, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Pass True, if the caption must be shown above the message media
@@ -3553,7 +3553,7 @@ type InlineQueryResultCachedMpeg4Gif struct {
 	// Optional. Caption of the MPEG-4 file to be sent, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Pass True, if the caption must be shown above the message media
@@ -3621,7 +3621,7 @@ type InlineQueryResultCachedPhoto struct {
 	// Optional. Caption of the photo to be sent, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the photo caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Pass True, if the caption must be shown above the message media
@@ -3741,7 +3741,7 @@ type InlineQueryResultCachedVideo struct {
 	// Optional. Caption of the video to be sent, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the video caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Pass True, if the caption must be shown above the message media
@@ -3808,7 +3808,7 @@ type InlineQueryResultCachedVoice struct {
 	// Optional. Caption, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the voice message caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Inline keyboard attached to the message
@@ -3938,7 +3938,7 @@ type InlineQueryResultDocument struct {
 	// Optional. Caption of the document to be sent, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the document caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// A valid URL for the file
@@ -4076,7 +4076,7 @@ type InlineQueryResultGif struct {
 	// Optional. Caption of the GIF file to be sent, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Pass True, if the caption must be shown above the message media
@@ -4235,7 +4235,7 @@ type InlineQueryResultMpeg4Gif struct {
 	// Optional. Caption of the MPEG-4 file to be sent, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Pass True, if the caption must be shown above the message media
@@ -4314,7 +4314,7 @@ type InlineQueryResultPhoto struct {
 	// Optional. Caption of the photo to be sent, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the photo caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Pass True, if the caption must be shown above the message media
@@ -4469,7 +4469,7 @@ type InlineQueryResultVideo struct {
 	// Optional. Caption of the video to be sent, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the video caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Pass True, if the caption must be shown above the message media
@@ -4549,7 +4549,7 @@ type InlineQueryResultVoice struct {
 	// Optional. Caption, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the voice message caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Recording duration in seconds
@@ -4743,7 +4743,7 @@ type MergedInputMedia struct {
 	// Optional. Caption of the animation to be sent, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the animation caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Pass True, if the caption must be shown above the message media (Only for animation, photo, video)
@@ -4795,7 +4795,7 @@ type InputMediaAnimation struct {
 	// Optional. Caption of the animation to be sent, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the animation caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Pass True, if the caption must be shown above the message media
@@ -4882,7 +4882,7 @@ type InputMediaAudio struct {
 	// Optional. Caption of the audio to be sent, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the audio caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Duration of the audio in seconds
@@ -4963,7 +4963,7 @@ type InputMediaDocument struct {
 	// Optional. Caption of the document to be sent, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the document caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Disables automatic server-side content type detection for files uploaded using multipart/form-data. Always True, if the document is sent as part of an album.
@@ -5036,7 +5036,7 @@ type InputMediaPhoto struct {
 	// Optional. Caption of the photo to be sent, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the photo caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Pass True, if the caption must be shown above the message media
@@ -5106,7 +5106,7 @@ type InputMediaVideo struct {
 	// Optional. Caption of the video to be sent, 0-1024 characters after entities parsing
 	Caption string `json:"caption,omitempty"`
 	// Optional. Mode for parsing entities in the video caption. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in the caption, which can be specified instead of parse_mode
 	CaptionEntities []MessageEntity `json:"caption_entities,omitempty"`
 	// Optional. Pass True, if the caption must be shown above the message media
@@ -5439,7 +5439,7 @@ type InputTextMessageContent struct {
 	// Text of the message to be sent, 1-4096 characters
 	MessageText string `json:"message_text"`
 	// Optional. Mode for parsing entities in the message text. See formatting options for more details.
-	ParseMode string `json:"parse_mode,omitempty"`
+	ParseMode ParseMode `json:"parse_mode,omitempty"`
 	// Optional. List of special entities that appear in message text, which can be specified instead of parse_mode
 	Entities []MessageEntity `json:"entities,omitempty"`
 	// Optional. Link preview generation options for the message

--- a/scripts/generate/common.go
+++ b/scripts/generate/common.go
@@ -143,6 +143,8 @@ func goTypeStringer(t string) string {
 		return "%s"
 	case "*string":
 		return "*%s"
+	case "ParseMode":
+		return "string(%s)"
 	default:
 		return ""
 	}

--- a/scripts/generate/consts.go
+++ b/scripts/generate/consts.go
@@ -115,15 +115,16 @@ func generateParseModeConsts() string {
 
 	out := strings.Builder{}
 	out.WriteString("\n// The consts listed below represent all the parse_mode options that can be sent to telegram.")
+	out.WriteString("\ntype ParseMode string")
 	out.WriteString("\nconst (")
 	for _, t := range formattingTypes {
 		constName := "ParseMode" + t
 		if t == "None" {
 			// no parsemode == empty string value.
-			out.WriteString(writeConst(constName, ""))
+			out.WriteString(writeConstWithType(constName, "", "ParseMode"))
 			continue
 		}
-		out.WriteString(writeConst(constName, t))
+		out.WriteString(writeConstWithType(constName, t, "ParseMode"))
 	}
 	out.WriteString(")\n\n")
 	return out.String()
@@ -178,4 +179,8 @@ func generateChatActionConsts(d APIDescription) (string, error) {
 
 func writeConst(name string, value string) string {
 	return fmt.Sprintf("\n%s = \"%s\"", name, value)
+}
+
+func writeConstWithType(name string, value string, valueType string) string {
+	return fmt.Sprintf("\n%s %s = \"%s\"", name, valueType, value)
 }

--- a/scripts/generate/gen.go
+++ b/scripts/generate/gen.go
@@ -365,6 +365,10 @@ func (f Field) getPreferredType(d APIDescription) (string, error) {
 		}
 	}
 
+	if f.Name == "parse_mode" {
+		return "ParseMode", nil
+	}
+
 	if len(f.Types) == 1 {
 		goType := toGoType(f.Types[0])
 

--- a/scripts/generate/types.go
+++ b/scripts/generate/types.go
@@ -684,7 +684,7 @@ type customStructUnmarshalCaseData struct {
 }
 
 const customStructUnmarshal = `
-// {{.UnmarshalFuncName}}Array is a JSON unmarshalling helper which allows unmarshalling an array of interfaces 
+// {{.UnmarshalFuncName}}Array is a JSON unmarshalling helper which allows unmarshalling an array of interfaces
 // using {{.UnmarshalFuncName}}.
 func {{.UnmarshalFuncName}}Array(d json.RawMessage) ([]{{.ParentType}}, error) {
 	if len(d) == 0 {


### PR DESCRIPTION
# What

I'd like to give string constants their own types. 
So, for RFC, I added only `ParseMode`. 
What do you think?

# Impact

Impact is not that much. But it is easy to read and write.

- Are your changes backwards compatible?
yes

- Have you included documentation, or updated existing documentation?
I would update it if the change is accepted.

