### PR TITLE
Crude implementation of context propagation to Updater

### DIFF
--- a/ext/botmapping.go
+++ b/ext/botmapping.go
@@ -47,8 +47,10 @@ type botMapping struct {
 	errorLog *log.Logger
 }
 
-var ErrBotAlreadyExists = errors.New("bot already exists in bot mapping")
-var ErrBotUrlPathAlreadyExists = errors.New("url path already exists in bot mapping")
+var (
+	ErrBotAlreadyExists        = errors.New("bot already exists in bot mapping")
+	ErrBotUrlPathAlreadyExists = errors.New("url path already exists in bot mapping")
+)
 
 // addBot Adds a new bot to the botMapping structure.
 // Pass an empty urlPath/webhookSecret if using polling instead of webhooks.


### PR DESCRIPTION
<!--
Hey, thank you for opening a PR!

Please fill out the details below; they're there to help both you and the maintainers!
-->

# What

Propagate parent Context to updater to prevent it idling till the next update when Stop is called.

This is draft and crude, and is intended to be a starting point for discussion.

# Impact

- A new field is added to the PollingOpts - ParentCtx that allows passing the parent Context.
   - If it is nil, it is initialised with context.Background() to prevent nil pointer dereference.
- Each Request originating from the poller is created with the ParentCtx, when it's cancelled, user may
  observe "Request Failed: context cancelled" in the logs.
- I had to pull the <-bData.stopUpdates to be on the same level as ctx.Done() check, and I don't like it.
  - This happened because I noticed it is called in the handler, I could have used r.Context() instead,
    but wasn't sure of consequences.  What if the request is terminated and that context is dead?
