### PR TITLE
Update base go version to 1.22

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,9 +21,6 @@ output:
   # print linter name in the end of issue text, default is true
   print-linter-name: true
 
-  # make issues output unique by line, default is true
-  uniq-by-line: true
-
   # sorts results by: filepath, line and column
   sort-results: true
 
@@ -72,6 +69,9 @@ linters:
     - unparam
     - wastedassign
 issues:
+  # make issues output unique by line, default is true
+  uniq-by-line: true
+
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
     - path: samples/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -44,7 +44,7 @@ linters:
     - durationcheck
     - errorlint
     - exhaustive
-    - exportloopref
+    - copyloopvar
     - forbidigo
     - forcetypeassert
     - godot

--- a/ext/dispatcher_ext_test.go
+++ b/ext/dispatcher_ext_test.go
@@ -78,14 +78,10 @@ func TestDispatcher(t *testing.T) {
 			numMatches: 2,
 		},
 	} {
-		name, testParams := name, testParams
-
 		t.Run(name, func(t *testing.T) {
 			d := ext.NewDispatcher(nil)
 			var events []int
 			for idx, h := range testParams.handlers {
-				idx, h := idx, h
-
 				t.Logf("Loading handler %d in group %d", idx, h.group)
 				d.AddHandlerToGroup(handlers.NewMessage(message.All, func(b *gotgbot.Bot, ctx *ext.Context) error {
 					if !h.shouldRun {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/PaulSonOfLars/gotgbot/v2
 
-go 1.19
+go 1.22

--- a/samples/callbackqueryBot/go.mod
+++ b/samples/callbackqueryBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/callbackqueryBot
 
-go 1.19
+go 1.22
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/commandBot/go.mod
+++ b/samples/commandBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/commandBot
 
-go 1.19
+go 1.22
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/conversationBot/go.mod
+++ b/samples/conversationBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/conversationBot
 
-go 1.19
+go 1.22
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/echoBot/go.mod
+++ b/samples/echoBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/echoBot
 
-go 1.19
+go 1.22
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/echoMultiBot/go.mod
+++ b/samples/echoMultiBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/echoMultiBot
 
-go 1.19
+go 1.22
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/echoWebhookBot/go.mod
+++ b/samples/echoWebhookBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/echoWebhookBot
 
-go 1.19
+go 1.22
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/inlinequeryBot/go.mod
+++ b/samples/inlinequeryBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/inlinequeryBot
 
-go 1.19
+go 1.22
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/metricsBot/go.mod
+++ b/samples/metricsBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/metricsBot
 
-go 1.19
+go 1.22
 
 require (
 	github.com/PaulSonOfLars/gotgbot/v2 v2.99.99

--- a/samples/metricsBot/go.sum
+++ b/samples/metricsBot/go.sum
@@ -8,6 +8,7 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/prometheus/client_golang v1.16.0 h1:yk/hx9hDbrGHovbci4BY+pRMfSuuat626eFsHb7tmT8=

--- a/samples/middlewareBot/go.mod
+++ b/samples/middlewareBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/middlewareBot
 
-go 1.19
+go 1.22
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/paymentsBot/go.mod
+++ b/samples/paymentsBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/paymentsBot
 
-go 1.19
+go 1.22
 
 require (
 	github.com/PaulSonOfLars/gotgbot/v2 v2.99.99

--- a/samples/statefulClientBot/go.mod
+++ b/samples/statefulClientBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/statefulClientBot
 
-go 1.19
+go 1.22
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/webappBot/go.mod
+++ b/samples/webappBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/webappBot
 
-go 1.19
+go 1.22
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/scripts/ci/ensure-consistent-sample-mod-files.sh
+++ b/scripts/ci/ensure-consistent-sample-mod-files.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SAMPLES_DIR="samples"
 
 REPO="github.com/PaulSonOfLars/gotgbot" # Current library import path
-GO_VERSION="1.19"                       # Go version we expect our samples to be using
+GO_VERSION="1.22"                       # Go version we expect our samples to be using
 V_MAJOR="v2"                            # Current major version for the library
 V_DUMMY="v2.99.99"                      # dummy version for the library
 


### PR DESCRIPTION
# What

Update base go version to 1.22

# Impact

- Are your changes backwards compatible? Yes - users should be on a maintained version of go.
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
