### PR TITLE
don't check message quotes

### DIFF
--- a/entities.go
+++ b/entities.go
@@ -76,9 +76,7 @@ func (m Message) ParseAnyEntityTypes(accepted map[string]struct{}) (out []Parsed
 			out = append(out, ParseEntityTypes(o.Text, o.TextEntities, accepted)...)
 		}
 	}
-	if m.Quote != nil {
-		out = append(out, ParseEntityTypes(m.Quote.Text, m.Quote.Entities, accepted)...)
-	}
+	// We do not check m.Quote, as this is not technically the current message, but the reply
 	return out
 }
 


### PR DESCRIPTION
# What

Fix a misconfiguration of the AnyEntity method which mistakenly considered quotes as part of the current message

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
