### PR TITLE
Add ChatMember status constants generation

### DIFF
--- a/gen_consts.go
+++ b/gen_consts.go
@@ -144,3 +144,13 @@ const (
 	ChatTypeSupergroup = "supergroup"
 	ChatTypeChannel    = "channel"
 )
+
+// The consts below represent possible status values for a ChatMember.
+const (
+	ChatMemberStatusOwner         = "creator"
+	ChatMemberStatusAdministrator = "administrator"
+	ChatMemberStatusMember        = "member"
+	ChatMemberStatusRestricted    = "restricted"
+	ChatMemberStatusLeft          = "left"
+	ChatMemberStatusBanned        = "kicked"
+)

--- a/scripts/generate/consts.go
+++ b/scripts/generate/consts.go
@@ -43,6 +43,12 @@ package gotgbot
 	}
 	consts.WriteString(chatTypeConsts)
 
+	chatMemberStatuses, err := generateChatMemberStatusConsts(d)
+	if err != nil {
+		return fmt.Errorf("failed to generate consts for chat member statuses: %w", err)
+	}
+	consts.WriteString(chatMemberStatuses)
+
 	return writeGenToFile(consts, "gen_consts.go")
 }
 
@@ -173,6 +179,50 @@ func generateChatActionConsts(d APIDescription) (string, error) {
 
 	out.WriteString(")\n\n")
 
+	return out.String(), nil
+}
+
+func generateChatMemberStatusConsts(d APIDescription) (string, error) {
+	chatMemberType, ok := d.Types["ChatMember"]
+	if !ok {
+		return "", errors.New("missing 'ChatMember' type data")
+	}
+
+	out := strings.Builder{}
+	out.WriteString("\n// The consts below represent possible status values for a ChatMember.\n")
+	out.WriteString("const (")
+
+	for _, subtypeName := range chatMemberType.Subtypes {
+		subtype, ok := d.Types[subtypeName]
+		if !ok {
+			continue
+		}
+
+		var statusValue string
+		for _, field := range subtype.Fields {
+			if field.Name != "status" {
+				continue
+			}
+			values, err := extractQuotedValues(field.Description)
+			if err != nil {
+				return "", fmt.Errorf("failed to extract status from %s: %w", subtypeName, err)
+			}
+			if len(values) != 1 {
+				return "", fmt.Errorf("unexpected multiple status values in %s", subtypeName)
+			}
+			statusValue = values[0]
+			break
+		}
+
+		if statusValue == "" {
+			continue // no valid status found
+		}
+
+		constName := "ChatMemberStatus" + strings.TrimPrefix(subtypeName, "ChatMember")
+		out.WriteString(writeConst(constName, statusValue))
+	}
+
+	out.WriteString("\n)\n\n")
 	return out.String(), nil
 }
 


### PR DESCRIPTION
# What

Adds `generateChatMemberStatusConsts` function to generate constants for all `ChatMember.status`

Related issue: https://github.com/PaulSonOfLars/gotgbot/issues/218

# Impact

- Are your changes backwards compatible? Yes
- Have you included documentation, or updated existing documentation? No
- Do errors and log messages provide enough context? Yes
