### PR TITLE
cleanup: drop temp var in range loop (Go 1.22+ makes loop vars unique)

### DIFF
--- a/ext/updater.go
+++ b/ext/updater.go
@@ -236,8 +236,7 @@ func (u *Updater) pollingLoop(ctx context.Context, bData *botData, opts *gotgbot
 		v["offset"] = strconv.FormatInt(lastUpdate.UpdateId+1, 10)
 
 		for _, updData := range rawUpdates {
-			temp := updData // use new mem address to avoid loop conflicts
-			bData.updateChan <- temp
+			bData.updateChan <- updData
 		}
 	}
 }


### PR DESCRIPTION
<!--
Hey, thank you for opening a PR!

Please fill out the details below; they're there to help both you and the maintainers!
-->

# What

This PR removes the redundant temp := updData assignment inside a for range loop.
In Go versions prior to 1.22, this pattern was required to avoid loop variable reuse issues when taking the address of the variable or capturing it inside goroutines/closures.

Since Go 1.22, each iteration of a for range loop creates a new loop variable, so the extra copy is unnecessary and can be safely removed.

Reference: https://go.dev/blog/loopvar-preview

# Impact

- Are your changes backwards compatible?
Yes.
- Have you included documentation, or updated existing documentation?
 No documentation changes needed.
- Do errors and log messages provide enough context?
Errors and log messages are unaffected; behavior is functionally identical.