### PR TITLE
Try out new OverrideParams field for RequestOpts

### DIFF
--- a/request.go
+++ b/request.go
@@ -78,6 +78,8 @@ type RequestOpts struct {
 	Timeout time.Duration
 	// Custom API URL to use for requests.
 	APIURL string
+	// ExtraParams represents additional params to be injected to request contents.
+	ExtraParams map[string]string
 }
 
 // getTimeoutContext returns the appropriate context for the current settings.
@@ -133,6 +135,12 @@ func timeoutFromOpts(parentCtx context.Context, opts *RequestOpts) (context.Cont
 func (bot *BaseBotClient) RequestWithContext(parentCtx context.Context, token string, method string, params map[string]string, data map[string]FileReader, opts *RequestOpts) (json.RawMessage, error) {
 	ctx, cancel := bot.getTimeoutContext(parentCtx, opts)
 	defer cancel()
+
+	if opts != nil {
+		for k, v := range opts.ExtraParams {
+			params[k] = v
+		}
+	}
 
 	var bodyData []byte
 	var contentType string

--- a/request.go
+++ b/request.go
@@ -78,8 +78,8 @@ type RequestOpts struct {
 	Timeout time.Duration
 	// Custom API URL to use for requests.
 	APIURL string
-	// ExtraParams represents additional params to be injected to request contents.
-	ExtraParams map[string]string
+	// OverrideParams can be used to override existing parameters, or override existing ones.
+	OverrideParams map[string]string
 }
 
 // getTimeoutContext returns the appropriate context for the current settings.
@@ -137,7 +137,7 @@ func (bot *BaseBotClient) RequestWithContext(parentCtx context.Context, token st
 	defer cancel()
 
 	if opts != nil {
-		for k, v := range opts.ExtraParams {
+		for k, v := range opts.OverrideParams {
 			params[k] = v
 		}
 	}


### PR DESCRIPTION
# What

Add new OverrideParams field to the RequestOpts field, which will overwrite any existing params with a custom value.
This can notably be used to use `GetChat` with a string instead of an integer.

Example:
```golang
b.GetChat(0, &gotgbot.GetChatOpts{RequestOpts: &gotgbot.RequestOpts{OverrideParams: map[string]string{"chat_id": "@marienews"}}})
```

As suggested in the support group by evgtg- https://t.me/GotgbotChat/16532

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
