### PR TITLE
Simplify requests code and reduce double-unmarshalling for many fields

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -114,14 +114,14 @@ func (bot *Bot) UseMiddleware(mw func(client BotClient) BotClient) *Bot {
 	return bot
 }
 
-func (bot *Bot) Request(method string, params map[string]any, data map[string]FileReader, opts *RequestOpts) (json.RawMessage, error) {
-	return bot.RequestWithContext(context.Background(), method, params, data, opts)
+func (bot *Bot) Request(method string, params map[string]any, opts *RequestOpts) (json.RawMessage, error) {
+	return bot.RequestWithContext(context.Background(), method, params, opts)
 }
 
-func (bot *Bot) RequestWithContext(ctx context.Context, method string, params map[string]any, data map[string]FileReader, opts *RequestOpts) (json.RawMessage, error) {
+func (bot *Bot) RequestWithContext(ctx context.Context, method string, params map[string]any, opts *RequestOpts) (json.RawMessage, error) {
 	if bot.BotClient == nil {
 		return nil, ErrNilBotClient
 	}
 
-	return bot.BotClient.RequestWithContext(ctx, bot.Token, method, params, data, opts)
+	return bot.BotClient.RequestWithContext(ctx, bot.Token, method, params, opts)
 }

--- a/bot.go
+++ b/bot.go
@@ -114,11 +114,11 @@ func (bot *Bot) UseMiddleware(mw func(client BotClient) BotClient) *Bot {
 	return bot
 }
 
-func (bot *Bot) Request(method string, params map[string]string, data map[string]FileReader, opts *RequestOpts) (json.RawMessage, error) {
+func (bot *Bot) Request(method string, params map[string]any, data map[string]FileReader, opts *RequestOpts) (json.RawMessage, error) {
 	return bot.RequestWithContext(context.Background(), method, params, data, opts)
 }
 
-func (bot *Bot) RequestWithContext(ctx context.Context, method string, params map[string]string, data map[string]FileReader, opts *RequestOpts) (json.RawMessage, error) {
+func (bot *Bot) RequestWithContext(ctx context.Context, method string, params map[string]any, data map[string]FileReader, opts *RequestOpts) (json.RawMessage, error) {
 	if bot.BotClient == nil {
 		return nil, ErrNilBotClient
 	}

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -117,7 +117,7 @@ func (u *Updater) StartPolling(b *gotgbot.Bot, opts *PollingOpts) error {
 	//  - needing to re-allocate new url.values structs.
 	//  - needing to convert the 'opt' values to strings.
 	//  - unnecessary unmarshalling of multiple full Update structs.
-	v := map[string]string{}
+	v := map[string]any{}
 	var reqOpts *gotgbot.RequestOpts
 
 	if opts != nil {
@@ -177,7 +177,7 @@ func (u *Updater) StartPolling(b *gotgbot.Bot, opts *PollingOpts) error {
 	return nil
 }
 
-func (u *Updater) pollingLoop(ctx context.Context, bData *botData, opts *gotgbot.RequestOpts, v map[string]string) {
+func (u *Updater) pollingLoop(ctx context.Context, bData *botData, opts *gotgbot.RequestOpts, v map[string]any) {
 	for {
 		// Check if updater loop has been terminated.
 		if bData.shouldStopUpdates() {

--- a/ext/updater.go
+++ b/ext/updater.go
@@ -186,7 +186,7 @@ func (u *Updater) pollingLoop(ctx context.Context, bData *botData, opts *gotgbot
 
 		// Manually craft the getUpdate calls to improve memory management, reduce json parsing overheads, and
 		// unnecessary reallocation of url.Values in the polling loop.
-		r, err := bData.bot.RequestWithContext(ctx, "getUpdates", v, nil, opts)
+		r, err := bData.bot.RequestWithContext(ctx, "getUpdates", v, opts)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
 				// context cancelled; means the bot was stopped gracefully through Updater.StopBot

--- a/file.go
+++ b/file.go
@@ -2,8 +2,9 @@ package gotgbot
 
 import (
 	"encoding/json"
-	"errors"
+	"fmt"
 	"io"
+	"mime/multipart"
 )
 
 // InputFile (https://core.telegram.org/bots/api#inputfile)
@@ -20,7 +21,7 @@ type InputFile interface {
 // This object represents the contents of a file to be uploaded, or a publicly accessible URL to be reused.
 // Files must be posted using multipart/form-data in the usual way that files are uploaded via the browser.
 type InputFileOrString interface {
-	Attach(name string, data map[string]FileReader) error
+	Attach(name string, w *multipart.Writer) error
 	getValue() string
 }
 
@@ -40,21 +41,29 @@ func (f *FileReader) MarshalJSON() ([]byte, error) {
 	return json.Marshal(f.getValue())
 }
 
-var ErrAttachmentKeyAlreadyExists = errors.New("key already exists")
-
 func (f *FileReader) justFiles() {}
 
-func (f *FileReader) Attach(key string, data map[string]FileReader) error {
+func (f *FileReader) Attach(key string, w *multipart.Writer) error {
 	if f.Data == nil {
 		// if no data, this must be a string; nothing to "attach".
 		return nil
 	}
 
-	if _, ok := data[key]; ok {
-		return ErrAttachmentKeyAlreadyExists
+	fileName := f.Name
+	if fileName == "" {
+		fileName = key
+	}
+
+	part, err := w.CreateFormFile(key, fileName)
+	if err != nil {
+		return fmt.Errorf("failed to create form file for field %s and fileName %s: %w", key, fileName, err)
+	}
+
+	_, err = io.Copy(part, f.Data)
+	if err != nil {
+		return fmt.Errorf("failed to copy file contents of field %s to form: %w", key, err)
 	}
 	f.value = "attach://" + key
-	data[key] = *f
 	return nil
 }
 

--- a/gen_methods.go
+++ b/gen_methods.go
@@ -6,7 +6,6 @@ package gotgbot
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 )
 
 // AddStickerToSetOpts is the set of optional fields for Bot.AddStickerToSet and Bot.AddStickerToSetWithContext.
@@ -38,7 +37,7 @@ func (bot *Bot) AddStickerToSetWithContext(ctx context.Context, userId int64, na
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "addStickerToSet", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "addStickerToSet", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -86,7 +85,7 @@ func (bot *Bot) AnswerCallbackQueryWithContext(ctx context.Context, callbackQuer
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "answerCallbackQuery", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "answerCallbackQuery", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -141,7 +140,7 @@ func (bot *Bot) AnswerInlineQueryWithContext(ctx context.Context, inlineQueryId 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "answerInlineQuery", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "answerInlineQuery", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -182,7 +181,7 @@ func (bot *Bot) AnswerPreCheckoutQueryWithContext(ctx context.Context, preChecko
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "answerPreCheckoutQuery", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "answerPreCheckoutQuery", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -228,7 +227,7 @@ func (bot *Bot) AnswerShippingQueryWithContext(ctx context.Context, shippingQuer
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "answerShippingQuery", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "answerShippingQuery", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -264,7 +263,7 @@ func (bot *Bot) AnswerWebAppQueryWithContext(ctx context.Context, webAppQueryId 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "answerWebAppQuery", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "answerWebAppQuery", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +299,7 @@ func (bot *Bot) ApproveChatJoinRequestWithContext(ctx context.Context, chatId in
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "approveChatJoinRequest", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "approveChatJoinRequest", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -341,7 +340,7 @@ func (bot *Bot) ApproveSuggestedPostWithContext(ctx context.Context, chatId int6
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "approveSuggestedPost", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "approveSuggestedPost", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -385,7 +384,7 @@ func (bot *Bot) BanChatMemberWithContext(ctx context.Context, chatId int64, user
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "banChatMember", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "banChatMember", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -421,7 +420,7 @@ func (bot *Bot) BanChatSenderChatWithContext(ctx context.Context, chatId int64, 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "banChatSenderChat", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "banChatSenderChat", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -453,7 +452,7 @@ func (bot *Bot) CloseWithContext(ctx context.Context, opts *CloseOpts) (bool, er
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "close", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "close", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -489,7 +488,7 @@ func (bot *Bot) CloseForumTopicWithContext(ctx context.Context, chatId int64, me
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "closeForumTopic", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "closeForumTopic", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -523,7 +522,7 @@ func (bot *Bot) CloseGeneralForumTopicWithContext(ctx context.Context, chatId in
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "closeGeneralForumTopic", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "closeGeneralForumTopic", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -559,7 +558,7 @@ func (bot *Bot) ConvertGiftToStarsWithContext(ctx context.Context, businessConne
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "convertGiftToStars", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "convertGiftToStars", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -648,7 +647,7 @@ func (bot *Bot) CopyMessageWithContext(ctx context.Context, chatId int64, fromCh
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "copyMessage", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "copyMessage", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -705,7 +704,7 @@ func (bot *Bot) CopyMessagesWithContext(ctx context.Context, chatId int64, fromC
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "copyMessages", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "copyMessages", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -753,7 +752,7 @@ func (bot *Bot) CreateChatInviteLinkWithContext(ctx context.Context, chatId int6
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "createChatInviteLink", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "createChatInviteLink", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -796,7 +795,7 @@ func (bot *Bot) CreateChatSubscriptionInviteLinkWithContext(ctx context.Context,
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "createChatSubscriptionInviteLink", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "createChatSubscriptionInviteLink", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -840,7 +839,7 @@ func (bot *Bot) CreateForumTopicWithContext(ctx context.Context, chatId int64, n
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "createForumTopic", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "createForumTopic", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -939,7 +938,7 @@ func (bot *Bot) CreateInvoiceLinkWithContext(ctx context.Context, title string, 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "createInvoiceLink", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "createInvoiceLink", v, reqOpts)
 	if err != nil {
 		return "", err
 	}
@@ -989,7 +988,7 @@ func (bot *Bot) CreateNewStickerSetWithContext(ctx context.Context, userId int64
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "createNewStickerSet", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "createNewStickerSet", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -1025,7 +1024,7 @@ func (bot *Bot) DeclineChatJoinRequestWithContext(ctx context.Context, chatId in
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "declineChatJoinRequest", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "declineChatJoinRequest", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -1066,7 +1065,7 @@ func (bot *Bot) DeclineSuggestedPostWithContext(ctx context.Context, chatId int6
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "declineSuggestedPost", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "declineSuggestedPost", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -1104,7 +1103,7 @@ func (bot *Bot) DeleteBusinessMessagesWithContext(ctx context.Context, businessC
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "deleteBusinessMessages", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "deleteBusinessMessages", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -1138,7 +1137,7 @@ func (bot *Bot) DeleteChatPhotoWithContext(ctx context.Context, chatId int64, op
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "deleteChatPhoto", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "deleteChatPhoto", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -1172,7 +1171,7 @@ func (bot *Bot) DeleteChatStickerSetWithContext(ctx context.Context, chatId int6
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "deleteChatStickerSet", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "deleteChatStickerSet", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -1208,7 +1207,7 @@ func (bot *Bot) DeleteForumTopicWithContext(ctx context.Context, chatId int64, m
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "deleteForumTopic", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "deleteForumTopic", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -1255,7 +1254,7 @@ func (bot *Bot) DeleteMessageWithContext(ctx context.Context, chatId int64, mess
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "deleteMessage", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "deleteMessage", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -1293,7 +1292,7 @@ func (bot *Bot) DeleteMessagesWithContext(ctx context.Context, chatId int64, mes
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "deleteMessages", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "deleteMessages", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -1333,7 +1332,7 @@ func (bot *Bot) DeleteMyCommandsWithContext(ctx context.Context, opts *DeleteMyC
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "deleteMyCommands", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "deleteMyCommands", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -1360,21 +1359,14 @@ func (bot *Bot) DeleteStickerFromSet(sticker InputFileOrString, opts *DeleteStic
 // DeleteStickerFromSetWithContext is the same as Bot.DeleteStickerFromSet, but with a context.Context parameter
 func (bot *Bot) DeleteStickerFromSetWithContext(ctx context.Context, sticker InputFileOrString, opts *DeleteStickerFromSetOpts) (bool, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
-	if sticker != nil {
-		err := sticker.Attach("sticker", data)
-		if err != nil {
-			return false, fmt.Errorf("failed to attach 'sticker' input file: %w", err)
-		}
-		v["sticker"] = sticker.getValue()
-	}
+	v["sticker"] = sticker
 
 	var reqOpts *RequestOpts
 	if opts != nil {
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "deleteStickerFromSet", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "deleteStickerFromSet", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -1408,7 +1400,7 @@ func (bot *Bot) DeleteStickerSetWithContext(ctx context.Context, name string, op
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "deleteStickerSet", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "deleteStickerSet", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -1444,7 +1436,7 @@ func (bot *Bot) DeleteStoryWithContext(ctx context.Context, businessConnectionId
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "deleteStory", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "deleteStory", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -1481,7 +1473,7 @@ func (bot *Bot) DeleteWebhookWithContext(ctx context.Context, opts *DeleteWebhoo
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "deleteWebhook", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "deleteWebhook", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -1531,7 +1523,7 @@ func (bot *Bot) EditChatInviteLinkWithContext(ctx context.Context, chatId int64,
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "editChatInviteLink", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "editChatInviteLink", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -1572,7 +1564,7 @@ func (bot *Bot) EditChatSubscriptionInviteLinkWithContext(ctx context.Context, c
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "editChatSubscriptionInviteLink", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "editChatSubscriptionInviteLink", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -1618,7 +1610,7 @@ func (bot *Bot) EditForumTopicWithContext(ctx context.Context, chatId int64, mes
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "editForumTopic", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "editForumTopic", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -1654,7 +1646,7 @@ func (bot *Bot) EditGeneralForumTopicWithContext(ctx context.Context, chatId int
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "editGeneralForumTopic", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "editGeneralForumTopic", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -1717,7 +1709,7 @@ func (bot *Bot) EditMessageCaptionWithContext(ctx context.Context, opts *EditMes
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "editMessageCaption", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "editMessageCaption", v, reqOpts)
 	if err != nil {
 		return nil, false, err
 	}
@@ -1770,7 +1762,7 @@ func (bot *Bot) EditMessageChecklistWithContext(ctx context.Context, businessCon
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "editMessageChecklist", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "editMessageChecklist", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -1837,7 +1829,7 @@ func (bot *Bot) EditMessageLiveLocationWithContext(ctx context.Context, latitude
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "editMessageLiveLocation", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "editMessageLiveLocation", v, reqOpts)
 	if err != nil {
 		return nil, false, err
 	}
@@ -1896,7 +1888,7 @@ func (bot *Bot) EditMessageMediaWithContext(ctx context.Context, media InputMedi
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "editMessageMedia", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "editMessageMedia", v, reqOpts)
 	if err != nil {
 		return nil, false, err
 	}
@@ -1953,7 +1945,7 @@ func (bot *Bot) EditMessageReplyMarkupWithContext(ctx context.Context, opts *Edi
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "editMessageReplyMarkup", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "editMessageReplyMarkup", v, reqOpts)
 	if err != nil {
 		return nil, false, err
 	}
@@ -2025,7 +2017,7 @@ func (bot *Bot) EditMessageTextWithContext(ctx context.Context, text string, opt
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "editMessageText", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "editMessageText", v, reqOpts)
 	if err != nil {
 		return nil, false, err
 	}
@@ -2089,7 +2081,7 @@ func (bot *Bot) EditStoryWithContext(ctx context.Context, businessConnectionId s
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "editStory", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "editStory", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2127,7 +2119,7 @@ func (bot *Bot) EditUserStarSubscriptionWithContext(ctx context.Context, userId 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "editUserStarSubscription", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "editUserStarSubscription", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -2161,7 +2153,7 @@ func (bot *Bot) ExportChatInviteLinkWithContext(ctx context.Context, chatId int6
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "exportChatInviteLink", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "exportChatInviteLink", v, reqOpts)
 	if err != nil {
 		return "", err
 	}
@@ -2221,7 +2213,7 @@ func (bot *Bot) ForwardMessageWithContext(ctx context.Context, chatId int64, fro
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "forwardMessage", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "forwardMessage", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2275,7 +2267,7 @@ func (bot *Bot) ForwardMessagesWithContext(ctx context.Context, chatId int64, fr
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "forwardMessages", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "forwardMessages", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2307,7 +2299,7 @@ func (bot *Bot) GetAvailableGiftsWithContext(ctx context.Context, opts *GetAvail
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getAvailableGifts", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getAvailableGifts", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2367,7 +2359,7 @@ func (bot *Bot) GetBusinessAccountGiftsWithContext(ctx context.Context, business
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getBusinessAccountGifts", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getBusinessAccountGifts", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2401,7 +2393,7 @@ func (bot *Bot) GetBusinessAccountStarBalanceWithContext(ctx context.Context, bu
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getBusinessAccountStarBalance", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getBusinessAccountStarBalance", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2435,7 +2427,7 @@ func (bot *Bot) GetBusinessConnectionWithContext(ctx context.Context, businessCo
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getBusinessConnection", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getBusinessConnection", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2469,7 +2461,7 @@ func (bot *Bot) GetChatWithContext(ctx context.Context, chatId int64, opts *GetC
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getChat", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getChat", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2503,7 +2495,7 @@ func (bot *Bot) GetChatAdministratorsWithContext(ctx context.Context, chatId int
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getChatAdministrators", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getChatAdministrators", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2538,7 +2530,7 @@ func (bot *Bot) GetChatMemberWithContext(ctx context.Context, chatId int64, user
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getChatMember", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getChatMember", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2571,7 +2563,7 @@ func (bot *Bot) GetChatMemberCountWithContext(ctx context.Context, chatId int64,
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getChatMemberCount", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getChatMemberCount", v, reqOpts)
 	if err != nil {
 		return 0, err
 	}
@@ -2610,7 +2602,7 @@ func (bot *Bot) GetChatMenuButtonWithContext(ctx context.Context, opts *GetChatM
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getChatMenuButton", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getChatMenuButton", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2645,7 +2637,7 @@ func (bot *Bot) GetCustomEmojiStickersWithContext(ctx context.Context, customEmo
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getCustomEmojiStickers", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getCustomEmojiStickers", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2680,7 +2672,7 @@ func (bot *Bot) GetFileWithContext(ctx context.Context, fileId string, opts *Get
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getFile", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getFile", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2712,7 +2704,7 @@ func (bot *Bot) GetForumTopicIconStickersWithContext(ctx context.Context, opts *
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getForumTopicIconStickers", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getForumTopicIconStickers", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2757,7 +2749,7 @@ func (bot *Bot) GetGameHighScoresWithContext(ctx context.Context, userId int64, 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getGameHighScores", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getGameHighScores", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2789,7 +2781,7 @@ func (bot *Bot) GetMeWithContext(ctx context.Context, opts *GetMeOpts) (*User, e
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getMe", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getMe", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2829,7 +2821,7 @@ func (bot *Bot) GetMyCommandsWithContext(ctx context.Context, opts *GetMyCommand
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getMyCommands", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getMyCommands", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2866,7 +2858,7 @@ func (bot *Bot) GetMyDefaultAdministratorRightsWithContext(ctx context.Context, 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getMyDefaultAdministratorRights", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getMyDefaultAdministratorRights", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2903,7 +2895,7 @@ func (bot *Bot) GetMyDescriptionWithContext(ctx context.Context, opts *GetMyDesc
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getMyDescription", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getMyDescription", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2940,7 +2932,7 @@ func (bot *Bot) GetMyNameWithContext(ctx context.Context, opts *GetMyNameOpts) (
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getMyName", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getMyName", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -2977,7 +2969,7 @@ func (bot *Bot) GetMyShortDescriptionWithContext(ctx context.Context, opts *GetM
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getMyShortDescription", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getMyShortDescription", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -3009,7 +3001,7 @@ func (bot *Bot) GetMyStarBalanceWithContext(ctx context.Context, opts *GetMyStar
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getMyStarBalance", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getMyStarBalance", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -3049,7 +3041,7 @@ func (bot *Bot) GetStarTransactionsWithContext(ctx context.Context, opts *GetSta
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getStarTransactions", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getStarTransactions", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -3083,7 +3075,7 @@ func (bot *Bot) GetStickerSetWithContext(ctx context.Context, name string, opts 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getStickerSet", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getStickerSet", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -3131,7 +3123,7 @@ func (bot *Bot) GetUpdatesWithContext(ctx context.Context, opts *GetUpdatesOpts)
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getUpdates", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getUpdates", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -3167,7 +3159,7 @@ func (bot *Bot) GetUserChatBoostsWithContext(ctx context.Context, chatId int64, 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getUserChatBoosts", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getUserChatBoosts", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -3209,7 +3201,7 @@ func (bot *Bot) GetUserProfilePhotosWithContext(ctx context.Context, userId int6
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getUserProfilePhotos", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getUserProfilePhotos", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -3241,7 +3233,7 @@ func (bot *Bot) GetWebhookInfoWithContext(ctx context.Context, opts *GetWebhookI
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "getWebhookInfo", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "getWebhookInfo", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -3292,7 +3284,7 @@ func (bot *Bot) GiftPremiumSubscriptionWithContext(ctx context.Context, userId i
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "giftPremiumSubscription", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "giftPremiumSubscription", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -3326,7 +3318,7 @@ func (bot *Bot) HideGeneralForumTopicWithContext(ctx context.Context, chatId int
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "hideGeneralForumTopic", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "hideGeneralForumTopic", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -3360,7 +3352,7 @@ func (bot *Bot) LeaveChatWithContext(ctx context.Context, chatId int64, opts *Le
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "leaveChat", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "leaveChat", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -3392,7 +3384,7 @@ func (bot *Bot) LogOutWithContext(ctx context.Context, opts *LogOutOpts) (bool, 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "logOut", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "logOut", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -3436,7 +3428,7 @@ func (bot *Bot) PinChatMessageWithContext(ctx context.Context, chatId int64, mes
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "pinChatMessage", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "pinChatMessage", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -3498,7 +3490,7 @@ func (bot *Bot) PostStoryWithContext(ctx context.Context, businessConnectionId s
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "postStory", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "postStory", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -3584,7 +3576,7 @@ func (bot *Bot) PromoteChatMemberWithContext(ctx context.Context, chatId int64, 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "promoteChatMember", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "promoteChatMember", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -3622,7 +3614,7 @@ func (bot *Bot) ReadBusinessMessageWithContext(ctx context.Context, businessConn
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "readBusinessMessage", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "readBusinessMessage", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -3658,7 +3650,7 @@ func (bot *Bot) RefundStarPaymentWithContext(ctx context.Context, userId int64, 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "refundStarPayment", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "refundStarPayment", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -3697,7 +3689,7 @@ func (bot *Bot) RemoveBusinessAccountProfilePhotoWithContext(ctx context.Context
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "removeBusinessAccountProfilePhoto", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "removeBusinessAccountProfilePhoto", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -3731,7 +3723,7 @@ func (bot *Bot) RemoveChatVerificationWithContext(ctx context.Context, chatId in
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "removeChatVerification", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "removeChatVerification", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -3765,7 +3757,7 @@ func (bot *Bot) RemoveUserVerificationWithContext(ctx context.Context, userId in
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "removeUserVerification", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "removeUserVerification", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -3801,7 +3793,7 @@ func (bot *Bot) ReopenForumTopicWithContext(ctx context.Context, chatId int64, m
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "reopenForumTopic", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "reopenForumTopic", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -3835,7 +3827,7 @@ func (bot *Bot) ReopenGeneralForumTopicWithContext(ctx context.Context, chatId i
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "reopenGeneralForumTopic", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "reopenGeneralForumTopic", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -3875,7 +3867,7 @@ func (bot *Bot) ReplaceStickerInSetWithContext(ctx context.Context, userId int64
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "replaceStickerInSet", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "replaceStickerInSet", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -3921,7 +3913,7 @@ func (bot *Bot) RestrictChatMemberWithContext(ctx context.Context, chatId int64,
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "restrictChatMember", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "restrictChatMember", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -3957,7 +3949,7 @@ func (bot *Bot) RevokeChatInviteLinkWithContext(ctx context.Context, chatId int6
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "revokeChatInviteLink", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "revokeChatInviteLink", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -4007,7 +3999,7 @@ func (bot *Bot) SavePreparedInlineMessageWithContext(ctx context.Context, userId
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "savePreparedInlineMessage", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "savePreparedInlineMessage", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -4073,15 +4065,8 @@ func (bot *Bot) SendAnimation(chatId int64, animation InputFileOrString, opts *S
 // SendAnimationWithContext is the same as Bot.SendAnimation, but with a context.Context parameter
 func (bot *Bot) SendAnimationWithContext(ctx context.Context, chatId int64, animation InputFileOrString, opts *SendAnimationOpts) (*Message, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
 	v["chat_id"] = chatId
-	if animation != nil {
-		err := animation.Attach("animation", data)
-		if err != nil {
-			return nil, fmt.Errorf("failed to attach 'animation' input file: %w", err)
-		}
-		v["animation"] = animation.getValue()
-	}
+	v["animation"] = animation
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["message_thread_id"] = opts.MessageThreadId
@@ -4089,13 +4074,7 @@ func (bot *Bot) SendAnimationWithContext(ctx context.Context, chatId int64, anim
 		v["duration"] = opts.Duration
 		v["width"] = opts.Width
 		v["height"] = opts.Height
-		if opts.Thumbnail != nil {
-			err := opts.Thumbnail.Attach("thumbnail", data)
-			if err != nil {
-				return nil, fmt.Errorf("failed to attach 'thumbnail' input file: %w", err)
-			}
-			v["thumbnail"] = opts.Thumbnail.getValue()
-		}
+		v["thumbnail"] = opts.Thumbnail
 		v["caption"] = opts.Caption
 		v["parse_mode"] = opts.ParseMode
 		if opts.CaptionEntities != nil {
@@ -4123,7 +4102,7 @@ func (bot *Bot) SendAnimationWithContext(ctx context.Context, chatId int64, anim
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendAnimation", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendAnimation", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -4186,15 +4165,8 @@ func (bot *Bot) SendAudio(chatId int64, audio InputFileOrString, opts *SendAudio
 // SendAudioWithContext is the same as Bot.SendAudio, but with a context.Context parameter
 func (bot *Bot) SendAudioWithContext(ctx context.Context, chatId int64, audio InputFileOrString, opts *SendAudioOpts) (*Message, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
 	v["chat_id"] = chatId
-	if audio != nil {
-		err := audio.Attach("audio", data)
-		if err != nil {
-			return nil, fmt.Errorf("failed to attach 'audio' input file: %w", err)
-		}
-		v["audio"] = audio.getValue()
-	}
+	v["audio"] = audio
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["message_thread_id"] = opts.MessageThreadId
@@ -4207,13 +4179,7 @@ func (bot *Bot) SendAudioWithContext(ctx context.Context, chatId int64, audio In
 		v["duration"] = opts.Duration
 		v["performer"] = opts.Performer
 		v["title"] = opts.Title
-		if opts.Thumbnail != nil {
-			err := opts.Thumbnail.Attach("thumbnail", data)
-			if err != nil {
-				return nil, fmt.Errorf("failed to attach 'thumbnail' input file: %w", err)
-			}
-			v["thumbnail"] = opts.Thumbnail.getValue()
-		}
+		v["thumbnail"] = opts.Thumbnail
 		v["disable_notification"] = opts.DisableNotification
 		v["protect_content"] = opts.ProtectContent
 		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
@@ -4234,7 +4200,7 @@ func (bot *Bot) SendAudioWithContext(ctx context.Context, chatId int64, audio In
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendAudio", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendAudio", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -4279,7 +4245,7 @@ func (bot *Bot) SendChatActionWithContext(ctx context.Context, chatId int64, act
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendChatAction", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendChatAction", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -4336,7 +4302,7 @@ func (bot *Bot) SendChecklistWithContext(ctx context.Context, businessConnection
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendChecklist", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendChecklist", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -4418,7 +4384,7 @@ func (bot *Bot) SendContactWithContext(ctx context.Context, chatId int64, phoneN
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendContact", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendContact", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -4493,7 +4459,7 @@ func (bot *Bot) SendDiceWithContext(ctx context.Context, chatId int64, opts *Sen
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendDice", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendDice", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -4551,26 +4517,13 @@ func (bot *Bot) SendDocument(chatId int64, document InputFileOrString, opts *Sen
 // SendDocumentWithContext is the same as Bot.SendDocument, but with a context.Context parameter
 func (bot *Bot) SendDocumentWithContext(ctx context.Context, chatId int64, document InputFileOrString, opts *SendDocumentOpts) (*Message, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
 	v["chat_id"] = chatId
-	if document != nil {
-		err := document.Attach("document", data)
-		if err != nil {
-			return nil, fmt.Errorf("failed to attach 'document' input file: %w", err)
-		}
-		v["document"] = document.getValue()
-	}
+	v["document"] = document
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["message_thread_id"] = opts.MessageThreadId
 		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		if opts.Thumbnail != nil {
-			err := opts.Thumbnail.Attach("thumbnail", data)
-			if err != nil {
-				return nil, fmt.Errorf("failed to attach 'thumbnail' input file: %w", err)
-			}
-			v["thumbnail"] = opts.Thumbnail.getValue()
-		}
+		v["thumbnail"] = opts.Thumbnail
 		v["caption"] = opts.Caption
 		v["parse_mode"] = opts.ParseMode
 		if opts.CaptionEntities != nil {
@@ -4597,7 +4550,7 @@ func (bot *Bot) SendDocumentWithContext(ctx context.Context, chatId int64, docum
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendDocument", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendDocument", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -4661,7 +4614,7 @@ func (bot *Bot) SendGameWithContext(ctx context.Context, chatId int64, gameShort
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendGame", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendGame", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -4717,7 +4670,7 @@ func (bot *Bot) SendGiftWithContext(ctx context.Context, giftId string, opts *Se
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendGift", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendGift", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -4846,7 +4799,7 @@ func (bot *Bot) SendInvoiceWithContext(ctx context.Context, chatId int64, title 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendInvoice", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendInvoice", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -4934,7 +4887,7 @@ func (bot *Bot) SendLocationWithContext(ctx context.Context, chatId int64, latit
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendLocation", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendLocation", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -5000,7 +4953,7 @@ func (bot *Bot) SendMediaGroupWithContext(ctx context.Context, chatId int64, med
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendMediaGroup", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendMediaGroup", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -5087,7 +5040,7 @@ func (bot *Bot) SendMessageWithContext(ctx context.Context, chatId int64, text s
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendMessage", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendMessage", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -5179,7 +5132,7 @@ func (bot *Bot) SendPaidMediaWithContext(ctx context.Context, chatId int64, star
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendPaidMedia", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendPaidMedia", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -5237,15 +5190,8 @@ func (bot *Bot) SendPhoto(chatId int64, photo InputFileOrString, opts *SendPhoto
 // SendPhotoWithContext is the same as Bot.SendPhoto, but with a context.Context parameter
 func (bot *Bot) SendPhotoWithContext(ctx context.Context, chatId int64, photo InputFileOrString, opts *SendPhotoOpts) (*Message, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
 	v["chat_id"] = chatId
-	if photo != nil {
-		err := photo.Attach("photo", data)
-		if err != nil {
-			return nil, fmt.Errorf("failed to attach 'photo' input file: %w", err)
-		}
-		v["photo"] = photo.getValue()
-	}
+	v["photo"] = photo
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["message_thread_id"] = opts.MessageThreadId
@@ -5277,7 +5223,7 @@ func (bot *Bot) SendPhotoWithContext(ctx context.Context, chatId int64, photo In
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendPhoto", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendPhoto", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -5390,7 +5336,7 @@ func (bot *Bot) SendPollWithContext(ctx context.Context, chatId int64, question 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendPoll", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendPoll", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -5440,15 +5386,8 @@ func (bot *Bot) SendSticker(chatId int64, sticker InputFileOrString, opts *SendS
 // SendStickerWithContext is the same as Bot.SendSticker, but with a context.Context parameter
 func (bot *Bot) SendStickerWithContext(ctx context.Context, chatId int64, sticker InputFileOrString, opts *SendStickerOpts) (*Message, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
 	v["chat_id"] = chatId
-	if sticker != nil {
-		err := sticker.Attach("sticker", data)
-		if err != nil {
-			return nil, fmt.Errorf("failed to attach 'sticker' input file: %w", err)
-		}
-		v["sticker"] = sticker.getValue()
-	}
+	v["sticker"] = sticker
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["message_thread_id"] = opts.MessageThreadId
@@ -5474,7 +5413,7 @@ func (bot *Bot) SendStickerWithContext(ctx context.Context, chatId int64, sticke
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendSticker", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendSticker", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -5566,7 +5505,7 @@ func (bot *Bot) SendVenueWithContext(ctx context.Context, chatId int64, latitude
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendVenue", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendVenue", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -5638,15 +5577,8 @@ func (bot *Bot) SendVideo(chatId int64, video InputFileOrString, opts *SendVideo
 // SendVideoWithContext is the same as Bot.SendVideo, but with a context.Context parameter
 func (bot *Bot) SendVideoWithContext(ctx context.Context, chatId int64, video InputFileOrString, opts *SendVideoOpts) (*Message, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
 	v["chat_id"] = chatId
-	if video != nil {
-		err := video.Attach("video", data)
-		if err != nil {
-			return nil, fmt.Errorf("failed to attach 'video' input file: %w", err)
-		}
-		v["video"] = video.getValue()
-	}
+	v["video"] = video
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["message_thread_id"] = opts.MessageThreadId
@@ -5654,20 +5586,8 @@ func (bot *Bot) SendVideoWithContext(ctx context.Context, chatId int64, video In
 		v["duration"] = opts.Duration
 		v["width"] = opts.Width
 		v["height"] = opts.Height
-		if opts.Thumbnail != nil {
-			err := opts.Thumbnail.Attach("thumbnail", data)
-			if err != nil {
-				return nil, fmt.Errorf("failed to attach 'thumbnail' input file: %w", err)
-			}
-			v["thumbnail"] = opts.Thumbnail.getValue()
-		}
-		if opts.Cover != nil {
-			err := opts.Cover.Attach("cover", data)
-			if err != nil {
-				return nil, fmt.Errorf("failed to attach 'cover' input file: %w", err)
-			}
-			v["cover"] = opts.Cover.getValue()
-		}
+		v["thumbnail"] = opts.Thumbnail
+		v["cover"] = opts.Cover
 		v["start_timestamp"] = opts.StartTimestamp
 		v["caption"] = opts.Caption
 		v["parse_mode"] = opts.ParseMode
@@ -5697,7 +5617,7 @@ func (bot *Bot) SendVideoWithContext(ctx context.Context, chatId int64, video In
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendVideo", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendVideo", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -5751,28 +5671,15 @@ func (bot *Bot) SendVideoNote(chatId int64, videoNote InputFileOrString, opts *S
 // SendVideoNoteWithContext is the same as Bot.SendVideoNote, but with a context.Context parameter
 func (bot *Bot) SendVideoNoteWithContext(ctx context.Context, chatId int64, videoNote InputFileOrString, opts *SendVideoNoteOpts) (*Message, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
 	v["chat_id"] = chatId
-	if videoNote != nil {
-		err := videoNote.Attach("video_note", data)
-		if err != nil {
-			return nil, fmt.Errorf("failed to attach 'video_note' input file: %w", err)
-		}
-		v["video_note"] = videoNote.getValue()
-	}
+	v["video_note"] = videoNote
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["message_thread_id"] = opts.MessageThreadId
 		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
 		v["duration"] = opts.Duration
 		v["length"] = opts.Length
-		if opts.Thumbnail != nil {
-			err := opts.Thumbnail.Attach("thumbnail", data)
-			if err != nil {
-				return nil, fmt.Errorf("failed to attach 'thumbnail' input file: %w", err)
-			}
-			v["thumbnail"] = opts.Thumbnail.getValue()
-		}
+		v["thumbnail"] = opts.Thumbnail
 		v["disable_notification"] = opts.DisableNotification
 		v["protect_content"] = opts.ProtectContent
 		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
@@ -5793,7 +5700,7 @@ func (bot *Bot) SendVideoNoteWithContext(ctx context.Context, chatId int64, vide
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendVideoNote", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendVideoNote", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -5849,15 +5756,8 @@ func (bot *Bot) SendVoice(chatId int64, voice InputFileOrString, opts *SendVoice
 // SendVoiceWithContext is the same as Bot.SendVoice, but with a context.Context parameter
 func (bot *Bot) SendVoiceWithContext(ctx context.Context, chatId int64, voice InputFileOrString, opts *SendVoiceOpts) (*Message, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
 	v["chat_id"] = chatId
-	if voice != nil {
-		err := voice.Attach("voice", data)
-		if err != nil {
-			return nil, fmt.Errorf("failed to attach 'voice' input file: %w", err)
-		}
-		v["voice"] = voice.getValue()
-	}
+	v["voice"] = voice
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["message_thread_id"] = opts.MessageThreadId
@@ -5888,7 +5788,7 @@ func (bot *Bot) SendVoiceWithContext(ctx context.Context, chatId int64, voice In
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendVoice", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendVoice", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -5927,7 +5827,7 @@ func (bot *Bot) SetBusinessAccountBioWithContext(ctx context.Context, businessCo
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setBusinessAccountBio", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setBusinessAccountBio", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -5965,7 +5865,7 @@ func (bot *Bot) SetBusinessAccountGiftSettingsWithContext(ctx context.Context, b
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setBusinessAccountGiftSettings", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setBusinessAccountGiftSettings", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6006,7 +5906,7 @@ func (bot *Bot) SetBusinessAccountNameWithContext(ctx context.Context, businessC
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setBusinessAccountName", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setBusinessAccountName", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6047,7 +5947,7 @@ func (bot *Bot) SetBusinessAccountProfilePhotoWithContext(ctx context.Context, b
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setBusinessAccountProfilePhoto", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setBusinessAccountProfilePhoto", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6086,7 +5986,7 @@ func (bot *Bot) SetBusinessAccountUsernameWithContext(ctx context.Context, busin
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setBusinessAccountUsername", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setBusinessAccountUsername", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6124,7 +6024,7 @@ func (bot *Bot) SetChatAdministratorCustomTitleWithContext(ctx context.Context, 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setChatAdministratorCustomTitle", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setChatAdministratorCustomTitle", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6163,7 +6063,7 @@ func (bot *Bot) SetChatDescriptionWithContext(ctx context.Context, chatId int64,
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setChatDescription", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setChatDescription", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6205,7 +6105,7 @@ func (bot *Bot) SetChatMenuButtonWithContext(ctx context.Context, opts *SetChatM
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setChatMenuButton", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setChatMenuButton", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6246,7 +6146,7 @@ func (bot *Bot) SetChatPermissionsWithContext(ctx context.Context, chatId int64,
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setChatPermissions", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setChatPermissions", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6274,22 +6174,15 @@ func (bot *Bot) SetChatPhoto(chatId int64, photo InputFile, opts *SetChatPhotoOp
 // SetChatPhotoWithContext is the same as Bot.SetChatPhoto, but with a context.Context parameter
 func (bot *Bot) SetChatPhotoWithContext(ctx context.Context, chatId int64, photo InputFile, opts *SetChatPhotoOpts) (bool, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
 	v["chat_id"] = chatId
-	if photo != nil {
-		err := photo.Attach("photo", data)
-		if err != nil {
-			return false, fmt.Errorf("failed to attach 'photo' input file: %w", err)
-		}
-		v["photo"] = photo.getValue()
-	}
+	v["photo"] = photo
 
 	var reqOpts *RequestOpts
 	if opts != nil {
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setChatPhoto", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setChatPhoto", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6325,7 +6218,7 @@ func (bot *Bot) SetChatStickerSetWithContext(ctx context.Context, chatId int64, 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setChatStickerSet", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setChatStickerSet", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6361,7 +6254,7 @@ func (bot *Bot) SetChatTitleWithContext(ctx context.Context, chatId int64, title
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setChatTitle", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setChatTitle", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6400,7 +6293,7 @@ func (bot *Bot) SetCustomEmojiStickerSetThumbnailWithContext(ctx context.Context
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setCustomEmojiStickerSetThumbnail", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setCustomEmojiStickerSetThumbnail", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6453,7 +6346,7 @@ func (bot *Bot) SetGameScoreWithContext(ctx context.Context, userId int64, score
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setGameScore", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setGameScore", v, reqOpts)
 	if err != nil {
 		return nil, false, err
 	}
@@ -6507,7 +6400,7 @@ func (bot *Bot) SetMessageReactionWithContext(ctx context.Context, chatId int64,
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setMessageReaction", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setMessageReaction", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6551,7 +6444,7 @@ func (bot *Bot) SetMyCommandsWithContext(ctx context.Context, commands []BotComm
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setMyCommands", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setMyCommands", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6593,7 +6486,7 @@ func (bot *Bot) SetMyDefaultAdministratorRightsWithContext(ctx context.Context, 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setMyDefaultAdministratorRights", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setMyDefaultAdministratorRights", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6633,7 +6526,7 @@ func (bot *Bot) SetMyDescriptionWithContext(ctx context.Context, opts *SetMyDesc
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setMyDescription", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setMyDescription", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6673,7 +6566,7 @@ func (bot *Bot) SetMyNameWithContext(ctx context.Context, opts *SetMyNameOpts) (
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setMyName", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setMyName", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6713,7 +6606,7 @@ func (bot *Bot) SetMyShortDescriptionWithContext(ctx context.Context, opts *SetM
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setMyShortDescription", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setMyShortDescription", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6752,7 +6645,7 @@ func (bot *Bot) SetPassportDataErrorsWithContext(ctx context.Context, userId int
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setPassportDataErrors", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setPassportDataErrors", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6780,14 +6673,7 @@ func (bot *Bot) SetStickerEmojiList(sticker InputFileOrString, emojiList []strin
 // SetStickerEmojiListWithContext is the same as Bot.SetStickerEmojiList, but with a context.Context parameter
 func (bot *Bot) SetStickerEmojiListWithContext(ctx context.Context, sticker InputFileOrString, emojiList []string, opts *SetStickerEmojiListOpts) (bool, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
-	if sticker != nil {
-		err := sticker.Attach("sticker", data)
-		if err != nil {
-			return false, fmt.Errorf("failed to attach 'sticker' input file: %w", err)
-		}
-		v["sticker"] = sticker.getValue()
-	}
+	v["sticker"] = sticker
 	if emojiList != nil {
 		v["emoji_list"] = emojiList
 	}
@@ -6797,7 +6683,7 @@ func (bot *Bot) SetStickerEmojiListWithContext(ctx context.Context, sticker Inpu
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setStickerEmojiList", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setStickerEmojiList", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6826,14 +6712,7 @@ func (bot *Bot) SetStickerKeywords(sticker InputFileOrString, opts *SetStickerKe
 // SetStickerKeywordsWithContext is the same as Bot.SetStickerKeywords, but with a context.Context parameter
 func (bot *Bot) SetStickerKeywordsWithContext(ctx context.Context, sticker InputFileOrString, opts *SetStickerKeywordsOpts) (bool, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
-	if sticker != nil {
-		err := sticker.Attach("sticker", data)
-		if err != nil {
-			return false, fmt.Errorf("failed to attach 'sticker' input file: %w", err)
-		}
-		v["sticker"] = sticker.getValue()
-	}
+	v["sticker"] = sticker
 	if opts != nil {
 		if opts.Keywords != nil {
 			v["keywords"] = opts.Keywords
@@ -6845,7 +6724,7 @@ func (bot *Bot) SetStickerKeywordsWithContext(ctx context.Context, sticker Input
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setStickerKeywords", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setStickerKeywords", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6874,14 +6753,7 @@ func (bot *Bot) SetStickerMaskPosition(sticker InputFileOrString, opts *SetStick
 // SetStickerMaskPositionWithContext is the same as Bot.SetStickerMaskPosition, but with a context.Context parameter
 func (bot *Bot) SetStickerMaskPositionWithContext(ctx context.Context, sticker InputFileOrString, opts *SetStickerMaskPositionOpts) (bool, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
-	if sticker != nil {
-		err := sticker.Attach("sticker", data)
-		if err != nil {
-			return false, fmt.Errorf("failed to attach 'sticker' input file: %w", err)
-		}
-		v["sticker"] = sticker.getValue()
-	}
+	v["sticker"] = sticker
 	if opts != nil {
 		if opts.MaskPosition != nil {
 			v["mask_position"] = opts.MaskPosition
@@ -6893,7 +6765,7 @@ func (bot *Bot) SetStickerMaskPositionWithContext(ctx context.Context, sticker I
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setStickerMaskPosition", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setStickerMaskPosition", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6921,14 +6793,7 @@ func (bot *Bot) SetStickerPositionInSet(sticker InputFileOrString, position int6
 // SetStickerPositionInSetWithContext is the same as Bot.SetStickerPositionInSet, but with a context.Context parameter
 func (bot *Bot) SetStickerPositionInSetWithContext(ctx context.Context, sticker InputFileOrString, position int64, opts *SetStickerPositionInSetOpts) (bool, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
-	if sticker != nil {
-		err := sticker.Attach("sticker", data)
-		if err != nil {
-			return false, fmt.Errorf("failed to attach 'sticker' input file: %w", err)
-		}
-		v["sticker"] = sticker.getValue()
-	}
+	v["sticker"] = sticker
 	v["position"] = position
 
 	var reqOpts *RequestOpts
@@ -6936,7 +6801,7 @@ func (bot *Bot) SetStickerPositionInSetWithContext(ctx context.Context, sticker 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setStickerPositionInSet", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setStickerPositionInSet", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -6967,18 +6832,11 @@ func (bot *Bot) SetStickerSetThumbnail(name string, userId int64, format string,
 // SetStickerSetThumbnailWithContext is the same as Bot.SetStickerSetThumbnail, but with a context.Context parameter
 func (bot *Bot) SetStickerSetThumbnailWithContext(ctx context.Context, name string, userId int64, format string, opts *SetStickerSetThumbnailOpts) (bool, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
 	v["name"] = name
 	v["user_id"] = userId
 	v["format"] = format
 	if opts != nil {
-		if opts.Thumbnail != nil {
-			err := opts.Thumbnail.Attach("thumbnail", data)
-			if err != nil {
-				return false, fmt.Errorf("failed to attach 'thumbnail' input file: %w", err)
-			}
-			v["thumbnail"] = opts.Thumbnail.getValue()
-		}
+		v["thumbnail"] = opts.Thumbnail
 	}
 
 	var reqOpts *RequestOpts
@@ -6986,7 +6844,7 @@ func (bot *Bot) SetStickerSetThumbnailWithContext(ctx context.Context, name stri
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setStickerSetThumbnail", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setStickerSetThumbnail", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -7022,7 +6880,7 @@ func (bot *Bot) SetStickerSetTitleWithContext(ctx context.Context, name string, 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setStickerSetTitle", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setStickerSetTitle", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -7064,7 +6922,7 @@ func (bot *Bot) SetUserEmojiStatusWithContext(ctx context.Context, userId int64,
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setUserEmojiStatus", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setUserEmojiStatus", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -7104,16 +6962,9 @@ func (bot *Bot) SetWebhook(url string, opts *SetWebhookOpts) (bool, error) {
 // SetWebhookWithContext is the same as Bot.SetWebhook, but with a context.Context parameter
 func (bot *Bot) SetWebhookWithContext(ctx context.Context, url string, opts *SetWebhookOpts) (bool, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
 	v["url"] = url
 	if opts != nil {
-		if opts.Certificate != nil {
-			err := opts.Certificate.Attach("certificate", data)
-			if err != nil {
-				return false, fmt.Errorf("failed to attach 'certificate' input file: %w", err)
-			}
-			v["certificate"] = opts.Certificate.getValue()
-		}
+		v["certificate"] = opts.Certificate
 		v["ip_address"] = opts.IpAddress
 		v["max_connections"] = opts.MaxConnections
 		if opts.AllowedUpdates != nil {
@@ -7128,7 +6979,7 @@ func (bot *Bot) SetWebhookWithContext(ctx context.Context, url string, opts *Set
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "setWebhook", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "setWebhook", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -7177,7 +7028,7 @@ func (bot *Bot) StopMessageLiveLocationWithContext(ctx context.Context, opts *St
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "stopMessageLiveLocation", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "stopMessageLiveLocation", v, reqOpts)
 	if err != nil {
 		return nil, false, err
 	}
@@ -7229,7 +7080,7 @@ func (bot *Bot) StopPollWithContext(ctx context.Context, chatId int64, messageId
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "stopPoll", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "stopPoll", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -7265,7 +7116,7 @@ func (bot *Bot) TransferBusinessAccountStarsWithContext(ctx context.Context, bus
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "transferBusinessAccountStars", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "transferBusinessAccountStars", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -7308,7 +7159,7 @@ func (bot *Bot) TransferGiftWithContext(ctx context.Context, businessConnectionI
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "transferGift", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "transferGift", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -7349,7 +7200,7 @@ func (bot *Bot) UnbanChatMemberWithContext(ctx context.Context, chatId int64, us
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "unbanChatMember", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "unbanChatMember", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -7385,7 +7236,7 @@ func (bot *Bot) UnbanChatSenderChatWithContext(ctx context.Context, chatId int64
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "unbanChatSenderChat", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "unbanChatSenderChat", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -7419,7 +7270,7 @@ func (bot *Bot) UnhideGeneralForumTopicWithContext(ctx context.Context, chatId i
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "unhideGeneralForumTopic", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "unhideGeneralForumTopic", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -7453,7 +7304,7 @@ func (bot *Bot) UnpinAllChatMessagesWithContext(ctx context.Context, chatId int6
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "unpinAllChatMessages", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "unpinAllChatMessages", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -7489,7 +7340,7 @@ func (bot *Bot) UnpinAllForumTopicMessagesWithContext(ctx context.Context, chatI
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "unpinAllForumTopicMessages", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "unpinAllForumTopicMessages", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -7523,7 +7374,7 @@ func (bot *Bot) UnpinAllGeneralForumTopicMessagesWithContext(ctx context.Context
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "unpinAllGeneralForumTopicMessages", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "unpinAllGeneralForumTopicMessages", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -7567,7 +7418,7 @@ func (bot *Bot) UnpinChatMessageWithContext(ctx context.Context, chatId int64, o
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "unpinChatMessage", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "unpinChatMessage", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -7611,7 +7462,7 @@ func (bot *Bot) UpgradeGiftWithContext(ctx context.Context, businessConnectionId
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "upgradeGift", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "upgradeGift", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -7640,15 +7491,8 @@ func (bot *Bot) UploadStickerFile(userId int64, sticker InputFile, stickerFormat
 // UploadStickerFileWithContext is the same as Bot.UploadStickerFile, but with a context.Context parameter
 func (bot *Bot) UploadStickerFileWithContext(ctx context.Context, userId int64, sticker InputFile, stickerFormat string, opts *UploadStickerFileOpts) (*File, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
 	v["user_id"] = userId
-	if sticker != nil {
-		err := sticker.Attach("sticker", data)
-		if err != nil {
-			return nil, fmt.Errorf("failed to attach 'sticker' input file: %w", err)
-		}
-		v["sticker"] = sticker.getValue()
-	}
+	v["sticker"] = sticker
 	v["sticker_format"] = stickerFormat
 
 	var reqOpts *RequestOpts
@@ -7656,7 +7500,7 @@ func (bot *Bot) UploadStickerFileWithContext(ctx context.Context, userId int64, 
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "uploadStickerFile", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "uploadStickerFile", v, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -7695,7 +7539,7 @@ func (bot *Bot) VerifyChatWithContext(ctx context.Context, chatId int64, opts *V
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "verifyChat", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "verifyChat", v, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -7734,7 +7578,7 @@ func (bot *Bot) VerifyUserWithContext(ctx context.Context, userId int64, opts *V
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "verifyUser", v, nil, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "verifyUser", v, reqOpts)
 	if err != nil {
 		return false, err
 	}

--- a/gen_methods.go
+++ b/gen_methods.go
@@ -32,11 +32,11 @@ func (bot *Bot) AddStickerToSetWithContext(ctx context.Context, userId int64, na
 	data := map[string]FileReader{}
 	v["user_id"] = userId
 	v["name"] = name
-	inputBs, err := sticker.InputParams("sticker", data)
+	err := sticker.InputParams("sticker", data)
 	if err != nil {
 		return false, fmt.Errorf("failed to marshal field sticker: %w", err)
 	}
-	v["sticker"] = string(inputBs)
+	v["sticker"] = sticker
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -1889,11 +1889,11 @@ func (bot *Bot) EditMessageMedia(media InputMedia, opts *EditMessageMediaOpts) (
 func (bot *Bot) EditMessageMediaWithContext(ctx context.Context, media InputMedia, opts *EditMessageMediaOpts) (*Message, bool, error) {
 	v := map[string]any{}
 	data := map[string]FileReader{}
-	inputBs, err := media.InputParams("media", data)
+	err := media.InputParams("media", data)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to marshal field media: %w", err)
 	}
-	v["media"] = string(inputBs)
+	v["media"] = media
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["chat_id"] = opts.ChatId
@@ -3880,11 +3880,11 @@ func (bot *Bot) ReplaceStickerInSetWithContext(ctx context.Context, userId int64
 	v["user_id"] = userId
 	v["name"] = name
 	v["old_sticker"] = oldSticker
-	inputBs, err := sticker.InputParams("sticker", data)
+	err := sticker.InputParams("sticker", data)
 	if err != nil {
 		return false, fmt.Errorf("failed to marshal field sticker: %w", err)
 	}
-	v["sticker"] = string(inputBs)
+	v["sticker"] = sticker
 
 	var reqOpts *RequestOpts
 	if opts != nil {

--- a/gen_methods.go
+++ b/gen_methods.go
@@ -1359,7 +1359,9 @@ func (bot *Bot) DeleteStickerFromSet(sticker InputFileOrString, opts *DeleteStic
 // DeleteStickerFromSetWithContext is the same as Bot.DeleteStickerFromSet, but with a context.Context parameter
 func (bot *Bot) DeleteStickerFromSetWithContext(ctx context.Context, sticker InputFileOrString, opts *DeleteStickerFromSetOpts) (bool, error) {
 	v := map[string]any{}
-	v["sticker"] = sticker
+	if sticker != nil {
+		v["sticker"] = sticker
+	}
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -1874,7 +1876,9 @@ func (bot *Bot) EditMessageMedia(media InputMedia, opts *EditMessageMediaOpts) (
 // EditMessageMediaWithContext is the same as Bot.EditMessageMedia, but with a context.Context parameter
 func (bot *Bot) EditMessageMediaWithContext(ctx context.Context, media InputMedia, opts *EditMessageMediaOpts) (*Message, bool, error) {
 	v := map[string]any{}
-	v["media"] = media
+	if media != nil {
+		v["media"] = media
+	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["chat_id"] = opts.ChatId
@@ -4066,7 +4070,9 @@ func (bot *Bot) SendAnimation(chatId int64, animation InputFileOrString, opts *S
 func (bot *Bot) SendAnimationWithContext(ctx context.Context, chatId int64, animation InputFileOrString, opts *SendAnimationOpts) (*Message, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	v["animation"] = animation
+	if animation != nil {
+		v["animation"] = animation
+	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["message_thread_id"] = opts.MessageThreadId
@@ -4074,7 +4080,9 @@ func (bot *Bot) SendAnimationWithContext(ctx context.Context, chatId int64, anim
 		v["duration"] = opts.Duration
 		v["width"] = opts.Width
 		v["height"] = opts.Height
-		v["thumbnail"] = opts.Thumbnail
+		if opts.Thumbnail != nil {
+			v["thumbnail"] = opts.Thumbnail
+		}
 		v["caption"] = opts.Caption
 		v["parse_mode"] = opts.ParseMode
 		if opts.CaptionEntities != nil {
@@ -4166,7 +4174,9 @@ func (bot *Bot) SendAudio(chatId int64, audio InputFileOrString, opts *SendAudio
 func (bot *Bot) SendAudioWithContext(ctx context.Context, chatId int64, audio InputFileOrString, opts *SendAudioOpts) (*Message, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	v["audio"] = audio
+	if audio != nil {
+		v["audio"] = audio
+	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["message_thread_id"] = opts.MessageThreadId
@@ -4179,7 +4189,9 @@ func (bot *Bot) SendAudioWithContext(ctx context.Context, chatId int64, audio In
 		v["duration"] = opts.Duration
 		v["performer"] = opts.Performer
 		v["title"] = opts.Title
-		v["thumbnail"] = opts.Thumbnail
+		if opts.Thumbnail != nil {
+			v["thumbnail"] = opts.Thumbnail
+		}
 		v["disable_notification"] = opts.DisableNotification
 		v["protect_content"] = opts.ProtectContent
 		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
@@ -4518,12 +4530,16 @@ func (bot *Bot) SendDocument(chatId int64, document InputFileOrString, opts *Sen
 func (bot *Bot) SendDocumentWithContext(ctx context.Context, chatId int64, document InputFileOrString, opts *SendDocumentOpts) (*Message, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	v["document"] = document
+	if document != nil {
+		v["document"] = document
+	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["message_thread_id"] = opts.MessageThreadId
 		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["thumbnail"] = opts.Thumbnail
+		if opts.Thumbnail != nil {
+			v["thumbnail"] = opts.Thumbnail
+		}
 		v["caption"] = opts.Caption
 		v["parse_mode"] = opts.ParseMode
 		if opts.CaptionEntities != nil {
@@ -5191,7 +5207,9 @@ func (bot *Bot) SendPhoto(chatId int64, photo InputFileOrString, opts *SendPhoto
 func (bot *Bot) SendPhotoWithContext(ctx context.Context, chatId int64, photo InputFileOrString, opts *SendPhotoOpts) (*Message, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	v["photo"] = photo
+	if photo != nil {
+		v["photo"] = photo
+	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["message_thread_id"] = opts.MessageThreadId
@@ -5387,7 +5405,9 @@ func (bot *Bot) SendSticker(chatId int64, sticker InputFileOrString, opts *SendS
 func (bot *Bot) SendStickerWithContext(ctx context.Context, chatId int64, sticker InputFileOrString, opts *SendStickerOpts) (*Message, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	v["sticker"] = sticker
+	if sticker != nil {
+		v["sticker"] = sticker
+	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["message_thread_id"] = opts.MessageThreadId
@@ -5578,7 +5598,9 @@ func (bot *Bot) SendVideo(chatId int64, video InputFileOrString, opts *SendVideo
 func (bot *Bot) SendVideoWithContext(ctx context.Context, chatId int64, video InputFileOrString, opts *SendVideoOpts) (*Message, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	v["video"] = video
+	if video != nil {
+		v["video"] = video
+	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["message_thread_id"] = opts.MessageThreadId
@@ -5586,8 +5608,12 @@ func (bot *Bot) SendVideoWithContext(ctx context.Context, chatId int64, video In
 		v["duration"] = opts.Duration
 		v["width"] = opts.Width
 		v["height"] = opts.Height
-		v["thumbnail"] = opts.Thumbnail
-		v["cover"] = opts.Cover
+		if opts.Thumbnail != nil {
+			v["thumbnail"] = opts.Thumbnail
+		}
+		if opts.Cover != nil {
+			v["cover"] = opts.Cover
+		}
 		v["start_timestamp"] = opts.StartTimestamp
 		v["caption"] = opts.Caption
 		v["parse_mode"] = opts.ParseMode
@@ -5672,14 +5698,18 @@ func (bot *Bot) SendVideoNote(chatId int64, videoNote InputFileOrString, opts *S
 func (bot *Bot) SendVideoNoteWithContext(ctx context.Context, chatId int64, videoNote InputFileOrString, opts *SendVideoNoteOpts) (*Message, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	v["video_note"] = videoNote
+	if videoNote != nil {
+		v["video_note"] = videoNote
+	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["message_thread_id"] = opts.MessageThreadId
 		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
 		v["duration"] = opts.Duration
 		v["length"] = opts.Length
-		v["thumbnail"] = opts.Thumbnail
+		if opts.Thumbnail != nil {
+			v["thumbnail"] = opts.Thumbnail
+		}
 		v["disable_notification"] = opts.DisableNotification
 		v["protect_content"] = opts.ProtectContent
 		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
@@ -5757,7 +5787,9 @@ func (bot *Bot) SendVoice(chatId int64, voice InputFileOrString, opts *SendVoice
 func (bot *Bot) SendVoiceWithContext(ctx context.Context, chatId int64, voice InputFileOrString, opts *SendVoiceOpts) (*Message, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	v["voice"] = voice
+	if voice != nil {
+		v["voice"] = voice
+	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["message_thread_id"] = opts.MessageThreadId
@@ -6175,7 +6207,9 @@ func (bot *Bot) SetChatPhoto(chatId int64, photo InputFile, opts *SetChatPhotoOp
 func (bot *Bot) SetChatPhotoWithContext(ctx context.Context, chatId int64, photo InputFile, opts *SetChatPhotoOpts) (bool, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	v["photo"] = photo
+	if photo != nil {
+		v["photo"] = photo
+	}
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -6673,7 +6707,9 @@ func (bot *Bot) SetStickerEmojiList(sticker InputFileOrString, emojiList []strin
 // SetStickerEmojiListWithContext is the same as Bot.SetStickerEmojiList, but with a context.Context parameter
 func (bot *Bot) SetStickerEmojiListWithContext(ctx context.Context, sticker InputFileOrString, emojiList []string, opts *SetStickerEmojiListOpts) (bool, error) {
 	v := map[string]any{}
-	v["sticker"] = sticker
+	if sticker != nil {
+		v["sticker"] = sticker
+	}
 	if emojiList != nil {
 		v["emoji_list"] = emojiList
 	}
@@ -6712,7 +6748,9 @@ func (bot *Bot) SetStickerKeywords(sticker InputFileOrString, opts *SetStickerKe
 // SetStickerKeywordsWithContext is the same as Bot.SetStickerKeywords, but with a context.Context parameter
 func (bot *Bot) SetStickerKeywordsWithContext(ctx context.Context, sticker InputFileOrString, opts *SetStickerKeywordsOpts) (bool, error) {
 	v := map[string]any{}
-	v["sticker"] = sticker
+	if sticker != nil {
+		v["sticker"] = sticker
+	}
 	if opts != nil {
 		if opts.Keywords != nil {
 			v["keywords"] = opts.Keywords
@@ -6753,7 +6791,9 @@ func (bot *Bot) SetStickerMaskPosition(sticker InputFileOrString, opts *SetStick
 // SetStickerMaskPositionWithContext is the same as Bot.SetStickerMaskPosition, but with a context.Context parameter
 func (bot *Bot) SetStickerMaskPositionWithContext(ctx context.Context, sticker InputFileOrString, opts *SetStickerMaskPositionOpts) (bool, error) {
 	v := map[string]any{}
-	v["sticker"] = sticker
+	if sticker != nil {
+		v["sticker"] = sticker
+	}
 	if opts != nil {
 		if opts.MaskPosition != nil {
 			v["mask_position"] = opts.MaskPosition
@@ -6793,7 +6833,9 @@ func (bot *Bot) SetStickerPositionInSet(sticker InputFileOrString, position int6
 // SetStickerPositionInSetWithContext is the same as Bot.SetStickerPositionInSet, but with a context.Context parameter
 func (bot *Bot) SetStickerPositionInSetWithContext(ctx context.Context, sticker InputFileOrString, position int64, opts *SetStickerPositionInSetOpts) (bool, error) {
 	v := map[string]any{}
-	v["sticker"] = sticker
+	if sticker != nil {
+		v["sticker"] = sticker
+	}
 	v["position"] = position
 
 	var reqOpts *RequestOpts
@@ -6836,7 +6878,9 @@ func (bot *Bot) SetStickerSetThumbnailWithContext(ctx context.Context, name stri
 	v["user_id"] = userId
 	v["format"] = format
 	if opts != nil {
-		v["thumbnail"] = opts.Thumbnail
+		if opts.Thumbnail != nil {
+			v["thumbnail"] = opts.Thumbnail
+		}
 	}
 
 	var reqOpts *RequestOpts
@@ -6964,7 +7008,9 @@ func (bot *Bot) SetWebhookWithContext(ctx context.Context, url string, opts *Set
 	v := map[string]any{}
 	v["url"] = url
 	if opts != nil {
-		v["certificate"] = opts.Certificate
+		if opts.Certificate != nil {
+			v["certificate"] = opts.Certificate
+		}
 		v["ip_address"] = opts.IpAddress
 		v["max_connections"] = opts.MaxConnections
 		if opts.AllowedUpdates != nil {
@@ -7492,7 +7538,9 @@ func (bot *Bot) UploadStickerFile(userId int64, sticker InputFile, stickerFormat
 func (bot *Bot) UploadStickerFileWithContext(ctx context.Context, userId int64, sticker InputFile, stickerFormat string, opts *UploadStickerFileOpts) (*File, error) {
 	v := map[string]any{}
 	v["user_id"] = userId
-	v["sticker"] = sticker
+	if sticker != nil {
+		v["sticker"] = sticker
+	}
 	v["sticker_format"] = stickerFormat
 
 	var reqOpts *RequestOpts

--- a/gen_methods.go
+++ b/gen_methods.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 )
 
 // AddStickerToSetOpts is the set of optional fields for Bot.AddStickerToSet and Bot.AddStickerToSetWithContext.
@@ -29,9 +28,9 @@ func (bot *Bot) AddStickerToSet(userId int64, name string, sticker InputSticker,
 
 // AddStickerToSetWithContext is the same as Bot.AddStickerToSet, but with a context.Context parameter
 func (bot *Bot) AddStickerToSetWithContext(ctx context.Context, userId int64, name string, sticker InputSticker, opts *AddStickerToSetOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v["user_id"] = userId
 	v["name"] = name
 	inputBs, err := sticker.InputParams("sticker", data)
 	if err != nil {
@@ -78,15 +77,13 @@ func (bot *Bot) AnswerCallbackQuery(callbackQueryId string, opts *AnswerCallback
 
 // AnswerCallbackQueryWithContext is the same as Bot.AnswerCallbackQuery, but with a context.Context parameter
 func (bot *Bot) AnswerCallbackQueryWithContext(ctx context.Context, callbackQueryId string, opts *AnswerCallbackQueryOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["callback_query_id"] = callbackQueryId
 	if opts != nil {
 		v["text"] = opts.Text
-		v["show_alert"] = strconv.FormatBool(opts.ShowAlert)
+		v["show_alert"] = opts.ShowAlert
 		v["url"] = opts.Url
-		if opts.CacheTime != 0 {
-			v["cache_time"] = strconv.FormatInt(opts.CacheTime, 10)
-		}
+		v["cache_time"] = opts.CacheTime
 	}
 
 	var reqOpts *RequestOpts
@@ -130,27 +127,17 @@ func (bot *Bot) AnswerInlineQuery(inlineQueryId string, results []InlineQueryRes
 
 // AnswerInlineQueryWithContext is the same as Bot.AnswerInlineQuery, but with a context.Context parameter
 func (bot *Bot) AnswerInlineQueryWithContext(ctx context.Context, inlineQueryId string, results []InlineQueryResult, opts *AnswerInlineQueryOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["inline_query_id"] = inlineQueryId
 	if results != nil {
-		bs, err := json.Marshal(results)
-		if err != nil {
-			return false, fmt.Errorf("failed to marshal field results: %w", err)
-		}
-		v["results"] = string(bs)
+		v["results"] = results
 	}
 	if opts != nil {
-		if opts.CacheTime != 0 {
-			v["cache_time"] = strconv.FormatInt(opts.CacheTime, 10)
-		}
-		v["is_personal"] = strconv.FormatBool(opts.IsPersonal)
+		v["cache_time"] = opts.CacheTime
+		v["is_personal"] = opts.IsPersonal
 		v["next_offset"] = opts.NextOffset
 		if opts.Button != nil {
-			bs, err := json.Marshal(opts.Button)
-			if err != nil {
-				return false, fmt.Errorf("failed to marshal field button: %w", err)
-			}
-			v["button"] = string(bs)
+			v["button"] = opts.Button
 		}
 	}
 
@@ -188,9 +175,9 @@ func (bot *Bot) AnswerPreCheckoutQuery(preCheckoutQueryId string, ok bool, opts 
 
 // AnswerPreCheckoutQueryWithContext is the same as Bot.AnswerPreCheckoutQuery, but with a context.Context parameter
 func (bot *Bot) AnswerPreCheckoutQueryWithContext(ctx context.Context, preCheckoutQueryId string, ok bool, opts *AnswerPreCheckoutQueryOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["pre_checkout_query_id"] = preCheckoutQueryId
-	v["ok"] = strconv.FormatBool(ok)
+	v["ok"] = ok
 	if opts != nil {
 		v["error_message"] = opts.ErrorMessage
 	}
@@ -231,16 +218,12 @@ func (bot *Bot) AnswerShippingQuery(shippingQueryId string, ok bool, opts *Answe
 
 // AnswerShippingQueryWithContext is the same as Bot.AnswerShippingQuery, but with a context.Context parameter
 func (bot *Bot) AnswerShippingQueryWithContext(ctx context.Context, shippingQueryId string, ok bool, opts *AnswerShippingQueryOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["shipping_query_id"] = shippingQueryId
-	v["ok"] = strconv.FormatBool(ok)
+	v["ok"] = ok
 	if opts != nil {
 		if opts.ShippingOptions != nil {
-			bs, err := json.Marshal(opts.ShippingOptions)
-			if err != nil {
-				return false, fmt.Errorf("failed to marshal field shipping_options: %w", err)
-			}
-			v["shipping_options"] = string(bs)
+			v["shipping_options"] = opts.ShippingOptions
 		}
 		v["error_message"] = opts.ErrorMessage
 	}
@@ -277,13 +260,9 @@ func (bot *Bot) AnswerWebAppQuery(webAppQueryId string, result InlineQueryResult
 
 // AnswerWebAppQueryWithContext is the same as Bot.AnswerWebAppQuery, but with a context.Context parameter
 func (bot *Bot) AnswerWebAppQueryWithContext(ctx context.Context, webAppQueryId string, result InlineQueryResult, opts *AnswerWebAppQueryOpts) (*SentWebAppMessage, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["web_app_query_id"] = webAppQueryId
-	bs, err := json.Marshal(result)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal field result: %w", err)
-	}
-	v["result"] = string(bs)
+	v["result"] = result
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -317,9 +296,9 @@ func (bot *Bot) ApproveChatJoinRequest(chatId int64, userId int64, opts *Approve
 
 // ApproveChatJoinRequestWithContext is the same as Bot.ApproveChatJoinRequest, but with a context.Context parameter
 func (bot *Bot) ApproveChatJoinRequestWithContext(ctx context.Context, chatId int64, userId int64, opts *ApproveChatJoinRequestOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["user_id"] = userId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -355,13 +334,11 @@ func (bot *Bot) ApproveSuggestedPost(chatId int64, messageId int64, opts *Approv
 
 // ApproveSuggestedPostWithContext is the same as Bot.ApproveSuggestedPost, but with a context.Context parameter
 func (bot *Bot) ApproveSuggestedPostWithContext(ctx context.Context, chatId int64, messageId int64, opts *ApproveSuggestedPostOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["message_id"] = strconv.FormatInt(messageId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["message_id"] = messageId
 	if opts != nil {
-		if opts.SendDate != 0 {
-			v["send_date"] = strconv.FormatInt(opts.SendDate, 10)
-		}
+		v["send_date"] = opts.SendDate
 	}
 
 	var reqOpts *RequestOpts
@@ -400,14 +377,12 @@ func (bot *Bot) BanChatMember(chatId int64, userId int64, opts *BanChatMemberOpt
 
 // BanChatMemberWithContext is the same as Bot.BanChatMember, but with a context.Context parameter
 func (bot *Bot) BanChatMemberWithContext(ctx context.Context, chatId int64, userId int64, opts *BanChatMemberOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["user_id"] = userId
 	if opts != nil {
-		if opts.UntilDate != 0 {
-			v["until_date"] = strconv.FormatInt(opts.UntilDate, 10)
-		}
-		v["revoke_messages"] = strconv.FormatBool(opts.RevokeMessages)
+		v["until_date"] = opts.UntilDate
+		v["revoke_messages"] = opts.RevokeMessages
 	}
 
 	var reqOpts *RequestOpts
@@ -442,9 +417,9 @@ func (bot *Bot) BanChatSenderChat(chatId int64, senderChatId int64, opts *BanCha
 
 // BanChatSenderChatWithContext is the same as Bot.BanChatSenderChat, but with a context.Context parameter
 func (bot *Bot) BanChatSenderChatWithContext(ctx context.Context, chatId int64, senderChatId int64, opts *BanChatSenderChatOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["sender_chat_id"] = strconv.FormatInt(senderChatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["sender_chat_id"] = senderChatId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -476,7 +451,7 @@ func (bot *Bot) Close(opts *CloseOpts) (bool, error) {
 
 // CloseWithContext is the same as Bot.Close, but with a context.Context parameter
 func (bot *Bot) CloseWithContext(ctx context.Context, opts *CloseOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -510,9 +485,9 @@ func (bot *Bot) CloseForumTopic(chatId int64, messageThreadId int64, opts *Close
 
 // CloseForumTopicWithContext is the same as Bot.CloseForumTopic, but with a context.Context parameter
 func (bot *Bot) CloseForumTopicWithContext(ctx context.Context, chatId int64, messageThreadId int64, opts *CloseForumTopicOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["message_thread_id"] = strconv.FormatInt(messageThreadId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["message_thread_id"] = messageThreadId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -545,8 +520,8 @@ func (bot *Bot) CloseGeneralForumTopic(chatId int64, opts *CloseGeneralForumTopi
 
 // CloseGeneralForumTopicWithContext is the same as Bot.CloseGeneralForumTopic, but with a context.Context parameter
 func (bot *Bot) CloseGeneralForumTopicWithContext(ctx context.Context, chatId int64, opts *CloseGeneralForumTopicOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -580,7 +555,7 @@ func (bot *Bot) ConvertGiftToStars(businessConnectionId string, ownedGiftId stri
 
 // ConvertGiftToStarsWithContext is the same as Bot.ConvertGiftToStars, but with a context.Context parameter
 func (bot *Bot) ConvertGiftToStarsWithContext(ctx context.Context, businessConnectionId string, ownedGiftId string, opts *ConvertGiftToStarsOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
 	v["owned_gift_id"] = ownedGiftId
 
@@ -643,55 +618,33 @@ func (bot *Bot) CopyMessage(chatId int64, fromChatId int64, messageId int64, opt
 
 // CopyMessageWithContext is the same as Bot.CopyMessage, but with a context.Context parameter
 func (bot *Bot) CopyMessageWithContext(ctx context.Context, chatId int64, fromChatId int64, messageId int64, opts *CopyMessageOpts) (*MessageId, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["from_chat_id"] = strconv.FormatInt(fromChatId, 10)
-	v["message_id"] = strconv.FormatInt(messageId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["from_chat_id"] = fromChatId
+	v["message_id"] = messageId
 	if opts != nil {
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
-		if opts.VideoStartTimestamp != 0 {
-			v["video_start_timestamp"] = strconv.FormatInt(opts.VideoStartTimestamp, 10)
-		}
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
+		v["video_start_timestamp"] = opts.VideoStartTimestamp
 		if opts.Caption != nil {
-			v["caption"] = *opts.Caption
+			v["caption"] = opts.Caption
 		}
 		v["parse_mode"] = opts.ParseMode
 		if opts.CaptionEntities != nil {
-			bs, err := json.Marshal(opts.CaptionEntities)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field caption_entities: %w", err)
-			}
-			v["caption_entities"] = string(bs)
+			v["caption_entities"] = opts.CaptionEntities
 		}
-		v["show_caption_above_media"] = strconv.FormatBool(opts.ShowCaptionAboveMedia)
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["allow_paid_broadcast"] = strconv.FormatBool(opts.AllowPaidBroadcast)
+		v["show_caption_above_media"] = opts.ShowCaptionAboveMedia
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
 		if opts.SuggestedPostParameters != nil {
-			bs, err := json.Marshal(opts.SuggestedPostParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field suggested_post_parameters: %w", err)
-			}
-			v["suggested_post_parameters"] = string(bs)
+			v["suggested_post_parameters"] = opts.SuggestedPostParameters
 		}
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
 		if opts.ReplyMarkup != nil {
-			bs, err := json.Marshal(opts.ReplyMarkup)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-			}
-			v["reply_markup"] = string(bs)
+			v["reply_markup"] = opts.ReplyMarkup
 		}
 	}
 
@@ -738,26 +691,18 @@ func (bot *Bot) CopyMessages(chatId int64, fromChatId int64, messageIds []int64,
 
 // CopyMessagesWithContext is the same as Bot.CopyMessages, but with a context.Context parameter
 func (bot *Bot) CopyMessagesWithContext(ctx context.Context, chatId int64, fromChatId int64, messageIds []int64, opts *CopyMessagesOpts) ([]MessageId, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["from_chat_id"] = strconv.FormatInt(fromChatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["from_chat_id"] = fromChatId
 	if messageIds != nil {
-		bs, err := json.Marshal(messageIds)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal field message_ids: %w", err)
-		}
-		v["message_ids"] = string(bs)
+		v["message_ids"] = messageIds
 	}
 	if opts != nil {
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["remove_caption"] = strconv.FormatBool(opts.RemoveCaption)
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["remove_caption"] = opts.RemoveCaption
 	}
 
 	var reqOpts *RequestOpts
@@ -799,17 +744,13 @@ func (bot *Bot) CreateChatInviteLink(chatId int64, opts *CreateChatInviteLinkOpt
 
 // CreateChatInviteLinkWithContext is the same as Bot.CreateChatInviteLink, but with a context.Context parameter
 func (bot *Bot) CreateChatInviteLinkWithContext(ctx context.Context, chatId int64, opts *CreateChatInviteLinkOpts) (*ChatInviteLink, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 	if opts != nil {
 		v["name"] = opts.Name
-		if opts.ExpireDate != 0 {
-			v["expire_date"] = strconv.FormatInt(opts.ExpireDate, 10)
-		}
-		if opts.MemberLimit != 0 {
-			v["member_limit"] = strconv.FormatInt(opts.MemberLimit, 10)
-		}
-		v["creates_join_request"] = strconv.FormatBool(opts.CreatesJoinRequest)
+		v["expire_date"] = opts.ExpireDate
+		v["member_limit"] = opts.MemberLimit
+		v["creates_join_request"] = opts.CreatesJoinRequest
 	}
 
 	var reqOpts *RequestOpts
@@ -847,10 +788,10 @@ func (bot *Bot) CreateChatSubscriptionInviteLink(chatId int64, subscriptionPerio
 
 // CreateChatSubscriptionInviteLinkWithContext is the same as Bot.CreateChatSubscriptionInviteLink, but with a context.Context parameter
 func (bot *Bot) CreateChatSubscriptionInviteLinkWithContext(ctx context.Context, chatId int64, subscriptionPeriod int64, subscriptionPrice int64, opts *CreateChatSubscriptionInviteLinkOpts) (*ChatInviteLink, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["subscription_period"] = strconv.FormatInt(subscriptionPeriod, 10)
-	v["subscription_price"] = strconv.FormatInt(subscriptionPrice, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["subscription_period"] = subscriptionPeriod
+	v["subscription_price"] = subscriptionPrice
 	if opts != nil {
 		v["name"] = opts.Name
 	}
@@ -891,13 +832,11 @@ func (bot *Bot) CreateForumTopic(chatId int64, name string, opts *CreateForumTop
 
 // CreateForumTopicWithContext is the same as Bot.CreateForumTopic, but with a context.Context parameter
 func (bot *Bot) CreateForumTopicWithContext(ctx context.Context, chatId int64, name string, opts *CreateForumTopicOpts) (*ForumTopic, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 	v["name"] = name
 	if opts != nil {
-		if opts.IconColor != 0 {
-			v["icon_color"] = strconv.FormatInt(opts.IconColor, 10)
-		}
+		v["icon_color"] = opts.IconColor
 		v["icon_custom_emoji_id"] = opts.IconCustomEmojiId
 	}
 
@@ -970,52 +909,34 @@ func (bot *Bot) CreateInvoiceLink(title string, description string, payload stri
 
 // CreateInvoiceLinkWithContext is the same as Bot.CreateInvoiceLink, but with a context.Context parameter
 func (bot *Bot) CreateInvoiceLinkWithContext(ctx context.Context, title string, description string, payload string, currency string, prices []LabeledPrice, opts *CreateInvoiceLinkOpts) (string, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["title"] = title
 	v["description"] = description
 	v["payload"] = payload
 	v["currency"] = currency
 	if prices != nil {
-		bs, err := json.Marshal(prices)
-		if err != nil {
-			return "", fmt.Errorf("failed to marshal field prices: %w", err)
-		}
-		v["prices"] = string(bs)
+		v["prices"] = prices
 	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		v["provider_token"] = opts.ProviderToken
-		if opts.SubscriptionPeriod != 0 {
-			v["subscription_period"] = strconv.FormatInt(opts.SubscriptionPeriod, 10)
-		}
-		if opts.MaxTipAmount != 0 {
-			v["max_tip_amount"] = strconv.FormatInt(opts.MaxTipAmount, 10)
-		}
+		v["subscription_period"] = opts.SubscriptionPeriod
+		v["max_tip_amount"] = opts.MaxTipAmount
 		if opts.SuggestedTipAmounts != nil {
-			bs, err := json.Marshal(opts.SuggestedTipAmounts)
-			if err != nil {
-				return "", fmt.Errorf("failed to marshal field suggested_tip_amounts: %w", err)
-			}
-			v["suggested_tip_amounts"] = string(bs)
+			v["suggested_tip_amounts"] = opts.SuggestedTipAmounts
 		}
 		v["provider_data"] = opts.ProviderData
 		v["photo_url"] = opts.PhotoUrl
-		if opts.PhotoSize != 0 {
-			v["photo_size"] = strconv.FormatInt(opts.PhotoSize, 10)
-		}
-		if opts.PhotoWidth != 0 {
-			v["photo_width"] = strconv.FormatInt(opts.PhotoWidth, 10)
-		}
-		if opts.PhotoHeight != 0 {
-			v["photo_height"] = strconv.FormatInt(opts.PhotoHeight, 10)
-		}
-		v["need_name"] = strconv.FormatBool(opts.NeedName)
-		v["need_phone_number"] = strconv.FormatBool(opts.NeedPhoneNumber)
-		v["need_email"] = strconv.FormatBool(opts.NeedEmail)
-		v["need_shipping_address"] = strconv.FormatBool(opts.NeedShippingAddress)
-		v["send_phone_number_to_provider"] = strconv.FormatBool(opts.SendPhoneNumberToProvider)
-		v["send_email_to_provider"] = strconv.FormatBool(opts.SendEmailToProvider)
-		v["is_flexible"] = strconv.FormatBool(opts.IsFlexible)
+		v["photo_size"] = opts.PhotoSize
+		v["photo_width"] = opts.PhotoWidth
+		v["photo_height"] = opts.PhotoHeight
+		v["need_name"] = opts.NeedName
+		v["need_phone_number"] = opts.NeedPhoneNumber
+		v["need_email"] = opts.NeedEmail
+		v["need_shipping_address"] = opts.NeedShippingAddress
+		v["send_phone_number_to_provider"] = opts.SendPhoneNumberToProvider
+		v["send_email_to_provider"] = opts.SendEmailToProvider
+		v["is_flexible"] = opts.IsFlexible
 	}
 
 	var reqOpts *RequestOpts
@@ -1056,29 +977,17 @@ func (bot *Bot) CreateNewStickerSet(userId int64, name string, title string, sti
 
 // CreateNewStickerSetWithContext is the same as Bot.CreateNewStickerSet, but with a context.Context parameter
 func (bot *Bot) CreateNewStickerSetWithContext(ctx context.Context, userId int64, name string, title string, stickers []InputSticker, opts *CreateNewStickerSetOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v["user_id"] = userId
 	v["name"] = name
 	v["title"] = title
 	if stickers != nil {
-		var rawList []json.RawMessage
-		for idx, im := range stickers {
-			inputBs, err := im.InputParams("stickers"+strconv.Itoa(idx), data)
-			if err != nil {
-				return false, fmt.Errorf("failed to marshal list item %d for field stickers: %w", idx, err)
-			}
-			rawList = append(rawList, inputBs)
-		}
-		bs, err := json.Marshal(rawList)
-		if err != nil {
-			return false, fmt.Errorf("failed to marshal raw json list for field: stickers %w", err)
-		}
-		v["stickers"] = string(bs)
+		v["stickers"] = stickers
 	}
 	if opts != nil {
 		v["sticker_type"] = opts.StickerType
-		v["needs_repainting"] = strconv.FormatBool(opts.NeedsRepainting)
+		v["needs_repainting"] = opts.NeedsRepainting
 	}
 
 	var reqOpts *RequestOpts
@@ -1113,9 +1022,9 @@ func (bot *Bot) DeclineChatJoinRequest(chatId int64, userId int64, opts *Decline
 
 // DeclineChatJoinRequestWithContext is the same as Bot.DeclineChatJoinRequest, but with a context.Context parameter
 func (bot *Bot) DeclineChatJoinRequestWithContext(ctx context.Context, chatId int64, userId int64, opts *DeclineChatJoinRequestOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["user_id"] = userId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -1151,9 +1060,9 @@ func (bot *Bot) DeclineSuggestedPost(chatId int64, messageId int64, opts *Declin
 
 // DeclineSuggestedPostWithContext is the same as Bot.DeclineSuggestedPost, but with a context.Context parameter
 func (bot *Bot) DeclineSuggestedPostWithContext(ctx context.Context, chatId int64, messageId int64, opts *DeclineSuggestedPostOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["message_id"] = strconv.FormatInt(messageId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["message_id"] = messageId
 	if opts != nil {
 		v["comment"] = opts.Comment
 	}
@@ -1190,14 +1099,10 @@ func (bot *Bot) DeleteBusinessMessages(businessConnectionId string, messageIds [
 
 // DeleteBusinessMessagesWithContext is the same as Bot.DeleteBusinessMessages, but with a context.Context parameter
 func (bot *Bot) DeleteBusinessMessagesWithContext(ctx context.Context, businessConnectionId string, messageIds []int64, opts *DeleteBusinessMessagesOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
 	if messageIds != nil {
-		bs, err := json.Marshal(messageIds)
-		if err != nil {
-			return false, fmt.Errorf("failed to marshal field message_ids: %w", err)
-		}
-		v["message_ids"] = string(bs)
+		v["message_ids"] = messageIds
 	}
 
 	var reqOpts *RequestOpts
@@ -1231,8 +1136,8 @@ func (bot *Bot) DeleteChatPhoto(chatId int64, opts *DeleteChatPhotoOpts) (bool, 
 
 // DeleteChatPhotoWithContext is the same as Bot.DeleteChatPhoto, but with a context.Context parameter
 func (bot *Bot) DeleteChatPhotoWithContext(ctx context.Context, chatId int64, opts *DeleteChatPhotoOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -1265,8 +1170,8 @@ func (bot *Bot) DeleteChatStickerSet(chatId int64, opts *DeleteChatStickerSetOpt
 
 // DeleteChatStickerSetWithContext is the same as Bot.DeleteChatStickerSet, but with a context.Context parameter
 func (bot *Bot) DeleteChatStickerSetWithContext(ctx context.Context, chatId int64, opts *DeleteChatStickerSetOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -1300,9 +1205,9 @@ func (bot *Bot) DeleteForumTopic(chatId int64, messageThreadId int64, opts *Dele
 
 // DeleteForumTopicWithContext is the same as Bot.DeleteForumTopic, but with a context.Context parameter
 func (bot *Bot) DeleteForumTopicWithContext(ctx context.Context, chatId int64, messageThreadId int64, opts *DeleteForumTopicOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["message_thread_id"] = strconv.FormatInt(messageThreadId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["message_thread_id"] = messageThreadId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -1347,9 +1252,9 @@ func (bot *Bot) DeleteMessage(chatId int64, messageId int64, opts *DeleteMessage
 
 // DeleteMessageWithContext is the same as Bot.DeleteMessage, but with a context.Context parameter
 func (bot *Bot) DeleteMessageWithContext(ctx context.Context, chatId int64, messageId int64, opts *DeleteMessageOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["message_id"] = strconv.FormatInt(messageId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["message_id"] = messageId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -1383,14 +1288,10 @@ func (bot *Bot) DeleteMessages(chatId int64, messageIds []int64, opts *DeleteMes
 
 // DeleteMessagesWithContext is the same as Bot.DeleteMessages, but with a context.Context parameter
 func (bot *Bot) DeleteMessagesWithContext(ctx context.Context, chatId int64, messageIds []int64, opts *DeleteMessagesOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 	if messageIds != nil {
-		bs, err := json.Marshal(messageIds)
-		if err != nil {
-			return false, fmt.Errorf("failed to marshal field message_ids: %w", err)
-		}
-		v["message_ids"] = string(bs)
+		v["message_ids"] = messageIds
 	}
 
 	var reqOpts *RequestOpts
@@ -1427,13 +1328,9 @@ func (bot *Bot) DeleteMyCommands(opts *DeleteMyCommandsOpts) (bool, error) {
 
 // DeleteMyCommandsWithContext is the same as Bot.DeleteMyCommands, but with a context.Context parameter
 func (bot *Bot) DeleteMyCommandsWithContext(ctx context.Context, opts *DeleteMyCommandsOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if opts != nil {
-		bs, err := json.Marshal(opts.Scope)
-		if err != nil {
-			return false, fmt.Errorf("failed to marshal field scope: %w", err)
-		}
-		v["scope"] = string(bs)
+		v["scope"] = opts.Scope
 		v["language_code"] = opts.LanguageCode
 	}
 
@@ -1468,7 +1365,7 @@ func (bot *Bot) DeleteStickerFromSet(sticker InputFileOrString, opts *DeleteStic
 
 // DeleteStickerFromSetWithContext is the same as Bot.DeleteStickerFromSet, but with a context.Context parameter
 func (bot *Bot) DeleteStickerFromSetWithContext(ctx context.Context, sticker InputFileOrString, opts *DeleteStickerFromSetOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
 	if sticker != nil {
 		err := sticker.Attach("sticker", data)
@@ -1509,7 +1406,7 @@ func (bot *Bot) DeleteStickerSet(name string, opts *DeleteStickerSetOpts) (bool,
 
 // DeleteStickerSetWithContext is the same as Bot.DeleteStickerSet, but with a context.Context parameter
 func (bot *Bot) DeleteStickerSetWithContext(ctx context.Context, name string, opts *DeleteStickerSetOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["name"] = name
 
 	var reqOpts *RequestOpts
@@ -1544,9 +1441,9 @@ func (bot *Bot) DeleteStory(businessConnectionId string, storyId int64, opts *De
 
 // DeleteStoryWithContext is the same as Bot.DeleteStory, but with a context.Context parameter
 func (bot *Bot) DeleteStoryWithContext(ctx context.Context, businessConnectionId string, storyId int64, opts *DeleteStoryOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
-	v["story_id"] = strconv.FormatInt(storyId, 10)
+	v["story_id"] = storyId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -1580,9 +1477,9 @@ func (bot *Bot) DeleteWebhook(opts *DeleteWebhookOpts) (bool, error) {
 
 // DeleteWebhookWithContext is the same as Bot.DeleteWebhook, but with a context.Context parameter
 func (bot *Bot) DeleteWebhookWithContext(ctx context.Context, opts *DeleteWebhookOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if opts != nil {
-		v["drop_pending_updates"] = strconv.FormatBool(opts.DropPendingUpdates)
+		v["drop_pending_updates"] = opts.DropPendingUpdates
 	}
 
 	var reqOpts *RequestOpts
@@ -1625,18 +1522,14 @@ func (bot *Bot) EditChatInviteLink(chatId int64, inviteLink string, opts *EditCh
 
 // EditChatInviteLinkWithContext is the same as Bot.EditChatInviteLink, but with a context.Context parameter
 func (bot *Bot) EditChatInviteLinkWithContext(ctx context.Context, chatId int64, inviteLink string, opts *EditChatInviteLinkOpts) (*ChatInviteLink, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 	v["invite_link"] = inviteLink
 	if opts != nil {
 		v["name"] = opts.Name
-		if opts.ExpireDate != 0 {
-			v["expire_date"] = strconv.FormatInt(opts.ExpireDate, 10)
-		}
-		if opts.MemberLimit != 0 {
-			v["member_limit"] = strconv.FormatInt(opts.MemberLimit, 10)
-		}
-		v["creates_join_request"] = strconv.FormatBool(opts.CreatesJoinRequest)
+		v["expire_date"] = opts.ExpireDate
+		v["member_limit"] = opts.MemberLimit
+		v["creates_join_request"] = opts.CreatesJoinRequest
 	}
 
 	var reqOpts *RequestOpts
@@ -1673,8 +1566,8 @@ func (bot *Bot) EditChatSubscriptionInviteLink(chatId int64, inviteLink string, 
 
 // EditChatSubscriptionInviteLinkWithContext is the same as Bot.EditChatSubscriptionInviteLink, but with a context.Context parameter
 func (bot *Bot) EditChatSubscriptionInviteLinkWithContext(ctx context.Context, chatId int64, inviteLink string, opts *EditChatSubscriptionInviteLinkOpts) (*ChatInviteLink, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 	v["invite_link"] = inviteLink
 	if opts != nil {
 		v["name"] = opts.Name
@@ -1716,13 +1609,13 @@ func (bot *Bot) EditForumTopic(chatId int64, messageThreadId int64, opts *EditFo
 
 // EditForumTopicWithContext is the same as Bot.EditForumTopic, but with a context.Context parameter
 func (bot *Bot) EditForumTopicWithContext(ctx context.Context, chatId int64, messageThreadId int64, opts *EditForumTopicOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["message_thread_id"] = strconv.FormatInt(messageThreadId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["message_thread_id"] = messageThreadId
 	if opts != nil {
 		v["name"] = opts.Name
 		if opts.IconCustomEmojiId != nil {
-			v["icon_custom_emoji_id"] = *opts.IconCustomEmojiId
+			v["icon_custom_emoji_id"] = opts.IconCustomEmojiId
 		}
 	}
 
@@ -1758,8 +1651,8 @@ func (bot *Bot) EditGeneralForumTopic(chatId int64, name string, opts *EditGener
 
 // EditGeneralForumTopicWithContext is the same as Bot.EditGeneralForumTopic, but with a context.Context parameter
 func (bot *Bot) EditGeneralForumTopicWithContext(ctx context.Context, chatId int64, name string, opts *EditGeneralForumTopicOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 	v["name"] = name
 
 	var reqOpts *RequestOpts
@@ -1810,31 +1703,19 @@ func (bot *Bot) EditMessageCaption(opts *EditMessageCaptionOpts) (*Message, bool
 
 // EditMessageCaptionWithContext is the same as Bot.EditMessageCaption, but with a context.Context parameter
 func (bot *Bot) EditMessageCaptionWithContext(ctx context.Context, opts *EditMessageCaptionOpts) (*Message, bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.ChatId != 0 {
-			v["chat_id"] = strconv.FormatInt(opts.ChatId, 10)
-		}
-		if opts.MessageId != 0 {
-			v["message_id"] = strconv.FormatInt(opts.MessageId, 10)
-		}
+		v["chat_id"] = opts.ChatId
+		v["message_id"] = opts.MessageId
 		v["inline_message_id"] = opts.InlineMessageId
 		v["caption"] = opts.Caption
 		v["parse_mode"] = opts.ParseMode
 		if opts.CaptionEntities != nil {
-			bs, err := json.Marshal(opts.CaptionEntities)
-			if err != nil {
-				return nil, false, fmt.Errorf("failed to marshal field caption_entities: %w", err)
-			}
-			v["caption_entities"] = string(bs)
+			v["caption_entities"] = opts.CaptionEntities
 		}
-		v["show_caption_above_media"] = strconv.FormatBool(opts.ShowCaptionAboveMedia)
-		bs, err := json.Marshal(opts.ReplyMarkup)
-		if err != nil {
-			return nil, false, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-		}
-		v["reply_markup"] = string(bs)
+		v["show_caption_above_media"] = opts.ShowCaptionAboveMedia
+		v["reply_markup"] = opts.ReplyMarkup
 	}
 
 	var reqOpts *RequestOpts
@@ -1881,21 +1762,13 @@ func (bot *Bot) EditMessageChecklist(businessConnectionId string, chatId int64, 
 
 // EditMessageChecklistWithContext is the same as Bot.EditMessageChecklist, but with a context.Context parameter
 func (bot *Bot) EditMessageChecklistWithContext(ctx context.Context, businessConnectionId string, chatId int64, messageId int64, checklist InputChecklist, opts *EditMessageChecklistOpts) (*Message, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["message_id"] = strconv.FormatInt(messageId, 10)
-	bs, err := json.Marshal(checklist)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal field checklist: %w", err)
-	}
-	v["checklist"] = string(bs)
+	v["chat_id"] = chatId
+	v["message_id"] = messageId
+	v["checklist"] = checklist
 	if opts != nil {
-		bs, err := json.Marshal(opts.ReplyMarkup)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-		}
-		v["reply_markup"] = string(bs)
+		v["reply_markup"] = opts.ReplyMarkup
 	}
 
 	var reqOpts *RequestOpts
@@ -1948,35 +1821,21 @@ func (bot *Bot) EditMessageLiveLocation(latitude float64, longitude float64, opt
 
 // EditMessageLiveLocationWithContext is the same as Bot.EditMessageLiveLocation, but with a context.Context parameter
 func (bot *Bot) EditMessageLiveLocationWithContext(ctx context.Context, latitude float64, longitude float64, opts *EditMessageLiveLocationOpts) (*Message, bool, error) {
-	v := map[string]string{}
-	v["latitude"] = strconv.FormatFloat(latitude, 'f', -1, 64)
-	v["longitude"] = strconv.FormatFloat(longitude, 'f', -1, 64)
+	v := map[string]any{}
+	v["latitude"] = latitude
+	v["longitude"] = longitude
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.ChatId != 0 {
-			v["chat_id"] = strconv.FormatInt(opts.ChatId, 10)
-		}
-		if opts.MessageId != 0 {
-			v["message_id"] = strconv.FormatInt(opts.MessageId, 10)
-		}
+		v["chat_id"] = opts.ChatId
+		v["message_id"] = opts.MessageId
 		v["inline_message_id"] = opts.InlineMessageId
 		if opts.LivePeriod != nil {
-			v["live_period"] = strconv.FormatInt(*opts.LivePeriod, 10)
+			v["live_period"] = opts.LivePeriod
 		}
-		if opts.HorizontalAccuracy != 0.0 {
-			v["horizontal_accuracy"] = strconv.FormatFloat(opts.HorizontalAccuracy, 'f', -1, 64)
-		}
-		if opts.Heading != 0 {
-			v["heading"] = strconv.FormatInt(opts.Heading, 10)
-		}
-		if opts.ProximityAlertRadius != 0 {
-			v["proximity_alert_radius"] = strconv.FormatInt(opts.ProximityAlertRadius, 10)
-		}
-		bs, err := json.Marshal(opts.ReplyMarkup)
-		if err != nil {
-			return nil, false, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-		}
-		v["reply_markup"] = string(bs)
+		v["horizontal_accuracy"] = opts.HorizontalAccuracy
+		v["heading"] = opts.Heading
+		v["proximity_alert_radius"] = opts.ProximityAlertRadius
+		v["reply_markup"] = opts.ReplyMarkup
 	}
 
 	var reqOpts *RequestOpts
@@ -2028,7 +1887,7 @@ func (bot *Bot) EditMessageMedia(media InputMedia, opts *EditMessageMediaOpts) (
 
 // EditMessageMediaWithContext is the same as Bot.EditMessageMedia, but with a context.Context parameter
 func (bot *Bot) EditMessageMediaWithContext(ctx context.Context, media InputMedia, opts *EditMessageMediaOpts) (*Message, bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
 	inputBs, err := media.InputParams("media", data)
 	if err != nil {
@@ -2037,18 +1896,10 @@ func (bot *Bot) EditMessageMediaWithContext(ctx context.Context, media InputMedi
 	v["media"] = string(inputBs)
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.ChatId != 0 {
-			v["chat_id"] = strconv.FormatInt(opts.ChatId, 10)
-		}
-		if opts.MessageId != 0 {
-			v["message_id"] = strconv.FormatInt(opts.MessageId, 10)
-		}
+		v["chat_id"] = opts.ChatId
+		v["message_id"] = opts.MessageId
 		v["inline_message_id"] = opts.InlineMessageId
-		bs, err := json.Marshal(opts.ReplyMarkup)
-		if err != nil {
-			return nil, false, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-		}
-		v["reply_markup"] = string(bs)
+		v["reply_markup"] = opts.ReplyMarkup
 	}
 
 	var reqOpts *RequestOpts
@@ -2099,21 +1950,13 @@ func (bot *Bot) EditMessageReplyMarkup(opts *EditMessageReplyMarkupOpts) (*Messa
 
 // EditMessageReplyMarkupWithContext is the same as Bot.EditMessageReplyMarkup, but with a context.Context parameter
 func (bot *Bot) EditMessageReplyMarkupWithContext(ctx context.Context, opts *EditMessageReplyMarkupOpts) (*Message, bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.ChatId != 0 {
-			v["chat_id"] = strconv.FormatInt(opts.ChatId, 10)
-		}
-		if opts.MessageId != 0 {
-			v["message_id"] = strconv.FormatInt(opts.MessageId, 10)
-		}
+		v["chat_id"] = opts.ChatId
+		v["message_id"] = opts.MessageId
 		v["inline_message_id"] = opts.InlineMessageId
-		bs, err := json.Marshal(opts.ReplyMarkup)
-		if err != nil {
-			return nil, false, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-		}
-		v["reply_markup"] = string(bs)
+		v["reply_markup"] = opts.ReplyMarkup
 	}
 
 	var reqOpts *RequestOpts
@@ -2171,37 +2014,21 @@ func (bot *Bot) EditMessageText(text string, opts *EditMessageTextOpts) (*Messag
 
 // EditMessageTextWithContext is the same as Bot.EditMessageText, but with a context.Context parameter
 func (bot *Bot) EditMessageTextWithContext(ctx context.Context, text string, opts *EditMessageTextOpts) (*Message, bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["text"] = text
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.ChatId != 0 {
-			v["chat_id"] = strconv.FormatInt(opts.ChatId, 10)
-		}
-		if opts.MessageId != 0 {
-			v["message_id"] = strconv.FormatInt(opts.MessageId, 10)
-		}
+		v["chat_id"] = opts.ChatId
+		v["message_id"] = opts.MessageId
 		v["inline_message_id"] = opts.InlineMessageId
 		v["parse_mode"] = opts.ParseMode
 		if opts.Entities != nil {
-			bs, err := json.Marshal(opts.Entities)
-			if err != nil {
-				return nil, false, fmt.Errorf("failed to marshal field entities: %w", err)
-			}
-			v["entities"] = string(bs)
+			v["entities"] = opts.Entities
 		}
 		if opts.LinkPreviewOptions != nil {
-			bs, err := json.Marshal(opts.LinkPreviewOptions)
-			if err != nil {
-				return nil, false, fmt.Errorf("failed to marshal field link_preview_options: %w", err)
-			}
-			v["link_preview_options"] = string(bs)
+			v["link_preview_options"] = opts.LinkPreviewOptions
 		}
-		bs, err := json.Marshal(opts.ReplyMarkup)
-		if err != nil {
-			return nil, false, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-		}
-		v["reply_markup"] = string(bs)
+		v["reply_markup"] = opts.ReplyMarkup
 	}
 
 	var reqOpts *RequestOpts
@@ -2253,30 +2080,18 @@ func (bot *Bot) EditStory(businessConnectionId string, storyId int64, content In
 
 // EditStoryWithContext is the same as Bot.EditStory, but with a context.Context parameter
 func (bot *Bot) EditStoryWithContext(ctx context.Context, businessConnectionId string, storyId int64, content InputStoryContent, opts *EditStoryOpts) (*Story, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
-	v["story_id"] = strconv.FormatInt(storyId, 10)
-	bs, err := json.Marshal(content)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal field content: %w", err)
-	}
-	v["content"] = string(bs)
+	v["story_id"] = storyId
+	v["content"] = content
 	if opts != nil {
 		v["caption"] = opts.Caption
 		v["parse_mode"] = opts.ParseMode
 		if opts.CaptionEntities != nil {
-			bs, err := json.Marshal(opts.CaptionEntities)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field caption_entities: %w", err)
-			}
-			v["caption_entities"] = string(bs)
+			v["caption_entities"] = opts.CaptionEntities
 		}
 		if opts.Areas != nil {
-			bs, err := json.Marshal(opts.Areas)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field areas: %w", err)
-			}
-			v["areas"] = string(bs)
+			v["areas"] = opts.Areas
 		}
 	}
 
@@ -2313,10 +2128,10 @@ func (bot *Bot) EditUserStarSubscription(userId int64, telegramPaymentChargeId s
 
 // EditUserStarSubscriptionWithContext is the same as Bot.EditUserStarSubscription, but with a context.Context parameter
 func (bot *Bot) EditUserStarSubscriptionWithContext(ctx context.Context, userId int64, telegramPaymentChargeId string, isCanceled bool, opts *EditUserStarSubscriptionOpts) (bool, error) {
-	v := map[string]string{}
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v := map[string]any{}
+	v["user_id"] = userId
 	v["telegram_payment_charge_id"] = telegramPaymentChargeId
-	v["is_canceled"] = strconv.FormatBool(isCanceled)
+	v["is_canceled"] = isCanceled
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -2349,8 +2164,8 @@ func (bot *Bot) ExportChatInviteLink(chatId int64, opts *ExportChatInviteLinkOpt
 
 // ExportChatInviteLinkWithContext is the same as Bot.ExportChatInviteLink, but with a context.Context parameter
 func (bot *Bot) ExportChatInviteLinkWithContext(ctx context.Context, chatId int64, opts *ExportChatInviteLinkOpts) (string, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -2397,28 +2212,18 @@ func (bot *Bot) ForwardMessage(chatId int64, fromChatId int64, messageId int64, 
 
 // ForwardMessageWithContext is the same as Bot.ForwardMessage, but with a context.Context parameter
 func (bot *Bot) ForwardMessageWithContext(ctx context.Context, chatId int64, fromChatId int64, messageId int64, opts *ForwardMessageOpts) (*Message, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["from_chat_id"] = strconv.FormatInt(fromChatId, 10)
-	v["message_id"] = strconv.FormatInt(messageId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["from_chat_id"] = fromChatId
+	v["message_id"] = messageId
 	if opts != nil {
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
-		if opts.VideoStartTimestamp != 0 {
-			v["video_start_timestamp"] = strconv.FormatInt(opts.VideoStartTimestamp, 10)
-		}
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
+		v["video_start_timestamp"] = opts.VideoStartTimestamp
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
 		if opts.SuggestedPostParameters != nil {
-			bs, err := json.Marshal(opts.SuggestedPostParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field suggested_post_parameters: %w", err)
-			}
-			v["suggested_post_parameters"] = string(bs)
+			v["suggested_post_parameters"] = opts.SuggestedPostParameters
 		}
 	}
 
@@ -2463,25 +2268,17 @@ func (bot *Bot) ForwardMessages(chatId int64, fromChatId int64, messageIds []int
 
 // ForwardMessagesWithContext is the same as Bot.ForwardMessages, but with a context.Context parameter
 func (bot *Bot) ForwardMessagesWithContext(ctx context.Context, chatId int64, fromChatId int64, messageIds []int64, opts *ForwardMessagesOpts) ([]MessageId, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["from_chat_id"] = strconv.FormatInt(fromChatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["from_chat_id"] = fromChatId
 	if messageIds != nil {
-		bs, err := json.Marshal(messageIds)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal field message_ids: %w", err)
-		}
-		v["message_ids"] = string(bs)
+		v["message_ids"] = messageIds
 	}
 	if opts != nil {
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
 	}
 
 	var reqOpts *RequestOpts
@@ -2514,7 +2311,7 @@ func (bot *Bot) GetAvailableGifts(opts *GetAvailableGiftsOpts) (*Gifts, error) {
 
 // GetAvailableGiftsWithContext is the same as Bot.GetAvailableGifts, but with a context.Context parameter
 func (bot *Bot) GetAvailableGiftsWithContext(ctx context.Context, opts *GetAvailableGiftsOpts) (*Gifts, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -2563,19 +2360,17 @@ func (bot *Bot) GetBusinessAccountGifts(businessConnectionId string, opts *GetBu
 
 // GetBusinessAccountGiftsWithContext is the same as Bot.GetBusinessAccountGifts, but with a context.Context parameter
 func (bot *Bot) GetBusinessAccountGiftsWithContext(ctx context.Context, businessConnectionId string, opts *GetBusinessAccountGiftsOpts) (*OwnedGifts, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
 	if opts != nil {
-		v["exclude_unsaved"] = strconv.FormatBool(opts.ExcludeUnsaved)
-		v["exclude_saved"] = strconv.FormatBool(opts.ExcludeSaved)
-		v["exclude_unlimited"] = strconv.FormatBool(opts.ExcludeUnlimited)
-		v["exclude_limited"] = strconv.FormatBool(opts.ExcludeLimited)
-		v["exclude_unique"] = strconv.FormatBool(opts.ExcludeUnique)
-		v["sort_by_price"] = strconv.FormatBool(opts.SortByPrice)
+		v["exclude_unsaved"] = opts.ExcludeUnsaved
+		v["exclude_saved"] = opts.ExcludeSaved
+		v["exclude_unlimited"] = opts.ExcludeUnlimited
+		v["exclude_limited"] = opts.ExcludeLimited
+		v["exclude_unique"] = opts.ExcludeUnique
+		v["sort_by_price"] = opts.SortByPrice
 		v["offset"] = opts.Offset
-		if opts.Limit != 0 {
-			v["limit"] = strconv.FormatInt(opts.Limit, 10)
-		}
+		v["limit"] = opts.Limit
 	}
 
 	var reqOpts *RequestOpts
@@ -2609,7 +2404,7 @@ func (bot *Bot) GetBusinessAccountStarBalance(businessConnectionId string, opts 
 
 // GetBusinessAccountStarBalanceWithContext is the same as Bot.GetBusinessAccountStarBalance, but with a context.Context parameter
 func (bot *Bot) GetBusinessAccountStarBalanceWithContext(ctx context.Context, businessConnectionId string, opts *GetBusinessAccountStarBalanceOpts) (*StarAmount, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
 
 	var reqOpts *RequestOpts
@@ -2643,7 +2438,7 @@ func (bot *Bot) GetBusinessConnection(businessConnectionId string, opts *GetBusi
 
 // GetBusinessConnectionWithContext is the same as Bot.GetBusinessConnection, but with a context.Context parameter
 func (bot *Bot) GetBusinessConnectionWithContext(ctx context.Context, businessConnectionId string, opts *GetBusinessConnectionOpts) (*BusinessConnection, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
 
 	var reqOpts *RequestOpts
@@ -2677,8 +2472,8 @@ func (bot *Bot) GetChat(chatId int64, opts *GetChatOpts) (*ChatFullInfo, error) 
 
 // GetChatWithContext is the same as Bot.GetChat, but with a context.Context parameter
 func (bot *Bot) GetChatWithContext(ctx context.Context, chatId int64, opts *GetChatOpts) (*ChatFullInfo, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -2711,8 +2506,8 @@ func (bot *Bot) GetChatAdministrators(chatId int64, opts *GetChatAdministratorsO
 
 // GetChatAdministratorsWithContext is the same as Bot.GetChatAdministrators, but with a context.Context parameter
 func (bot *Bot) GetChatAdministratorsWithContext(ctx context.Context, chatId int64, opts *GetChatAdministratorsOpts) ([]ChatMember, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -2745,9 +2540,9 @@ func (bot *Bot) GetChatMember(chatId int64, userId int64, opts *GetChatMemberOpt
 
 // GetChatMemberWithContext is the same as Bot.GetChatMember, but with a context.Context parameter
 func (bot *Bot) GetChatMemberWithContext(ctx context.Context, chatId int64, userId int64, opts *GetChatMemberOpts) (ChatMember, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["user_id"] = userId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -2779,8 +2574,8 @@ func (bot *Bot) GetChatMemberCount(chatId int64, opts *GetChatMemberCountOpts) (
 
 // GetChatMemberCountWithContext is the same as Bot.GetChatMemberCount, but with a context.Context parameter
 func (bot *Bot) GetChatMemberCountWithContext(ctx context.Context, chatId int64, opts *GetChatMemberCountOpts) (int64, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -2814,10 +2609,10 @@ func (bot *Bot) GetChatMenuButton(opts *GetChatMenuButtonOpts) (MenuButton, erro
 
 // GetChatMenuButtonWithContext is the same as Bot.GetChatMenuButton, but with a context.Context parameter
 func (bot *Bot) GetChatMenuButtonWithContext(ctx context.Context, opts *GetChatMenuButtonOpts) (MenuButton, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if opts != nil {
 		if opts.ChatId != nil {
-			v["chat_id"] = strconv.FormatInt(*opts.ChatId, 10)
+			v["chat_id"] = opts.ChatId
 		}
 	}
 
@@ -2851,13 +2646,9 @@ func (bot *Bot) GetCustomEmojiStickers(customEmojiIds []string, opts *GetCustomE
 
 // GetCustomEmojiStickersWithContext is the same as Bot.GetCustomEmojiStickers, but with a context.Context parameter
 func (bot *Bot) GetCustomEmojiStickersWithContext(ctx context.Context, customEmojiIds []string, opts *GetCustomEmojiStickersOpts) ([]Sticker, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if customEmojiIds != nil {
-		bs, err := json.Marshal(customEmojiIds)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal field custom_emoji_ids: %w", err)
-		}
-		v["custom_emoji_ids"] = string(bs)
+		v["custom_emoji_ids"] = customEmojiIds
 	}
 
 	var reqOpts *RequestOpts
@@ -2892,7 +2683,7 @@ func (bot *Bot) GetFile(fileId string, opts *GetFileOpts) (*File, error) {
 
 // GetFileWithContext is the same as Bot.GetFile, but with a context.Context parameter
 func (bot *Bot) GetFileWithContext(ctx context.Context, fileId string, opts *GetFileOpts) (*File, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["file_id"] = fileId
 
 	var reqOpts *RequestOpts
@@ -2925,7 +2716,7 @@ func (bot *Bot) GetForumTopicIconStickers(opts *GetForumTopicIconStickersOpts) (
 
 // GetForumTopicIconStickersWithContext is the same as Bot.GetForumTopicIconStickers, but with a context.Context parameter
 func (bot *Bot) GetForumTopicIconStickersWithContext(ctx context.Context, opts *GetForumTopicIconStickersOpts) ([]Sticker, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -2964,15 +2755,11 @@ func (bot *Bot) GetGameHighScores(userId int64, opts *GetGameHighScoresOpts) ([]
 
 // GetGameHighScoresWithContext is the same as Bot.GetGameHighScores, but with a context.Context parameter
 func (bot *Bot) GetGameHighScoresWithContext(ctx context.Context, userId int64, opts *GetGameHighScoresOpts) ([]GameHighScore, error) {
-	v := map[string]string{}
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v := map[string]any{}
+	v["user_id"] = userId
 	if opts != nil {
-		if opts.ChatId != 0 {
-			v["chat_id"] = strconv.FormatInt(opts.ChatId, 10)
-		}
-		if opts.MessageId != 0 {
-			v["message_id"] = strconv.FormatInt(opts.MessageId, 10)
-		}
+		v["chat_id"] = opts.ChatId
+		v["message_id"] = opts.MessageId
 		v["inline_message_id"] = opts.InlineMessageId
 	}
 
@@ -3006,7 +2793,7 @@ func (bot *Bot) GetMe(opts *GetMeOpts) (*User, error) {
 
 // GetMeWithContext is the same as Bot.GetMe, but with a context.Context parameter
 func (bot *Bot) GetMeWithContext(ctx context.Context, opts *GetMeOpts) (*User, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -3042,13 +2829,9 @@ func (bot *Bot) GetMyCommands(opts *GetMyCommandsOpts) ([]BotCommand, error) {
 
 // GetMyCommandsWithContext is the same as Bot.GetMyCommands, but with a context.Context parameter
 func (bot *Bot) GetMyCommandsWithContext(ctx context.Context, opts *GetMyCommandsOpts) ([]BotCommand, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if opts != nil {
-		bs, err := json.Marshal(opts.Scope)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal field scope: %w", err)
-		}
-		v["scope"] = string(bs)
+		v["scope"] = opts.Scope
 		v["language_code"] = opts.LanguageCode
 	}
 
@@ -3084,9 +2867,9 @@ func (bot *Bot) GetMyDefaultAdministratorRights(opts *GetMyDefaultAdministratorR
 
 // GetMyDefaultAdministratorRightsWithContext is the same as Bot.GetMyDefaultAdministratorRights, but with a context.Context parameter
 func (bot *Bot) GetMyDefaultAdministratorRightsWithContext(ctx context.Context, opts *GetMyDefaultAdministratorRightsOpts) (*ChatAdministratorRights, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if opts != nil {
-		v["for_channels"] = strconv.FormatBool(opts.ForChannels)
+		v["for_channels"] = opts.ForChannels
 	}
 
 	var reqOpts *RequestOpts
@@ -3121,7 +2904,7 @@ func (bot *Bot) GetMyDescription(opts *GetMyDescriptionOpts) (*BotDescription, e
 
 // GetMyDescriptionWithContext is the same as Bot.GetMyDescription, but with a context.Context parameter
 func (bot *Bot) GetMyDescriptionWithContext(ctx context.Context, opts *GetMyDescriptionOpts) (*BotDescription, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if opts != nil {
 		v["language_code"] = opts.LanguageCode
 	}
@@ -3158,7 +2941,7 @@ func (bot *Bot) GetMyName(opts *GetMyNameOpts) (*BotName, error) {
 
 // GetMyNameWithContext is the same as Bot.GetMyName, but with a context.Context parameter
 func (bot *Bot) GetMyNameWithContext(ctx context.Context, opts *GetMyNameOpts) (*BotName, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if opts != nil {
 		v["language_code"] = opts.LanguageCode
 	}
@@ -3195,7 +2978,7 @@ func (bot *Bot) GetMyShortDescription(opts *GetMyShortDescriptionOpts) (*BotShor
 
 // GetMyShortDescriptionWithContext is the same as Bot.GetMyShortDescription, but with a context.Context parameter
 func (bot *Bot) GetMyShortDescriptionWithContext(ctx context.Context, opts *GetMyShortDescriptionOpts) (*BotShortDescription, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if opts != nil {
 		v["language_code"] = opts.LanguageCode
 	}
@@ -3230,7 +3013,7 @@ func (bot *Bot) GetMyStarBalance(opts *GetMyStarBalanceOpts) (*StarAmount, error
 
 // GetMyStarBalanceWithContext is the same as Bot.GetMyStarBalance, but with a context.Context parameter
 func (bot *Bot) GetMyStarBalanceWithContext(ctx context.Context, opts *GetMyStarBalanceOpts) (*StarAmount, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -3266,14 +3049,10 @@ func (bot *Bot) GetStarTransactions(opts *GetStarTransactionsOpts) (*StarTransac
 
 // GetStarTransactionsWithContext is the same as Bot.GetStarTransactions, but with a context.Context parameter
 func (bot *Bot) GetStarTransactionsWithContext(ctx context.Context, opts *GetStarTransactionsOpts) (*StarTransactions, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if opts != nil {
-		if opts.Offset != 0 {
-			v["offset"] = strconv.FormatInt(opts.Offset, 10)
-		}
-		if opts.Limit != 0 {
-			v["limit"] = strconv.FormatInt(opts.Limit, 10)
-		}
+		v["offset"] = opts.Offset
+		v["limit"] = opts.Limit
 	}
 
 	var reqOpts *RequestOpts
@@ -3307,7 +3086,7 @@ func (bot *Bot) GetStickerSet(name string, opts *GetStickerSetOpts) (*StickerSet
 
 // GetStickerSetWithContext is the same as Bot.GetStickerSet, but with a context.Context parameter
 func (bot *Bot) GetStickerSetWithContext(ctx context.Context, name string, opts *GetStickerSetOpts) (*StickerSet, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["name"] = name
 
 	var reqOpts *RequestOpts
@@ -3348,23 +3127,13 @@ func (bot *Bot) GetUpdates(opts *GetUpdatesOpts) ([]Update, error) {
 
 // GetUpdatesWithContext is the same as Bot.GetUpdates, but with a context.Context parameter
 func (bot *Bot) GetUpdatesWithContext(ctx context.Context, opts *GetUpdatesOpts) ([]Update, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if opts != nil {
-		if opts.Offset != 0 {
-			v["offset"] = strconv.FormatInt(opts.Offset, 10)
-		}
-		if opts.Limit != 0 {
-			v["limit"] = strconv.FormatInt(opts.Limit, 10)
-		}
-		if opts.Timeout != 0 {
-			v["timeout"] = strconv.FormatInt(opts.Timeout, 10)
-		}
+		v["offset"] = opts.Offset
+		v["limit"] = opts.Limit
+		v["timeout"] = opts.Timeout
 		if opts.AllowedUpdates != nil {
-			bs, err := json.Marshal(opts.AllowedUpdates)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field allowed_updates: %w", err)
-			}
-			v["allowed_updates"] = string(bs)
+			v["allowed_updates"] = opts.AllowedUpdates
 		}
 	}
 
@@ -3400,9 +3169,9 @@ func (bot *Bot) GetUserChatBoosts(chatId int64, userId int64, opts *GetUserChatB
 
 // GetUserChatBoostsWithContext is the same as Bot.GetUserChatBoosts, but with a context.Context parameter
 func (bot *Bot) GetUserChatBoostsWithContext(ctx context.Context, chatId int64, userId int64, opts *GetUserChatBoostsOpts) (*UserChatBoosts, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["user_id"] = userId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -3439,15 +3208,11 @@ func (bot *Bot) GetUserProfilePhotos(userId int64, opts *GetUserProfilePhotosOpt
 
 // GetUserProfilePhotosWithContext is the same as Bot.GetUserProfilePhotos, but with a context.Context parameter
 func (bot *Bot) GetUserProfilePhotosWithContext(ctx context.Context, userId int64, opts *GetUserProfilePhotosOpts) (*UserProfilePhotos, error) {
-	v := map[string]string{}
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v := map[string]any{}
+	v["user_id"] = userId
 	if opts != nil {
-		if opts.Offset != 0 {
-			v["offset"] = strconv.FormatInt(opts.Offset, 10)
-		}
-		if opts.Limit != 0 {
-			v["limit"] = strconv.FormatInt(opts.Limit, 10)
-		}
+		v["offset"] = opts.Offset
+		v["limit"] = opts.Limit
 	}
 
 	var reqOpts *RequestOpts
@@ -3480,7 +3245,7 @@ func (bot *Bot) GetWebhookInfo(opts *GetWebhookInfoOpts) (*WebhookInfo, error) {
 
 // GetWebhookInfoWithContext is the same as Bot.GetWebhookInfo, but with a context.Context parameter
 func (bot *Bot) GetWebhookInfoWithContext(ctx context.Context, opts *GetWebhookInfoOpts) (*WebhookInfo, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -3521,19 +3286,15 @@ func (bot *Bot) GiftPremiumSubscription(userId int64, monthCount int64, starCoun
 
 // GiftPremiumSubscriptionWithContext is the same as Bot.GiftPremiumSubscription, but with a context.Context parameter
 func (bot *Bot) GiftPremiumSubscriptionWithContext(ctx context.Context, userId int64, monthCount int64, starCount int64, opts *GiftPremiumSubscriptionOpts) (bool, error) {
-	v := map[string]string{}
-	v["user_id"] = strconv.FormatInt(userId, 10)
-	v["month_count"] = strconv.FormatInt(monthCount, 10)
-	v["star_count"] = strconv.FormatInt(starCount, 10)
+	v := map[string]any{}
+	v["user_id"] = userId
+	v["month_count"] = monthCount
+	v["star_count"] = starCount
 	if opts != nil {
 		v["text"] = opts.Text
 		v["text_parse_mode"] = opts.TextParseMode
 		if opts.TextEntities != nil {
-			bs, err := json.Marshal(opts.TextEntities)
-			if err != nil {
-				return false, fmt.Errorf("failed to marshal field text_entities: %w", err)
-			}
-			v["text_entities"] = string(bs)
+			v["text_entities"] = opts.TextEntities
 		}
 	}
 
@@ -3568,8 +3329,8 @@ func (bot *Bot) HideGeneralForumTopic(chatId int64, opts *HideGeneralForumTopicO
 
 // HideGeneralForumTopicWithContext is the same as Bot.HideGeneralForumTopic, but with a context.Context parameter
 func (bot *Bot) HideGeneralForumTopicWithContext(ctx context.Context, chatId int64, opts *HideGeneralForumTopicOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -3602,8 +3363,8 @@ func (bot *Bot) LeaveChat(chatId int64, opts *LeaveChatOpts) (bool, error) {
 
 // LeaveChatWithContext is the same as Bot.LeaveChat, but with a context.Context parameter
 func (bot *Bot) LeaveChatWithContext(ctx context.Context, chatId int64, opts *LeaveChatOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -3635,7 +3396,7 @@ func (bot *Bot) LogOut(opts *LogOutOpts) (bool, error) {
 
 // LogOutWithContext is the same as Bot.LogOut, but with a context.Context parameter
 func (bot *Bot) LogOutWithContext(ctx context.Context, opts *LogOutOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -3673,12 +3434,12 @@ func (bot *Bot) PinChatMessage(chatId int64, messageId int64, opts *PinChatMessa
 
 // PinChatMessageWithContext is the same as Bot.PinChatMessage, but with a context.Context parameter
 func (bot *Bot) PinChatMessageWithContext(ctx context.Context, chatId int64, messageId int64, opts *PinChatMessageOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["message_id"] = strconv.FormatInt(messageId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["message_id"] = messageId
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
+		v["disable_notification"] = opts.DisableNotification
 	}
 
 	var reqOpts *RequestOpts
@@ -3726,33 +3487,21 @@ func (bot *Bot) PostStory(businessConnectionId string, content InputStoryContent
 
 // PostStoryWithContext is the same as Bot.PostStory, but with a context.Context parameter
 func (bot *Bot) PostStoryWithContext(ctx context.Context, businessConnectionId string, content InputStoryContent, activePeriod int64, opts *PostStoryOpts) (*Story, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
-	bs, err := json.Marshal(content)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal field content: %w", err)
-	}
-	v["content"] = string(bs)
-	v["active_period"] = strconv.FormatInt(activePeriod, 10)
+	v["content"] = content
+	v["active_period"] = activePeriod
 	if opts != nil {
 		v["caption"] = opts.Caption
 		v["parse_mode"] = opts.ParseMode
 		if opts.CaptionEntities != nil {
-			bs, err := json.Marshal(opts.CaptionEntities)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field caption_entities: %w", err)
-			}
-			v["caption_entities"] = string(bs)
+			v["caption_entities"] = opts.CaptionEntities
 		}
 		if opts.Areas != nil {
-			bs, err := json.Marshal(opts.Areas)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field areas: %w", err)
-			}
-			v["areas"] = string(bs)
+			v["areas"] = opts.Areas
 		}
-		v["post_to_chat_page"] = strconv.FormatBool(opts.PostToChatPage)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
+		v["post_to_chat_page"] = opts.PostToChatPage
+		v["protect_content"] = opts.ProtectContent
 	}
 
 	var reqOpts *RequestOpts
@@ -3819,26 +3568,26 @@ func (bot *Bot) PromoteChatMember(chatId int64, userId int64, opts *PromoteChatM
 
 // PromoteChatMemberWithContext is the same as Bot.PromoteChatMember, but with a context.Context parameter
 func (bot *Bot) PromoteChatMemberWithContext(ctx context.Context, chatId int64, userId int64, opts *PromoteChatMemberOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["user_id"] = userId
 	if opts != nil {
-		v["is_anonymous"] = strconv.FormatBool(opts.IsAnonymous)
-		v["can_manage_chat"] = strconv.FormatBool(opts.CanManageChat)
-		v["can_delete_messages"] = strconv.FormatBool(opts.CanDeleteMessages)
-		v["can_manage_video_chats"] = strconv.FormatBool(opts.CanManageVideoChats)
-		v["can_restrict_members"] = strconv.FormatBool(opts.CanRestrictMembers)
-		v["can_promote_members"] = strconv.FormatBool(opts.CanPromoteMembers)
-		v["can_change_info"] = strconv.FormatBool(opts.CanChangeInfo)
-		v["can_invite_users"] = strconv.FormatBool(opts.CanInviteUsers)
-		v["can_post_stories"] = strconv.FormatBool(opts.CanPostStories)
-		v["can_edit_stories"] = strconv.FormatBool(opts.CanEditStories)
-		v["can_delete_stories"] = strconv.FormatBool(opts.CanDeleteStories)
-		v["can_post_messages"] = strconv.FormatBool(opts.CanPostMessages)
-		v["can_edit_messages"] = strconv.FormatBool(opts.CanEditMessages)
-		v["can_pin_messages"] = strconv.FormatBool(opts.CanPinMessages)
-		v["can_manage_topics"] = strconv.FormatBool(opts.CanManageTopics)
-		v["can_manage_direct_messages"] = strconv.FormatBool(opts.CanManageDirectMessages)
+		v["is_anonymous"] = opts.IsAnonymous
+		v["can_manage_chat"] = opts.CanManageChat
+		v["can_delete_messages"] = opts.CanDeleteMessages
+		v["can_manage_video_chats"] = opts.CanManageVideoChats
+		v["can_restrict_members"] = opts.CanRestrictMembers
+		v["can_promote_members"] = opts.CanPromoteMembers
+		v["can_change_info"] = opts.CanChangeInfo
+		v["can_invite_users"] = opts.CanInviteUsers
+		v["can_post_stories"] = opts.CanPostStories
+		v["can_edit_stories"] = opts.CanEditStories
+		v["can_delete_stories"] = opts.CanDeleteStories
+		v["can_post_messages"] = opts.CanPostMessages
+		v["can_edit_messages"] = opts.CanEditMessages
+		v["can_pin_messages"] = opts.CanPinMessages
+		v["can_manage_topics"] = opts.CanManageTopics
+		v["can_manage_direct_messages"] = opts.CanManageDirectMessages
 	}
 
 	var reqOpts *RequestOpts
@@ -3874,10 +3623,10 @@ func (bot *Bot) ReadBusinessMessage(businessConnectionId string, chatId int64, m
 
 // ReadBusinessMessageWithContext is the same as Bot.ReadBusinessMessage, but with a context.Context parameter
 func (bot *Bot) ReadBusinessMessageWithContext(ctx context.Context, businessConnectionId string, chatId int64, messageId int64, opts *ReadBusinessMessageOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["message_id"] = strconv.FormatInt(messageId, 10)
+	v["chat_id"] = chatId
+	v["message_id"] = messageId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -3911,8 +3660,8 @@ func (bot *Bot) RefundStarPayment(userId int64, telegramPaymentChargeId string, 
 
 // RefundStarPaymentWithContext is the same as Bot.RefundStarPayment, but with a context.Context parameter
 func (bot *Bot) RefundStarPaymentWithContext(ctx context.Context, userId int64, telegramPaymentChargeId string, opts *RefundStarPaymentOpts) (bool, error) {
-	v := map[string]string{}
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v := map[string]any{}
+	v["user_id"] = userId
 	v["telegram_payment_charge_id"] = telegramPaymentChargeId
 
 	var reqOpts *RequestOpts
@@ -3948,10 +3697,10 @@ func (bot *Bot) RemoveBusinessAccountProfilePhoto(businessConnectionId string, o
 
 // RemoveBusinessAccountProfilePhotoWithContext is the same as Bot.RemoveBusinessAccountProfilePhoto, but with a context.Context parameter
 func (bot *Bot) RemoveBusinessAccountProfilePhotoWithContext(ctx context.Context, businessConnectionId string, opts *RemoveBusinessAccountProfilePhotoOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
 	if opts != nil {
-		v["is_public"] = strconv.FormatBool(opts.IsPublic)
+		v["is_public"] = opts.IsPublic
 	}
 
 	var reqOpts *RequestOpts
@@ -3985,8 +3734,8 @@ func (bot *Bot) RemoveChatVerification(chatId int64, opts *RemoveChatVerificatio
 
 // RemoveChatVerificationWithContext is the same as Bot.RemoveChatVerification, but with a context.Context parameter
 func (bot *Bot) RemoveChatVerificationWithContext(ctx context.Context, chatId int64, opts *RemoveChatVerificationOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -4019,8 +3768,8 @@ func (bot *Bot) RemoveUserVerification(userId int64, opts *RemoveUserVerificatio
 
 // RemoveUserVerificationWithContext is the same as Bot.RemoveUserVerification, but with a context.Context parameter
 func (bot *Bot) RemoveUserVerificationWithContext(ctx context.Context, userId int64, opts *RemoveUserVerificationOpts) (bool, error) {
-	v := map[string]string{}
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v := map[string]any{}
+	v["user_id"] = userId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -4054,9 +3803,9 @@ func (bot *Bot) ReopenForumTopic(chatId int64, messageThreadId int64, opts *Reop
 
 // ReopenForumTopicWithContext is the same as Bot.ReopenForumTopic, but with a context.Context parameter
 func (bot *Bot) ReopenForumTopicWithContext(ctx context.Context, chatId int64, messageThreadId int64, opts *ReopenForumTopicOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["message_thread_id"] = strconv.FormatInt(messageThreadId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["message_thread_id"] = messageThreadId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -4089,8 +3838,8 @@ func (bot *Bot) ReopenGeneralForumTopic(chatId int64, opts *ReopenGeneralForumTo
 
 // ReopenGeneralForumTopicWithContext is the same as Bot.ReopenGeneralForumTopic, but with a context.Context parameter
 func (bot *Bot) ReopenGeneralForumTopicWithContext(ctx context.Context, chatId int64, opts *ReopenGeneralForumTopicOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -4126,9 +3875,9 @@ func (bot *Bot) ReplaceStickerInSet(userId int64, name string, oldSticker string
 
 // ReplaceStickerInSetWithContext is the same as Bot.ReplaceStickerInSet, but with a context.Context parameter
 func (bot *Bot) ReplaceStickerInSetWithContext(ctx context.Context, userId int64, name string, oldSticker string, sticker InputSticker, opts *ReplaceStickerInSetOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v["user_id"] = userId
 	v["name"] = name
 	v["old_sticker"] = oldSticker
 	inputBs, err := sticker.InputParams("sticker", data)
@@ -4174,19 +3923,13 @@ func (bot *Bot) RestrictChatMember(chatId int64, userId int64, permissions ChatP
 
 // RestrictChatMemberWithContext is the same as Bot.RestrictChatMember, but with a context.Context parameter
 func (bot *Bot) RestrictChatMemberWithContext(ctx context.Context, chatId int64, userId int64, permissions ChatPermissions, opts *RestrictChatMemberOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["user_id"] = strconv.FormatInt(userId, 10)
-	bs, err := json.Marshal(permissions)
-	if err != nil {
-		return false, fmt.Errorf("failed to marshal field permissions: %w", err)
-	}
-	v["permissions"] = string(bs)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["user_id"] = userId
+	v["permissions"] = permissions
 	if opts != nil {
-		v["use_independent_chat_permissions"] = strconv.FormatBool(opts.UseIndependentChatPermissions)
-		if opts.UntilDate != 0 {
-			v["until_date"] = strconv.FormatInt(opts.UntilDate, 10)
-		}
+		v["use_independent_chat_permissions"] = opts.UseIndependentChatPermissions
+		v["until_date"] = opts.UntilDate
 	}
 
 	var reqOpts *RequestOpts
@@ -4221,8 +3964,8 @@ func (bot *Bot) RevokeChatInviteLink(chatId int64, inviteLink string, opts *Revo
 
 // RevokeChatInviteLinkWithContext is the same as Bot.RevokeChatInviteLink, but with a context.Context parameter
 func (bot *Bot) RevokeChatInviteLinkWithContext(ctx context.Context, chatId int64, inviteLink string, opts *RevokeChatInviteLinkOpts) (*ChatInviteLink, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 	v["invite_link"] = inviteLink
 
 	var reqOpts *RequestOpts
@@ -4265,18 +4008,14 @@ func (bot *Bot) SavePreparedInlineMessage(userId int64, result InlineQueryResult
 
 // SavePreparedInlineMessageWithContext is the same as Bot.SavePreparedInlineMessage, but with a context.Context parameter
 func (bot *Bot) SavePreparedInlineMessageWithContext(ctx context.Context, userId int64, result InlineQueryResult, opts *SavePreparedInlineMessageOpts) (*PreparedInlineMessage, error) {
-	v := map[string]string{}
-	v["user_id"] = strconv.FormatInt(userId, 10)
-	bs, err := json.Marshal(result)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal field result: %w", err)
-	}
-	v["result"] = string(bs)
+	v := map[string]any{}
+	v["user_id"] = userId
+	v["result"] = result
 	if opts != nil {
-		v["allow_user_chats"] = strconv.FormatBool(opts.AllowUserChats)
-		v["allow_bot_chats"] = strconv.FormatBool(opts.AllowBotChats)
-		v["allow_group_chats"] = strconv.FormatBool(opts.AllowGroupChats)
-		v["allow_channel_chats"] = strconv.FormatBool(opts.AllowChannelChats)
+		v["allow_user_chats"] = opts.AllowUserChats
+		v["allow_bot_chats"] = opts.AllowBotChats
+		v["allow_group_chats"] = opts.AllowGroupChats
+		v["allow_channel_chats"] = opts.AllowChannelChats
 	}
 
 	var reqOpts *RequestOpts
@@ -4349,9 +4088,9 @@ func (bot *Bot) SendAnimation(chatId int64, animation InputFileOrString, opts *S
 
 // SendAnimationWithContext is the same as Bot.SendAnimation, but with a context.Context parameter
 func (bot *Bot) SendAnimationWithContext(ctx context.Context, chatId int64, animation InputFileOrString, opts *SendAnimationOpts) (*Message, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v["chat_id"] = chatId
 	if animation != nil {
 		err := animation.Attach("animation", data)
 		if err != nil {
@@ -4361,21 +4100,11 @@ func (bot *Bot) SendAnimationWithContext(ctx context.Context, chatId int64, anim
 	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
-		if opts.Duration != 0 {
-			v["duration"] = strconv.FormatInt(opts.Duration, 10)
-		}
-		if opts.Width != 0 {
-			v["width"] = strconv.FormatInt(opts.Width, 10)
-		}
-		if opts.Height != 0 {
-			v["height"] = strconv.FormatInt(opts.Height, 10)
-		}
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
+		v["duration"] = opts.Duration
+		v["width"] = opts.Width
+		v["height"] = opts.Height
 		if opts.Thumbnail != nil {
 			err := opts.Thumbnail.Attach("thumbnail", data)
 			if err != nil {
@@ -4386,38 +4115,22 @@ func (bot *Bot) SendAnimationWithContext(ctx context.Context, chatId int64, anim
 		v["caption"] = opts.Caption
 		v["parse_mode"] = opts.ParseMode
 		if opts.CaptionEntities != nil {
-			bs, err := json.Marshal(opts.CaptionEntities)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field caption_entities: %w", err)
-			}
-			v["caption_entities"] = string(bs)
+			v["caption_entities"] = opts.CaptionEntities
 		}
-		v["show_caption_above_media"] = strconv.FormatBool(opts.ShowCaptionAboveMedia)
-		v["has_spoiler"] = strconv.FormatBool(opts.HasSpoiler)
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["allow_paid_broadcast"] = strconv.FormatBool(opts.AllowPaidBroadcast)
+		v["show_caption_above_media"] = opts.ShowCaptionAboveMedia
+		v["has_spoiler"] = opts.HasSpoiler
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
 		v["message_effect_id"] = opts.MessageEffectId
 		if opts.SuggestedPostParameters != nil {
-			bs, err := json.Marshal(opts.SuggestedPostParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field suggested_post_parameters: %w", err)
-			}
-			v["suggested_post_parameters"] = string(bs)
+			v["suggested_post_parameters"] = opts.SuggestedPostParameters
 		}
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
 		if opts.ReplyMarkup != nil {
-			bs, err := json.Marshal(opts.ReplyMarkup)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-			}
-			v["reply_markup"] = string(bs)
+			v["reply_markup"] = opts.ReplyMarkup
 		}
 	}
 
@@ -4488,9 +4201,9 @@ func (bot *Bot) SendAudio(chatId int64, audio InputFileOrString, opts *SendAudio
 
 // SendAudioWithContext is the same as Bot.SendAudio, but with a context.Context parameter
 func (bot *Bot) SendAudioWithContext(ctx context.Context, chatId int64, audio InputFileOrString, opts *SendAudioOpts) (*Message, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v["chat_id"] = chatId
 	if audio != nil {
 		err := audio.Attach("audio", data)
 		if err != nil {
@@ -4500,24 +4213,14 @@ func (bot *Bot) SendAudioWithContext(ctx context.Context, chatId int64, audio In
 	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
 		v["caption"] = opts.Caption
 		v["parse_mode"] = opts.ParseMode
 		if opts.CaptionEntities != nil {
-			bs, err := json.Marshal(opts.CaptionEntities)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field caption_entities: %w", err)
-			}
-			v["caption_entities"] = string(bs)
+			v["caption_entities"] = opts.CaptionEntities
 		}
-		if opts.Duration != 0 {
-			v["duration"] = strconv.FormatInt(opts.Duration, 10)
-		}
+		v["duration"] = opts.Duration
 		v["performer"] = opts.Performer
 		v["title"] = opts.Title
 		if opts.Thumbnail != nil {
@@ -4527,30 +4230,18 @@ func (bot *Bot) SendAudioWithContext(ctx context.Context, chatId int64, audio In
 			}
 			v["thumbnail"] = opts.Thumbnail.getValue()
 		}
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["allow_paid_broadcast"] = strconv.FormatBool(opts.AllowPaidBroadcast)
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
 		v["message_effect_id"] = opts.MessageEffectId
 		if opts.SuggestedPostParameters != nil {
-			bs, err := json.Marshal(opts.SuggestedPostParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field suggested_post_parameters: %w", err)
-			}
-			v["suggested_post_parameters"] = string(bs)
+			v["suggested_post_parameters"] = opts.SuggestedPostParameters
 		}
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
 		if opts.ReplyMarkup != nil {
-			bs, err := json.Marshal(opts.ReplyMarkup)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-			}
-			v["reply_markup"] = string(bs)
+			v["reply_markup"] = opts.ReplyMarkup
 		}
 	}
 
@@ -4591,14 +4282,12 @@ func (bot *Bot) SendChatAction(chatId int64, action string, opts *SendChatAction
 
 // SendChatActionWithContext is the same as Bot.SendChatAction, but with a context.Context parameter
 func (bot *Bot) SendChatActionWithContext(ctx context.Context, chatId int64, action string, opts *SendChatActionOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 	v["action"] = action
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
+		v["message_thread_id"] = opts.MessageThreadId
 	}
 
 	var reqOpts *RequestOpts
@@ -4644,30 +4333,18 @@ func (bot *Bot) SendChecklist(businessConnectionId string, chatId int64, checkli
 
 // SendChecklistWithContext is the same as Bot.SendChecklist, but with a context.Context parameter
 func (bot *Bot) SendChecklistWithContext(ctx context.Context, businessConnectionId string, chatId int64, checklist InputChecklist, opts *SendChecklistOpts) (*Message, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	bs, err := json.Marshal(checklist)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal field checklist: %w", err)
-	}
-	v["checklist"] = string(bs)
+	v["chat_id"] = chatId
+	v["checklist"] = checklist
 	if opts != nil {
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
 		v["message_effect_id"] = opts.MessageEffectId
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
-		bs, err := json.Marshal(opts.ReplyMarkup)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-		}
-		v["reply_markup"] = string(bs)
+		v["reply_markup"] = opts.ReplyMarkup
 	}
 
 	var reqOpts *RequestOpts
@@ -4727,44 +4404,28 @@ func (bot *Bot) SendContact(chatId int64, phoneNumber string, firstName string, 
 
 // SendContactWithContext is the same as Bot.SendContact, but with a context.Context parameter
 func (bot *Bot) SendContactWithContext(ctx context.Context, chatId int64, phoneNumber string, firstName string, opts *SendContactOpts) (*Message, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 	v["phone_number"] = phoneNumber
 	v["first_name"] = firstName
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
 		v["last_name"] = opts.LastName
 		v["vcard"] = opts.Vcard
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["allow_paid_broadcast"] = strconv.FormatBool(opts.AllowPaidBroadcast)
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
 		v["message_effect_id"] = opts.MessageEffectId
 		if opts.SuggestedPostParameters != nil {
-			bs, err := json.Marshal(opts.SuggestedPostParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field suggested_post_parameters: %w", err)
-			}
-			v["suggested_post_parameters"] = string(bs)
+			v["suggested_post_parameters"] = opts.SuggestedPostParameters
 		}
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
 		if opts.ReplyMarkup != nil {
-			bs, err := json.Marshal(opts.ReplyMarkup)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-			}
-			v["reply_markup"] = string(bs)
+			v["reply_markup"] = opts.ReplyMarkup
 		}
 	}
 
@@ -4821,41 +4482,25 @@ func (bot *Bot) SendDice(chatId int64, opts *SendDiceOpts) (*Message, error) {
 
 // SendDiceWithContext is the same as Bot.SendDice, but with a context.Context parameter
 func (bot *Bot) SendDiceWithContext(ctx context.Context, chatId int64, opts *SendDiceOpts) (*Message, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
 		v["emoji"] = opts.Emoji
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["allow_paid_broadcast"] = strconv.FormatBool(opts.AllowPaidBroadcast)
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
 		v["message_effect_id"] = opts.MessageEffectId
 		if opts.SuggestedPostParameters != nil {
-			bs, err := json.Marshal(opts.SuggestedPostParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field suggested_post_parameters: %w", err)
-			}
-			v["suggested_post_parameters"] = string(bs)
+			v["suggested_post_parameters"] = opts.SuggestedPostParameters
 		}
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
 		if opts.ReplyMarkup != nil {
-			bs, err := json.Marshal(opts.ReplyMarkup)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-			}
-			v["reply_markup"] = string(bs)
+			v["reply_markup"] = opts.ReplyMarkup
 		}
 	}
 
@@ -4921,9 +4566,9 @@ func (bot *Bot) SendDocument(chatId int64, document InputFileOrString, opts *Sen
 
 // SendDocumentWithContext is the same as Bot.SendDocument, but with a context.Context parameter
 func (bot *Bot) SendDocumentWithContext(ctx context.Context, chatId int64, document InputFileOrString, opts *SendDocumentOpts) (*Message, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v["chat_id"] = chatId
 	if document != nil {
 		err := document.Attach("document", data)
 		if err != nil {
@@ -4933,12 +4578,8 @@ func (bot *Bot) SendDocumentWithContext(ctx context.Context, chatId int64, docum
 	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
 		if opts.Thumbnail != nil {
 			err := opts.Thumbnail.Attach("thumbnail", data)
 			if err != nil {
@@ -4949,37 +4590,21 @@ func (bot *Bot) SendDocumentWithContext(ctx context.Context, chatId int64, docum
 		v["caption"] = opts.Caption
 		v["parse_mode"] = opts.ParseMode
 		if opts.CaptionEntities != nil {
-			bs, err := json.Marshal(opts.CaptionEntities)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field caption_entities: %w", err)
-			}
-			v["caption_entities"] = string(bs)
+			v["caption_entities"] = opts.CaptionEntities
 		}
-		v["disable_content_type_detection"] = strconv.FormatBool(opts.DisableContentTypeDetection)
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["allow_paid_broadcast"] = strconv.FormatBool(opts.AllowPaidBroadcast)
+		v["disable_content_type_detection"] = opts.DisableContentTypeDetection
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
 		v["message_effect_id"] = opts.MessageEffectId
 		if opts.SuggestedPostParameters != nil {
-			bs, err := json.Marshal(opts.SuggestedPostParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field suggested_post_parameters: %w", err)
-			}
-			v["suggested_post_parameters"] = string(bs)
+			v["suggested_post_parameters"] = opts.SuggestedPostParameters
 		}
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
 		if opts.ReplyMarkup != nil {
-			bs, err := json.Marshal(opts.ReplyMarkup)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-			}
-			v["reply_markup"] = string(bs)
+			v["reply_markup"] = opts.ReplyMarkup
 		}
 	}
 
@@ -5031,30 +4656,20 @@ func (bot *Bot) SendGame(chatId int64, gameShortName string, opts *SendGameOpts)
 
 // SendGameWithContext is the same as Bot.SendGame, but with a context.Context parameter
 func (bot *Bot) SendGameWithContext(ctx context.Context, chatId int64, gameShortName string, opts *SendGameOpts) (*Message, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 	v["game_short_name"] = gameShortName
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["allow_paid_broadcast"] = strconv.FormatBool(opts.AllowPaidBroadcast)
+		v["message_thread_id"] = opts.MessageThreadId
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
 		v["message_effect_id"] = opts.MessageEffectId
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
-		bs, err := json.Marshal(opts.ReplyMarkup)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-		}
-		v["reply_markup"] = string(bs)
+		v["reply_markup"] = opts.ReplyMarkup
 	}
 
 	var reqOpts *RequestOpts
@@ -5100,24 +4715,16 @@ func (bot *Bot) SendGift(giftId string, opts *SendGiftOpts) (bool, error) {
 
 // SendGiftWithContext is the same as Bot.SendGift, but with a context.Context parameter
 func (bot *Bot) SendGiftWithContext(ctx context.Context, giftId string, opts *SendGiftOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["gift_id"] = giftId
 	if opts != nil {
-		if opts.UserId != 0 {
-			v["user_id"] = strconv.FormatInt(opts.UserId, 10)
-		}
-		if opts.ChatId != 0 {
-			v["chat_id"] = strconv.FormatInt(opts.ChatId, 10)
-		}
-		v["pay_for_upgrade"] = strconv.FormatBool(opts.PayForUpgrade)
+		v["user_id"] = opts.UserId
+		v["chat_id"] = opts.ChatId
+		v["pay_for_upgrade"] = opts.PayForUpgrade
 		v["text"] = opts.Text
 		v["text_parse_mode"] = opts.TextParseMode
 		if opts.TextEntities != nil {
-			bs, err := json.Marshal(opts.TextEntities)
-			if err != nil {
-				return false, fmt.Errorf("failed to marshal field text_entities: %w", err)
-			}
-			v["text_entities"] = string(bs)
+			v["text_entities"] = opts.TextEntities
 		}
 	}
 
@@ -5207,79 +4814,47 @@ func (bot *Bot) SendInvoice(chatId int64, title string, description string, payl
 
 // SendInvoiceWithContext is the same as Bot.SendInvoice, but with a context.Context parameter
 func (bot *Bot) SendInvoiceWithContext(ctx context.Context, chatId int64, title string, description string, payload string, currency string, prices []LabeledPrice, opts *SendInvoiceOpts) (*Message, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 	v["title"] = title
 	v["description"] = description
 	v["payload"] = payload
 	v["currency"] = currency
 	if prices != nil {
-		bs, err := json.Marshal(prices)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal field prices: %w", err)
-		}
-		v["prices"] = string(bs)
+		v["prices"] = prices
 	}
 	if opts != nil {
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
 		v["provider_token"] = opts.ProviderToken
-		if opts.MaxTipAmount != 0 {
-			v["max_tip_amount"] = strconv.FormatInt(opts.MaxTipAmount, 10)
-		}
+		v["max_tip_amount"] = opts.MaxTipAmount
 		if opts.SuggestedTipAmounts != nil {
-			bs, err := json.Marshal(opts.SuggestedTipAmounts)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field suggested_tip_amounts: %w", err)
-			}
-			v["suggested_tip_amounts"] = string(bs)
+			v["suggested_tip_amounts"] = opts.SuggestedTipAmounts
 		}
 		v["start_parameter"] = opts.StartParameter
 		v["provider_data"] = opts.ProviderData
 		v["photo_url"] = opts.PhotoUrl
-		if opts.PhotoSize != 0 {
-			v["photo_size"] = strconv.FormatInt(opts.PhotoSize, 10)
-		}
-		if opts.PhotoWidth != 0 {
-			v["photo_width"] = strconv.FormatInt(opts.PhotoWidth, 10)
-		}
-		if opts.PhotoHeight != 0 {
-			v["photo_height"] = strconv.FormatInt(opts.PhotoHeight, 10)
-		}
-		v["need_name"] = strconv.FormatBool(opts.NeedName)
-		v["need_phone_number"] = strconv.FormatBool(opts.NeedPhoneNumber)
-		v["need_email"] = strconv.FormatBool(opts.NeedEmail)
-		v["need_shipping_address"] = strconv.FormatBool(opts.NeedShippingAddress)
-		v["send_phone_number_to_provider"] = strconv.FormatBool(opts.SendPhoneNumberToProvider)
-		v["send_email_to_provider"] = strconv.FormatBool(opts.SendEmailToProvider)
-		v["is_flexible"] = strconv.FormatBool(opts.IsFlexible)
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["allow_paid_broadcast"] = strconv.FormatBool(opts.AllowPaidBroadcast)
+		v["photo_size"] = opts.PhotoSize
+		v["photo_width"] = opts.PhotoWidth
+		v["photo_height"] = opts.PhotoHeight
+		v["need_name"] = opts.NeedName
+		v["need_phone_number"] = opts.NeedPhoneNumber
+		v["need_email"] = opts.NeedEmail
+		v["need_shipping_address"] = opts.NeedShippingAddress
+		v["send_phone_number_to_provider"] = opts.SendPhoneNumberToProvider
+		v["send_email_to_provider"] = opts.SendEmailToProvider
+		v["is_flexible"] = opts.IsFlexible
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
 		v["message_effect_id"] = opts.MessageEffectId
 		if opts.SuggestedPostParameters != nil {
-			bs, err := json.Marshal(opts.SuggestedPostParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field suggested_post_parameters: %w", err)
-			}
-			v["suggested_post_parameters"] = string(bs)
+			v["suggested_post_parameters"] = opts.SuggestedPostParameters
 		}
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
-		bs, err := json.Marshal(opts.ReplyMarkup)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-		}
-		v["reply_markup"] = string(bs)
+		v["reply_markup"] = opts.ReplyMarkup
 	}
 
 	var reqOpts *RequestOpts
@@ -5343,54 +4918,30 @@ func (bot *Bot) SendLocation(chatId int64, latitude float64, longitude float64, 
 
 // SendLocationWithContext is the same as Bot.SendLocation, but with a context.Context parameter
 func (bot *Bot) SendLocationWithContext(ctx context.Context, chatId int64, latitude float64, longitude float64, opts *SendLocationOpts) (*Message, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["latitude"] = strconv.FormatFloat(latitude, 'f', -1, 64)
-	v["longitude"] = strconv.FormatFloat(longitude, 'f', -1, 64)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["latitude"] = latitude
+	v["longitude"] = longitude
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
-		if opts.HorizontalAccuracy != 0.0 {
-			v["horizontal_accuracy"] = strconv.FormatFloat(opts.HorizontalAccuracy, 'f', -1, 64)
-		}
-		if opts.LivePeriod != 0 {
-			v["live_period"] = strconv.FormatInt(opts.LivePeriod, 10)
-		}
-		if opts.Heading != 0 {
-			v["heading"] = strconv.FormatInt(opts.Heading, 10)
-		}
-		if opts.ProximityAlertRadius != 0 {
-			v["proximity_alert_radius"] = strconv.FormatInt(opts.ProximityAlertRadius, 10)
-		}
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["allow_paid_broadcast"] = strconv.FormatBool(opts.AllowPaidBroadcast)
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
+		v["horizontal_accuracy"] = opts.HorizontalAccuracy
+		v["live_period"] = opts.LivePeriod
+		v["heading"] = opts.Heading
+		v["proximity_alert_radius"] = opts.ProximityAlertRadius
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
 		v["message_effect_id"] = opts.MessageEffectId
 		if opts.SuggestedPostParameters != nil {
-			bs, err := json.Marshal(opts.SuggestedPostParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field suggested_post_parameters: %w", err)
-			}
-			v["suggested_post_parameters"] = string(bs)
+			v["suggested_post_parameters"] = opts.SuggestedPostParameters
 		}
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
 		if opts.ReplyMarkup != nil {
-			bs, err := json.Marshal(opts.ReplyMarkup)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-			}
-			v["reply_markup"] = string(bs)
+			v["reply_markup"] = opts.ReplyMarkup
 		}
 	}
 
@@ -5442,42 +4993,22 @@ func (bot *Bot) SendMediaGroup(chatId int64, media []InputMedia, opts *SendMedia
 
 // SendMediaGroupWithContext is the same as Bot.SendMediaGroup, but with a context.Context parameter
 func (bot *Bot) SendMediaGroupWithContext(ctx context.Context, chatId int64, media []InputMedia, opts *SendMediaGroupOpts) ([]Message, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v["chat_id"] = chatId
 	if media != nil {
-		var rawList []json.RawMessage
-		for idx, im := range media {
-			inputBs, err := im.InputParams("media"+strconv.Itoa(idx), data)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal list item %d for field media: %w", idx, err)
-			}
-			rawList = append(rawList, inputBs)
-		}
-		bs, err := json.Marshal(rawList)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal raw json list for field: media %w", err)
-		}
-		v["media"] = string(bs)
+		v["media"] = media
 	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["allow_paid_broadcast"] = strconv.FormatBool(opts.AllowPaidBroadcast)
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
 		v["message_effect_id"] = opts.MessageEffectId
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
 	}
 
@@ -5539,56 +5070,32 @@ func (bot *Bot) SendMessage(chatId int64, text string, opts *SendMessageOpts) (*
 
 // SendMessageWithContext is the same as Bot.SendMessage, but with a context.Context parameter
 func (bot *Bot) SendMessageWithContext(ctx context.Context, chatId int64, text string, opts *SendMessageOpts) (*Message, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 	v["text"] = text
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
 		v["parse_mode"] = opts.ParseMode
 		if opts.Entities != nil {
-			bs, err := json.Marshal(opts.Entities)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field entities: %w", err)
-			}
-			v["entities"] = string(bs)
+			v["entities"] = opts.Entities
 		}
 		if opts.LinkPreviewOptions != nil {
-			bs, err := json.Marshal(opts.LinkPreviewOptions)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field link_preview_options: %w", err)
-			}
-			v["link_preview_options"] = string(bs)
+			v["link_preview_options"] = opts.LinkPreviewOptions
 		}
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["allow_paid_broadcast"] = strconv.FormatBool(opts.AllowPaidBroadcast)
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
 		v["message_effect_id"] = opts.MessageEffectId
 		if opts.SuggestedPostParameters != nil {
-			bs, err := json.Marshal(opts.SuggestedPostParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field suggested_post_parameters: %w", err)
-			}
-			v["suggested_post_parameters"] = string(bs)
+			v["suggested_post_parameters"] = opts.SuggestedPostParameters
 		}
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
 		if opts.ReplyMarkup != nil {
-			bs, err := json.Marshal(opts.ReplyMarkup)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-			}
-			v["reply_markup"] = string(bs)
+			v["reply_markup"] = opts.ReplyMarkup
 		}
 	}
 
@@ -5653,67 +5160,35 @@ func (bot *Bot) SendPaidMedia(chatId int64, starCount int64, media []InputPaidMe
 
 // SendPaidMediaWithContext is the same as Bot.SendPaidMedia, but with a context.Context parameter
 func (bot *Bot) SendPaidMediaWithContext(ctx context.Context, chatId int64, starCount int64, media []InputPaidMedia, opts *SendPaidMediaOpts) (*Message, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["star_count"] = strconv.FormatInt(starCount, 10)
+	v["chat_id"] = chatId
+	v["star_count"] = starCount
 	if media != nil {
-		var rawList []json.RawMessage
-		for idx, im := range media {
-			inputBs, err := im.InputParams("media"+strconv.Itoa(idx), data)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal list item %d for field media: %w", idx, err)
-			}
-			rawList = append(rawList, inputBs)
-		}
-		bs, err := json.Marshal(rawList)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal raw json list for field: media %w", err)
-		}
-		v["media"] = string(bs)
+		v["media"] = media
 	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
 		v["payload"] = opts.Payload
 		v["caption"] = opts.Caption
 		v["parse_mode"] = opts.ParseMode
 		if opts.CaptionEntities != nil {
-			bs, err := json.Marshal(opts.CaptionEntities)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field caption_entities: %w", err)
-			}
-			v["caption_entities"] = string(bs)
+			v["caption_entities"] = opts.CaptionEntities
 		}
-		v["show_caption_above_media"] = strconv.FormatBool(opts.ShowCaptionAboveMedia)
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["allow_paid_broadcast"] = strconv.FormatBool(opts.AllowPaidBroadcast)
+		v["show_caption_above_media"] = opts.ShowCaptionAboveMedia
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
 		if opts.SuggestedPostParameters != nil {
-			bs, err := json.Marshal(opts.SuggestedPostParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field suggested_post_parameters: %w", err)
-			}
-			v["suggested_post_parameters"] = string(bs)
+			v["suggested_post_parameters"] = opts.SuggestedPostParameters
 		}
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
 		if opts.ReplyMarkup != nil {
-			bs, err := json.Marshal(opts.ReplyMarkup)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-			}
-			v["reply_markup"] = string(bs)
+			v["reply_markup"] = opts.ReplyMarkup
 		}
 	}
 
@@ -5779,9 +5254,9 @@ func (bot *Bot) SendPhoto(chatId int64, photo InputFileOrString, opts *SendPhoto
 
 // SendPhotoWithContext is the same as Bot.SendPhoto, but with a context.Context parameter
 func (bot *Bot) SendPhotoWithContext(ctx context.Context, chatId int64, photo InputFileOrString, opts *SendPhotoOpts) (*Message, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v["chat_id"] = chatId
 	if photo != nil {
 		err := photo.Attach("photo", data)
 		if err != nil {
@@ -5791,47 +5266,27 @@ func (bot *Bot) SendPhotoWithContext(ctx context.Context, chatId int64, photo In
 	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
 		v["caption"] = opts.Caption
 		v["parse_mode"] = opts.ParseMode
 		if opts.CaptionEntities != nil {
-			bs, err := json.Marshal(opts.CaptionEntities)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field caption_entities: %w", err)
-			}
-			v["caption_entities"] = string(bs)
+			v["caption_entities"] = opts.CaptionEntities
 		}
-		v["show_caption_above_media"] = strconv.FormatBool(opts.ShowCaptionAboveMedia)
-		v["has_spoiler"] = strconv.FormatBool(opts.HasSpoiler)
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["allow_paid_broadcast"] = strconv.FormatBool(opts.AllowPaidBroadcast)
+		v["show_caption_above_media"] = opts.ShowCaptionAboveMedia
+		v["has_spoiler"] = opts.HasSpoiler
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
 		v["message_effect_id"] = opts.MessageEffectId
 		if opts.SuggestedPostParameters != nil {
-			bs, err := json.Marshal(opts.SuggestedPostParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field suggested_post_parameters: %w", err)
-			}
-			v["suggested_post_parameters"] = string(bs)
+			v["suggested_post_parameters"] = opts.SuggestedPostParameters
 		}
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
 		if opts.ReplyMarkup != nil {
-			bs, err := json.Marshal(opts.ReplyMarkup)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-			}
-			v["reply_markup"] = string(bs)
+			v["reply_markup"] = opts.ReplyMarkup
 		}
 	}
 
@@ -5908,69 +5363,43 @@ func (bot *Bot) SendPoll(chatId int64, question string, options []InputPollOptio
 
 // SendPollWithContext is the same as Bot.SendPoll, but with a context.Context parameter
 func (bot *Bot) SendPollWithContext(ctx context.Context, chatId int64, question string, options []InputPollOption, opts *SendPollOpts) (*Message, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 	v["question"] = question
 	if options != nil {
-		bs, err := json.Marshal(options)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal field options: %w", err)
-		}
-		v["options"] = string(bs)
+		v["options"] = options
 	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
+		v["message_thread_id"] = opts.MessageThreadId
 		v["question_parse_mode"] = opts.QuestionParseMode
 		if opts.QuestionEntities != nil {
-			bs, err := json.Marshal(opts.QuestionEntities)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field question_entities: %w", err)
-			}
-			v["question_entities"] = string(bs)
+			v["question_entities"] = opts.QuestionEntities
 		}
-		v["is_anonymous"] = strconv.FormatBool(opts.IsAnonymous)
+		v["is_anonymous"] = opts.IsAnonymous
 		v["type"] = opts.Type
-		v["allows_multiple_answers"] = strconv.FormatBool(opts.AllowsMultipleAnswers)
+		v["allows_multiple_answers"] = opts.AllowsMultipleAnswers
 		if opts.Type == "quiz" {
 			// correct_option_id should always be set when the type is "quiz" - it doesnt need to be set for type "regular".
-			v["correct_option_id"] = strconv.FormatInt(opts.CorrectOptionId, 10)
+			v["correct_option_id"] = opts.CorrectOptionId
 		}
 		v["explanation"] = opts.Explanation
 		v["explanation_parse_mode"] = opts.ExplanationParseMode
 		if opts.ExplanationEntities != nil {
-			bs, err := json.Marshal(opts.ExplanationEntities)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field explanation_entities: %w", err)
-			}
-			v["explanation_entities"] = string(bs)
+			v["explanation_entities"] = opts.ExplanationEntities
 		}
-		if opts.OpenPeriod != 0 {
-			v["open_period"] = strconv.FormatInt(opts.OpenPeriod, 10)
-		}
-		if opts.CloseDate != 0 {
-			v["close_date"] = strconv.FormatInt(opts.CloseDate, 10)
-		}
-		v["is_closed"] = strconv.FormatBool(opts.IsClosed)
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["allow_paid_broadcast"] = strconv.FormatBool(opts.AllowPaidBroadcast)
+		v["open_period"] = opts.OpenPeriod
+		v["close_date"] = opts.CloseDate
+		v["is_closed"] = opts.IsClosed
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
 		v["message_effect_id"] = opts.MessageEffectId
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
 		if opts.ReplyMarkup != nil {
-			bs, err := json.Marshal(opts.ReplyMarkup)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-			}
-			v["reply_markup"] = string(bs)
+			v["reply_markup"] = opts.ReplyMarkup
 		}
 	}
 
@@ -6028,9 +5457,9 @@ func (bot *Bot) SendSticker(chatId int64, sticker InputFileOrString, opts *SendS
 
 // SendStickerWithContext is the same as Bot.SendSticker, but with a context.Context parameter
 func (bot *Bot) SendStickerWithContext(ctx context.Context, chatId int64, sticker InputFileOrString, opts *SendStickerOpts) (*Message, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v["chat_id"] = chatId
 	if sticker != nil {
 		err := sticker.Attach("sticker", data)
 		if err != nil {
@@ -6040,37 +5469,21 @@ func (bot *Bot) SendStickerWithContext(ctx context.Context, chatId int64, sticke
 	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
 		v["emoji"] = opts.Emoji
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["allow_paid_broadcast"] = strconv.FormatBool(opts.AllowPaidBroadcast)
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
 		v["message_effect_id"] = opts.MessageEffectId
 		if opts.SuggestedPostParameters != nil {
-			bs, err := json.Marshal(opts.SuggestedPostParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field suggested_post_parameters: %w", err)
-			}
-			v["suggested_post_parameters"] = string(bs)
+			v["suggested_post_parameters"] = opts.SuggestedPostParameters
 		}
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
 		if opts.ReplyMarkup != nil {
-			bs, err := json.Marshal(opts.ReplyMarkup)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-			}
-			v["reply_markup"] = string(bs)
+			v["reply_markup"] = opts.ReplyMarkup
 		}
 	}
 
@@ -6137,48 +5550,32 @@ func (bot *Bot) SendVenue(chatId int64, latitude float64, longitude float64, tit
 
 // SendVenueWithContext is the same as Bot.SendVenue, but with a context.Context parameter
 func (bot *Bot) SendVenueWithContext(ctx context.Context, chatId int64, latitude float64, longitude float64, title string, address string, opts *SendVenueOpts) (*Message, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["latitude"] = strconv.FormatFloat(latitude, 'f', -1, 64)
-	v["longitude"] = strconv.FormatFloat(longitude, 'f', -1, 64)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["latitude"] = latitude
+	v["longitude"] = longitude
 	v["title"] = title
 	v["address"] = address
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
 		v["foursquare_id"] = opts.FoursquareId
 		v["foursquare_type"] = opts.FoursquareType
 		v["google_place_id"] = opts.GooglePlaceId
 		v["google_place_type"] = opts.GooglePlaceType
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["allow_paid_broadcast"] = strconv.FormatBool(opts.AllowPaidBroadcast)
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
 		v["message_effect_id"] = opts.MessageEffectId
 		if opts.SuggestedPostParameters != nil {
-			bs, err := json.Marshal(opts.SuggestedPostParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field suggested_post_parameters: %w", err)
-			}
-			v["suggested_post_parameters"] = string(bs)
+			v["suggested_post_parameters"] = opts.SuggestedPostParameters
 		}
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
 		if opts.ReplyMarkup != nil {
-			bs, err := json.Marshal(opts.ReplyMarkup)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-			}
-			v["reply_markup"] = string(bs)
+			v["reply_markup"] = opts.ReplyMarkup
 		}
 	}
 
@@ -6258,9 +5655,9 @@ func (bot *Bot) SendVideo(chatId int64, video InputFileOrString, opts *SendVideo
 
 // SendVideoWithContext is the same as Bot.SendVideo, but with a context.Context parameter
 func (bot *Bot) SendVideoWithContext(ctx context.Context, chatId int64, video InputFileOrString, opts *SendVideoOpts) (*Message, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v["chat_id"] = chatId
 	if video != nil {
 		err := video.Attach("video", data)
 		if err != nil {
@@ -6270,21 +5667,11 @@ func (bot *Bot) SendVideoWithContext(ctx context.Context, chatId int64, video In
 	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
-		if opts.Duration != 0 {
-			v["duration"] = strconv.FormatInt(opts.Duration, 10)
-		}
-		if opts.Width != 0 {
-			v["width"] = strconv.FormatInt(opts.Width, 10)
-		}
-		if opts.Height != 0 {
-			v["height"] = strconv.FormatInt(opts.Height, 10)
-		}
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
+		v["duration"] = opts.Duration
+		v["width"] = opts.Width
+		v["height"] = opts.Height
 		if opts.Thumbnail != nil {
 			err := opts.Thumbnail.Attach("thumbnail", data)
 			if err != nil {
@@ -6299,45 +5686,27 @@ func (bot *Bot) SendVideoWithContext(ctx context.Context, chatId int64, video In
 			}
 			v["cover"] = opts.Cover.getValue()
 		}
-		if opts.StartTimestamp != 0 {
-			v["start_timestamp"] = strconv.FormatInt(opts.StartTimestamp, 10)
-		}
+		v["start_timestamp"] = opts.StartTimestamp
 		v["caption"] = opts.Caption
 		v["parse_mode"] = opts.ParseMode
 		if opts.CaptionEntities != nil {
-			bs, err := json.Marshal(opts.CaptionEntities)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field caption_entities: %w", err)
-			}
-			v["caption_entities"] = string(bs)
+			v["caption_entities"] = opts.CaptionEntities
 		}
-		v["show_caption_above_media"] = strconv.FormatBool(opts.ShowCaptionAboveMedia)
-		v["has_spoiler"] = strconv.FormatBool(opts.HasSpoiler)
-		v["supports_streaming"] = strconv.FormatBool(opts.SupportsStreaming)
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["allow_paid_broadcast"] = strconv.FormatBool(opts.AllowPaidBroadcast)
+		v["show_caption_above_media"] = opts.ShowCaptionAboveMedia
+		v["has_spoiler"] = opts.HasSpoiler
+		v["supports_streaming"] = opts.SupportsStreaming
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
 		v["message_effect_id"] = opts.MessageEffectId
 		if opts.SuggestedPostParameters != nil {
-			bs, err := json.Marshal(opts.SuggestedPostParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field suggested_post_parameters: %w", err)
-			}
-			v["suggested_post_parameters"] = string(bs)
+			v["suggested_post_parameters"] = opts.SuggestedPostParameters
 		}
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
 		if opts.ReplyMarkup != nil {
-			bs, err := json.Marshal(opts.ReplyMarkup)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-			}
-			v["reply_markup"] = string(bs)
+			v["reply_markup"] = opts.ReplyMarkup
 		}
 	}
 
@@ -6399,9 +5768,9 @@ func (bot *Bot) SendVideoNote(chatId int64, videoNote InputFileOrString, opts *S
 
 // SendVideoNoteWithContext is the same as Bot.SendVideoNote, but with a context.Context parameter
 func (bot *Bot) SendVideoNoteWithContext(ctx context.Context, chatId int64, videoNote InputFileOrString, opts *SendVideoNoteOpts) (*Message, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v["chat_id"] = chatId
 	if videoNote != nil {
 		err := videoNote.Attach("video_note", data)
 		if err != nil {
@@ -6411,18 +5780,10 @@ func (bot *Bot) SendVideoNoteWithContext(ctx context.Context, chatId int64, vide
 	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
-		if opts.Duration != 0 {
-			v["duration"] = strconv.FormatInt(opts.Duration, 10)
-		}
-		if opts.Length != 0 {
-			v["length"] = strconv.FormatInt(opts.Length, 10)
-		}
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
+		v["duration"] = opts.Duration
+		v["length"] = opts.Length
 		if opts.Thumbnail != nil {
 			err := opts.Thumbnail.Attach("thumbnail", data)
 			if err != nil {
@@ -6430,30 +5791,18 @@ func (bot *Bot) SendVideoNoteWithContext(ctx context.Context, chatId int64, vide
 			}
 			v["thumbnail"] = opts.Thumbnail.getValue()
 		}
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["allow_paid_broadcast"] = strconv.FormatBool(opts.AllowPaidBroadcast)
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
 		v["message_effect_id"] = opts.MessageEffectId
 		if opts.SuggestedPostParameters != nil {
-			bs, err := json.Marshal(opts.SuggestedPostParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field suggested_post_parameters: %w", err)
-			}
-			v["suggested_post_parameters"] = string(bs)
+			v["suggested_post_parameters"] = opts.SuggestedPostParameters
 		}
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
 		if opts.ReplyMarkup != nil {
-			bs, err := json.Marshal(opts.ReplyMarkup)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-			}
-			v["reply_markup"] = string(bs)
+			v["reply_markup"] = opts.ReplyMarkup
 		}
 	}
 
@@ -6517,9 +5866,9 @@ func (bot *Bot) SendVoice(chatId int64, voice InputFileOrString, opts *SendVoice
 
 // SendVoiceWithContext is the same as Bot.SendVoice, but with a context.Context parameter
 func (bot *Bot) SendVoiceWithContext(ctx context.Context, chatId int64, voice InputFileOrString, opts *SendVoiceOpts) (*Message, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v["chat_id"] = chatId
 	if voice != nil {
 		err := voice.Attach("voice", data)
 		if err != nil {
@@ -6529,48 +5878,26 @@ func (bot *Bot) SendVoiceWithContext(ctx context.Context, chatId int64, voice In
 	}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.MessageThreadId != 0 {
-			v["message_thread_id"] = strconv.FormatInt(opts.MessageThreadId, 10)
-		}
-		if opts.DirectMessagesTopicId != 0 {
-			v["direct_messages_topic_id"] = strconv.FormatInt(opts.DirectMessagesTopicId, 10)
-		}
+		v["message_thread_id"] = opts.MessageThreadId
+		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
 		v["caption"] = opts.Caption
 		v["parse_mode"] = opts.ParseMode
 		if opts.CaptionEntities != nil {
-			bs, err := json.Marshal(opts.CaptionEntities)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field caption_entities: %w", err)
-			}
-			v["caption_entities"] = string(bs)
+			v["caption_entities"] = opts.CaptionEntities
 		}
-		if opts.Duration != 0 {
-			v["duration"] = strconv.FormatInt(opts.Duration, 10)
-		}
-		v["disable_notification"] = strconv.FormatBool(opts.DisableNotification)
-		v["protect_content"] = strconv.FormatBool(opts.ProtectContent)
-		v["allow_paid_broadcast"] = strconv.FormatBool(opts.AllowPaidBroadcast)
+		v["duration"] = opts.Duration
+		v["disable_notification"] = opts.DisableNotification
+		v["protect_content"] = opts.ProtectContent
+		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
 		v["message_effect_id"] = opts.MessageEffectId
 		if opts.SuggestedPostParameters != nil {
-			bs, err := json.Marshal(opts.SuggestedPostParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field suggested_post_parameters: %w", err)
-			}
-			v["suggested_post_parameters"] = string(bs)
+			v["suggested_post_parameters"] = opts.SuggestedPostParameters
 		}
 		if opts.ReplyParameters != nil {
-			bs, err := json.Marshal(opts.ReplyParameters)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_parameters: %w", err)
-			}
-			v["reply_parameters"] = string(bs)
+			v["reply_parameters"] = opts.ReplyParameters
 		}
 		if opts.ReplyMarkup != nil {
-			bs, err := json.Marshal(opts.ReplyMarkup)
-			if err != nil {
-				return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-			}
-			v["reply_markup"] = string(bs)
+			v["reply_markup"] = opts.ReplyMarkup
 		}
 	}
 
@@ -6607,7 +5934,7 @@ func (bot *Bot) SetBusinessAccountBio(businessConnectionId string, opts *SetBusi
 
 // SetBusinessAccountBioWithContext is the same as Bot.SetBusinessAccountBio, but with a context.Context parameter
 func (bot *Bot) SetBusinessAccountBioWithContext(ctx context.Context, businessConnectionId string, opts *SetBusinessAccountBioOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
 	if opts != nil {
 		v["bio"] = opts.Bio
@@ -6646,14 +5973,10 @@ func (bot *Bot) SetBusinessAccountGiftSettings(businessConnectionId string, show
 
 // SetBusinessAccountGiftSettingsWithContext is the same as Bot.SetBusinessAccountGiftSettings, but with a context.Context parameter
 func (bot *Bot) SetBusinessAccountGiftSettingsWithContext(ctx context.Context, businessConnectionId string, showGiftButton bool, acceptedGiftTypes AcceptedGiftTypes, opts *SetBusinessAccountGiftSettingsOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
-	v["show_gift_button"] = strconv.FormatBool(showGiftButton)
-	bs, err := json.Marshal(acceptedGiftTypes)
-	if err != nil {
-		return false, fmt.Errorf("failed to marshal field accepted_gift_types: %w", err)
-	}
-	v["accepted_gift_types"] = string(bs)
+	v["show_gift_button"] = showGiftButton
+	v["accepted_gift_types"] = acceptedGiftTypes
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -6689,7 +6012,7 @@ func (bot *Bot) SetBusinessAccountName(businessConnectionId string, firstName st
 
 // SetBusinessAccountNameWithContext is the same as Bot.SetBusinessAccountName, but with a context.Context parameter
 func (bot *Bot) SetBusinessAccountNameWithContext(ctx context.Context, businessConnectionId string, firstName string, opts *SetBusinessAccountNameOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
 	v["first_name"] = firstName
 	if opts != nil {
@@ -6730,15 +6053,11 @@ func (bot *Bot) SetBusinessAccountProfilePhoto(businessConnectionId string, phot
 
 // SetBusinessAccountProfilePhotoWithContext is the same as Bot.SetBusinessAccountProfilePhoto, but with a context.Context parameter
 func (bot *Bot) SetBusinessAccountProfilePhotoWithContext(ctx context.Context, businessConnectionId string, photo InputProfilePhoto, opts *SetBusinessAccountProfilePhotoOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
-	bs, err := json.Marshal(photo)
-	if err != nil {
-		return false, fmt.Errorf("failed to marshal field photo: %w", err)
-	}
-	v["photo"] = string(bs)
+	v["photo"] = photo
 	if opts != nil {
-		v["is_public"] = strconv.FormatBool(opts.IsPublic)
+		v["is_public"] = opts.IsPublic
 	}
 
 	var reqOpts *RequestOpts
@@ -6774,7 +6093,7 @@ func (bot *Bot) SetBusinessAccountUsername(businessConnectionId string, opts *Se
 
 // SetBusinessAccountUsernameWithContext is the same as Bot.SetBusinessAccountUsername, but with a context.Context parameter
 func (bot *Bot) SetBusinessAccountUsernameWithContext(ctx context.Context, businessConnectionId string, opts *SetBusinessAccountUsernameOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
 	if opts != nil {
 		v["username"] = opts.Username
@@ -6813,9 +6132,9 @@ func (bot *Bot) SetChatAdministratorCustomTitle(chatId int64, userId int64, cust
 
 // SetChatAdministratorCustomTitleWithContext is the same as Bot.SetChatAdministratorCustomTitle, but with a context.Context parameter
 func (bot *Bot) SetChatAdministratorCustomTitleWithContext(ctx context.Context, chatId int64, userId int64, customTitle string, opts *SetChatAdministratorCustomTitleOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["user_id"] = userId
 	v["custom_title"] = customTitle
 
 	var reqOpts *RequestOpts
@@ -6851,8 +6170,8 @@ func (bot *Bot) SetChatDescription(chatId int64, opts *SetChatDescriptionOpts) (
 
 // SetChatDescriptionWithContext is the same as Bot.SetChatDescription, but with a context.Context parameter
 func (bot *Bot) SetChatDescriptionWithContext(ctx context.Context, chatId int64, opts *SetChatDescriptionOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 	if opts != nil {
 		v["description"] = opts.Description
 	}
@@ -6891,16 +6210,12 @@ func (bot *Bot) SetChatMenuButton(opts *SetChatMenuButtonOpts) (bool, error) {
 
 // SetChatMenuButtonWithContext is the same as Bot.SetChatMenuButton, but with a context.Context parameter
 func (bot *Bot) SetChatMenuButtonWithContext(ctx context.Context, opts *SetChatMenuButtonOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if opts != nil {
 		if opts.ChatId != nil {
-			v["chat_id"] = strconv.FormatInt(*opts.ChatId, 10)
+			v["chat_id"] = opts.ChatId
 		}
-		bs, err := json.Marshal(opts.MenuButton)
-		if err != nil {
-			return false, fmt.Errorf("failed to marshal field menu_button: %w", err)
-		}
-		v["menu_button"] = string(bs)
+		v["menu_button"] = opts.MenuButton
 	}
 
 	var reqOpts *RequestOpts
@@ -6937,15 +6252,11 @@ func (bot *Bot) SetChatPermissions(chatId int64, permissions ChatPermissions, op
 
 // SetChatPermissionsWithContext is the same as Bot.SetChatPermissions, but with a context.Context parameter
 func (bot *Bot) SetChatPermissionsWithContext(ctx context.Context, chatId int64, permissions ChatPermissions, opts *SetChatPermissionsOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	bs, err := json.Marshal(permissions)
-	if err != nil {
-		return false, fmt.Errorf("failed to marshal field permissions: %w", err)
-	}
-	v["permissions"] = string(bs)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["permissions"] = permissions
 	if opts != nil {
-		v["use_independent_chat_permissions"] = strconv.FormatBool(opts.UseIndependentChatPermissions)
+		v["use_independent_chat_permissions"] = opts.UseIndependentChatPermissions
 	}
 
 	var reqOpts *RequestOpts
@@ -6980,9 +6291,9 @@ func (bot *Bot) SetChatPhoto(chatId int64, photo InputFile, opts *SetChatPhotoOp
 
 // SetChatPhotoWithContext is the same as Bot.SetChatPhoto, but with a context.Context parameter
 func (bot *Bot) SetChatPhotoWithContext(ctx context.Context, chatId int64, photo InputFile, opts *SetChatPhotoOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v["chat_id"] = chatId
 	if photo != nil {
 		err := photo.Attach("photo", data)
 		if err != nil {
@@ -7023,8 +6334,8 @@ func (bot *Bot) SetChatStickerSet(chatId int64, stickerSetName string, opts *Set
 
 // SetChatStickerSetWithContext is the same as Bot.SetChatStickerSet, but with a context.Context parameter
 func (bot *Bot) SetChatStickerSetWithContext(ctx context.Context, chatId int64, stickerSetName string, opts *SetChatStickerSetOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 	v["sticker_set_name"] = stickerSetName
 
 	var reqOpts *RequestOpts
@@ -7059,8 +6370,8 @@ func (bot *Bot) SetChatTitle(chatId int64, title string, opts *SetChatTitleOpts)
 
 // SetChatTitleWithContext is the same as Bot.SetChatTitle, but with a context.Context parameter
 func (bot *Bot) SetChatTitleWithContext(ctx context.Context, chatId int64, title string, opts *SetChatTitleOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 	v["title"] = title
 
 	var reqOpts *RequestOpts
@@ -7096,7 +6407,7 @@ func (bot *Bot) SetCustomEmojiStickerSetThumbnail(name string, opts *SetCustomEm
 
 // SetCustomEmojiStickerSetThumbnailWithContext is the same as Bot.SetCustomEmojiStickerSetThumbnail, but with a context.Context parameter
 func (bot *Bot) SetCustomEmojiStickerSetThumbnailWithContext(ctx context.Context, name string, opts *SetCustomEmojiStickerSetThumbnailOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["name"] = name
 	if opts != nil {
 		v["custom_emoji_id"] = opts.CustomEmojiId
@@ -7144,18 +6455,14 @@ func (bot *Bot) SetGameScore(userId int64, score int64, opts *SetGameScoreOpts) 
 
 // SetGameScoreWithContext is the same as Bot.SetGameScore, but with a context.Context parameter
 func (bot *Bot) SetGameScoreWithContext(ctx context.Context, userId int64, score int64, opts *SetGameScoreOpts) (*Message, bool, error) {
-	v := map[string]string{}
-	v["user_id"] = strconv.FormatInt(userId, 10)
-	v["score"] = strconv.FormatInt(score, 10)
+	v := map[string]any{}
+	v["user_id"] = userId
+	v["score"] = score
 	if opts != nil {
-		v["force"] = strconv.FormatBool(opts.Force)
-		v["disable_edit_message"] = strconv.FormatBool(opts.DisableEditMessage)
-		if opts.ChatId != 0 {
-			v["chat_id"] = strconv.FormatInt(opts.ChatId, 10)
-		}
-		if opts.MessageId != 0 {
-			v["message_id"] = strconv.FormatInt(opts.MessageId, 10)
-		}
+		v["force"] = opts.Force
+		v["disable_edit_message"] = opts.DisableEditMessage
+		v["chat_id"] = opts.ChatId
+		v["message_id"] = opts.MessageId
 		v["inline_message_id"] = opts.InlineMessageId
 	}
 
@@ -7203,18 +6510,14 @@ func (bot *Bot) SetMessageReaction(chatId int64, messageId int64, opts *SetMessa
 
 // SetMessageReactionWithContext is the same as Bot.SetMessageReaction, but with a context.Context parameter
 func (bot *Bot) SetMessageReactionWithContext(ctx context.Context, chatId int64, messageId int64, opts *SetMessageReactionOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["message_id"] = strconv.FormatInt(messageId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["message_id"] = messageId
 	if opts != nil {
 		if opts.Reaction != nil {
-			bs, err := json.Marshal(opts.Reaction)
-			if err != nil {
-				return false, fmt.Errorf("failed to marshal field reaction: %w", err)
-			}
-			v["reaction"] = string(bs)
+			v["reaction"] = opts.Reaction
 		}
-		v["is_big"] = strconv.FormatBool(opts.IsBig)
+		v["is_big"] = opts.IsBig
 	}
 
 	var reqOpts *RequestOpts
@@ -7252,20 +6555,12 @@ func (bot *Bot) SetMyCommands(commands []BotCommand, opts *SetMyCommandsOpts) (b
 
 // SetMyCommandsWithContext is the same as Bot.SetMyCommands, but with a context.Context parameter
 func (bot *Bot) SetMyCommandsWithContext(ctx context.Context, commands []BotCommand, opts *SetMyCommandsOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if commands != nil {
-		bs, err := json.Marshal(commands)
-		if err != nil {
-			return false, fmt.Errorf("failed to marshal field commands: %w", err)
-		}
-		v["commands"] = string(bs)
+		v["commands"] = commands
 	}
 	if opts != nil {
-		bs, err := json.Marshal(opts.Scope)
-		if err != nil {
-			return false, fmt.Errorf("failed to marshal field scope: %w", err)
-		}
-		v["scope"] = string(bs)
+		v["scope"] = opts.Scope
 		v["language_code"] = opts.LanguageCode
 	}
 
@@ -7303,16 +6598,12 @@ func (bot *Bot) SetMyDefaultAdministratorRights(opts *SetMyDefaultAdministratorR
 
 // SetMyDefaultAdministratorRightsWithContext is the same as Bot.SetMyDefaultAdministratorRights, but with a context.Context parameter
 func (bot *Bot) SetMyDefaultAdministratorRightsWithContext(ctx context.Context, opts *SetMyDefaultAdministratorRightsOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if opts != nil {
 		if opts.Rights != nil {
-			bs, err := json.Marshal(opts.Rights)
-			if err != nil {
-				return false, fmt.Errorf("failed to marshal field rights: %w", err)
-			}
-			v["rights"] = string(bs)
+			v["rights"] = opts.Rights
 		}
-		v["for_channels"] = strconv.FormatBool(opts.ForChannels)
+		v["for_channels"] = opts.ForChannels
 	}
 
 	var reqOpts *RequestOpts
@@ -7349,7 +6640,7 @@ func (bot *Bot) SetMyDescription(opts *SetMyDescriptionOpts) (bool, error) {
 
 // SetMyDescriptionWithContext is the same as Bot.SetMyDescription, but with a context.Context parameter
 func (bot *Bot) SetMyDescriptionWithContext(ctx context.Context, opts *SetMyDescriptionOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if opts != nil {
 		v["description"] = opts.Description
 		v["language_code"] = opts.LanguageCode
@@ -7389,7 +6680,7 @@ func (bot *Bot) SetMyName(opts *SetMyNameOpts) (bool, error) {
 
 // SetMyNameWithContext is the same as Bot.SetMyName, but with a context.Context parameter
 func (bot *Bot) SetMyNameWithContext(ctx context.Context, opts *SetMyNameOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if opts != nil {
 		v["name"] = opts.Name
 		v["language_code"] = opts.LanguageCode
@@ -7429,7 +6720,7 @@ func (bot *Bot) SetMyShortDescription(opts *SetMyShortDescriptionOpts) (bool, er
 
 // SetMyShortDescriptionWithContext is the same as Bot.SetMyShortDescription, but with a context.Context parameter
 func (bot *Bot) SetMyShortDescriptionWithContext(ctx context.Context, opts *SetMyShortDescriptionOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if opts != nil {
 		v["short_description"] = opts.ShortDescription
 		v["language_code"] = opts.LanguageCode
@@ -7468,14 +6759,10 @@ func (bot *Bot) SetPassportDataErrors(userId int64, errors []PassportElementErro
 
 // SetPassportDataErrorsWithContext is the same as Bot.SetPassportDataErrors, but with a context.Context parameter
 func (bot *Bot) SetPassportDataErrorsWithContext(ctx context.Context, userId int64, errors []PassportElementError, opts *SetPassportDataErrorsOpts) (bool, error) {
-	v := map[string]string{}
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v := map[string]any{}
+	v["user_id"] = userId
 	if errors != nil {
-		bs, err := json.Marshal(errors)
-		if err != nil {
-			return false, fmt.Errorf("failed to marshal field errors: %w", err)
-		}
-		v["errors"] = string(bs)
+		v["errors"] = errors
 	}
 
 	var reqOpts *RequestOpts
@@ -7510,7 +6797,7 @@ func (bot *Bot) SetStickerEmojiList(sticker InputFileOrString, emojiList []strin
 
 // SetStickerEmojiListWithContext is the same as Bot.SetStickerEmojiList, but with a context.Context parameter
 func (bot *Bot) SetStickerEmojiListWithContext(ctx context.Context, sticker InputFileOrString, emojiList []string, opts *SetStickerEmojiListOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
 	if sticker != nil {
 		err := sticker.Attach("sticker", data)
@@ -7520,11 +6807,7 @@ func (bot *Bot) SetStickerEmojiListWithContext(ctx context.Context, sticker Inpu
 		v["sticker"] = sticker.getValue()
 	}
 	if emojiList != nil {
-		bs, err := json.Marshal(emojiList)
-		if err != nil {
-			return false, fmt.Errorf("failed to marshal field emoji_list: %w", err)
-		}
-		v["emoji_list"] = string(bs)
+		v["emoji_list"] = emojiList
 	}
 
 	var reqOpts *RequestOpts
@@ -7560,7 +6843,7 @@ func (bot *Bot) SetStickerKeywords(sticker InputFileOrString, opts *SetStickerKe
 
 // SetStickerKeywordsWithContext is the same as Bot.SetStickerKeywords, but with a context.Context parameter
 func (bot *Bot) SetStickerKeywordsWithContext(ctx context.Context, sticker InputFileOrString, opts *SetStickerKeywordsOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
 	if sticker != nil {
 		err := sticker.Attach("sticker", data)
@@ -7571,11 +6854,7 @@ func (bot *Bot) SetStickerKeywordsWithContext(ctx context.Context, sticker Input
 	}
 	if opts != nil {
 		if opts.Keywords != nil {
-			bs, err := json.Marshal(opts.Keywords)
-			if err != nil {
-				return false, fmt.Errorf("failed to marshal field keywords: %w", err)
-			}
-			v["keywords"] = string(bs)
+			v["keywords"] = opts.Keywords
 		}
 	}
 
@@ -7612,7 +6891,7 @@ func (bot *Bot) SetStickerMaskPosition(sticker InputFileOrString, opts *SetStick
 
 // SetStickerMaskPositionWithContext is the same as Bot.SetStickerMaskPosition, but with a context.Context parameter
 func (bot *Bot) SetStickerMaskPositionWithContext(ctx context.Context, sticker InputFileOrString, opts *SetStickerMaskPositionOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
 	if sticker != nil {
 		err := sticker.Attach("sticker", data)
@@ -7623,11 +6902,7 @@ func (bot *Bot) SetStickerMaskPositionWithContext(ctx context.Context, sticker I
 	}
 	if opts != nil {
 		if opts.MaskPosition != nil {
-			bs, err := json.Marshal(opts.MaskPosition)
-			if err != nil {
-				return false, fmt.Errorf("failed to marshal field mask_position: %w", err)
-			}
-			v["mask_position"] = string(bs)
+			v["mask_position"] = opts.MaskPosition
 		}
 	}
 
@@ -7663,7 +6938,7 @@ func (bot *Bot) SetStickerPositionInSet(sticker InputFileOrString, position int6
 
 // SetStickerPositionInSetWithContext is the same as Bot.SetStickerPositionInSet, but with a context.Context parameter
 func (bot *Bot) SetStickerPositionInSetWithContext(ctx context.Context, sticker InputFileOrString, position int64, opts *SetStickerPositionInSetOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
 	if sticker != nil {
 		err := sticker.Attach("sticker", data)
@@ -7672,7 +6947,7 @@ func (bot *Bot) SetStickerPositionInSetWithContext(ctx context.Context, sticker 
 		}
 		v["sticker"] = sticker.getValue()
 	}
-	v["position"] = strconv.FormatInt(position, 10)
+	v["position"] = position
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -7709,10 +6984,10 @@ func (bot *Bot) SetStickerSetThumbnail(name string, userId int64, format string,
 
 // SetStickerSetThumbnailWithContext is the same as Bot.SetStickerSetThumbnail, but with a context.Context parameter
 func (bot *Bot) SetStickerSetThumbnailWithContext(ctx context.Context, name string, userId int64, format string, opts *SetStickerSetThumbnailOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
 	v["name"] = name
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v["user_id"] = userId
 	v["format"] = format
 	if opts != nil {
 		if opts.Thumbnail != nil {
@@ -7756,7 +7031,7 @@ func (bot *Bot) SetStickerSetTitle(name string, title string, opts *SetStickerSe
 
 // SetStickerSetTitleWithContext is the same as Bot.SetStickerSetTitle, but with a context.Context parameter
 func (bot *Bot) SetStickerSetTitleWithContext(ctx context.Context, name string, title string, opts *SetStickerSetTitleOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["name"] = name
 	v["title"] = title
 
@@ -7795,13 +7070,11 @@ func (bot *Bot) SetUserEmojiStatus(userId int64, opts *SetUserEmojiStatusOpts) (
 
 // SetUserEmojiStatusWithContext is the same as Bot.SetUserEmojiStatus, but with a context.Context parameter
 func (bot *Bot) SetUserEmojiStatusWithContext(ctx context.Context, userId int64, opts *SetUserEmojiStatusOpts) (bool, error) {
-	v := map[string]string{}
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v := map[string]any{}
+	v["user_id"] = userId
 	if opts != nil {
 		v["emoji_status_custom_emoji_id"] = opts.EmojiStatusCustomEmojiId
-		if opts.EmojiStatusExpirationDate != 0 {
-			v["emoji_status_expiration_date"] = strconv.FormatInt(opts.EmojiStatusExpirationDate, 10)
-		}
+		v["emoji_status_expiration_date"] = opts.EmojiStatusExpirationDate
 	}
 
 	var reqOpts *RequestOpts
@@ -7848,7 +7121,7 @@ func (bot *Bot) SetWebhook(url string, opts *SetWebhookOpts) (bool, error) {
 
 // SetWebhookWithContext is the same as Bot.SetWebhook, but with a context.Context parameter
 func (bot *Bot) SetWebhookWithContext(ctx context.Context, url string, opts *SetWebhookOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
 	v["url"] = url
 	if opts != nil {
@@ -7860,17 +7133,11 @@ func (bot *Bot) SetWebhookWithContext(ctx context.Context, url string, opts *Set
 			v["certificate"] = opts.Certificate.getValue()
 		}
 		v["ip_address"] = opts.IpAddress
-		if opts.MaxConnections != 0 {
-			v["max_connections"] = strconv.FormatInt(opts.MaxConnections, 10)
-		}
+		v["max_connections"] = opts.MaxConnections
 		if opts.AllowedUpdates != nil {
-			bs, err := json.Marshal(opts.AllowedUpdates)
-			if err != nil {
-				return false, fmt.Errorf("failed to marshal field allowed_updates: %w", err)
-			}
-			v["allowed_updates"] = string(bs)
+			v["allowed_updates"] = opts.AllowedUpdates
 		}
-		v["drop_pending_updates"] = strconv.FormatBool(opts.DropPendingUpdates)
+		v["drop_pending_updates"] = opts.DropPendingUpdates
 		v["secret_token"] = opts.SecretToken
 	}
 
@@ -7914,21 +7181,13 @@ func (bot *Bot) StopMessageLiveLocation(opts *StopMessageLiveLocationOpts) (*Mes
 
 // StopMessageLiveLocationWithContext is the same as Bot.StopMessageLiveLocation, but with a context.Context parameter
 func (bot *Bot) StopMessageLiveLocationWithContext(ctx context.Context, opts *StopMessageLiveLocationOpts) (*Message, bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.ChatId != 0 {
-			v["chat_id"] = strconv.FormatInt(opts.ChatId, 10)
-		}
-		if opts.MessageId != 0 {
-			v["message_id"] = strconv.FormatInt(opts.MessageId, 10)
-		}
+		v["chat_id"] = opts.ChatId
+		v["message_id"] = opts.MessageId
 		v["inline_message_id"] = opts.InlineMessageId
-		bs, err := json.Marshal(opts.ReplyMarkup)
-		if err != nil {
-			return nil, false, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-		}
-		v["reply_markup"] = string(bs)
+		v["reply_markup"] = opts.ReplyMarkup
 	}
 
 	var reqOpts *RequestOpts
@@ -7975,16 +7234,12 @@ func (bot *Bot) StopPoll(chatId int64, messageId int64, opts *StopPollOpts) (*Po
 
 // StopPollWithContext is the same as Bot.StopPoll, but with a context.Context parameter
 func (bot *Bot) StopPollWithContext(ctx context.Context, chatId int64, messageId int64, opts *StopPollOpts) (*Poll, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["message_id"] = strconv.FormatInt(messageId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["message_id"] = messageId
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
-		bs, err := json.Marshal(opts.ReplyMarkup)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal field reply_markup: %w", err)
-		}
-		v["reply_markup"] = string(bs)
+		v["reply_markup"] = opts.ReplyMarkup
 	}
 
 	var reqOpts *RequestOpts
@@ -8019,9 +7274,9 @@ func (bot *Bot) TransferBusinessAccountStars(businessConnectionId string, starCo
 
 // TransferBusinessAccountStarsWithContext is the same as Bot.TransferBusinessAccountStars, but with a context.Context parameter
 func (bot *Bot) TransferBusinessAccountStarsWithContext(ctx context.Context, businessConnectionId string, starCount int64, opts *TransferBusinessAccountStarsOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
-	v["star_count"] = strconv.FormatInt(starCount, 10)
+	v["star_count"] = starCount
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -8058,14 +7313,12 @@ func (bot *Bot) TransferGift(businessConnectionId string, ownedGiftId string, ne
 
 // TransferGiftWithContext is the same as Bot.TransferGift, but with a context.Context parameter
 func (bot *Bot) TransferGiftWithContext(ctx context.Context, businessConnectionId string, ownedGiftId string, newOwnerChatId int64, opts *TransferGiftOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
 	v["owned_gift_id"] = ownedGiftId
-	v["new_owner_chat_id"] = strconv.FormatInt(newOwnerChatId, 10)
+	v["new_owner_chat_id"] = newOwnerChatId
 	if opts != nil {
-		if opts.StarCount != 0 {
-			v["star_count"] = strconv.FormatInt(opts.StarCount, 10)
-		}
+		v["star_count"] = opts.StarCount
 	}
 
 	var reqOpts *RequestOpts
@@ -8102,11 +7355,11 @@ func (bot *Bot) UnbanChatMember(chatId int64, userId int64, opts *UnbanChatMembe
 
 // UnbanChatMemberWithContext is the same as Bot.UnbanChatMember, but with a context.Context parameter
 func (bot *Bot) UnbanChatMemberWithContext(ctx context.Context, chatId int64, userId int64, opts *UnbanChatMemberOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["user_id"] = userId
 	if opts != nil {
-		v["only_if_banned"] = strconv.FormatBool(opts.OnlyIfBanned)
+		v["only_if_banned"] = opts.OnlyIfBanned
 	}
 
 	var reqOpts *RequestOpts
@@ -8141,9 +7394,9 @@ func (bot *Bot) UnbanChatSenderChat(chatId int64, senderChatId int64, opts *Unba
 
 // UnbanChatSenderChatWithContext is the same as Bot.UnbanChatSenderChat, but with a context.Context parameter
 func (bot *Bot) UnbanChatSenderChatWithContext(ctx context.Context, chatId int64, senderChatId int64, opts *UnbanChatSenderChatOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["sender_chat_id"] = strconv.FormatInt(senderChatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["sender_chat_id"] = senderChatId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -8176,8 +7429,8 @@ func (bot *Bot) UnhideGeneralForumTopic(chatId int64, opts *UnhideGeneralForumTo
 
 // UnhideGeneralForumTopicWithContext is the same as Bot.UnhideGeneralForumTopic, but with a context.Context parameter
 func (bot *Bot) UnhideGeneralForumTopicWithContext(ctx context.Context, chatId int64, opts *UnhideGeneralForumTopicOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -8210,8 +7463,8 @@ func (bot *Bot) UnpinAllChatMessages(chatId int64, opts *UnpinAllChatMessagesOpt
 
 // UnpinAllChatMessagesWithContext is the same as Bot.UnpinAllChatMessages, but with a context.Context parameter
 func (bot *Bot) UnpinAllChatMessagesWithContext(ctx context.Context, chatId int64, opts *UnpinAllChatMessagesOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -8245,9 +7498,9 @@ func (bot *Bot) UnpinAllForumTopicMessages(chatId int64, messageThreadId int64, 
 
 // UnpinAllForumTopicMessagesWithContext is the same as Bot.UnpinAllForumTopicMessages, but with a context.Context parameter
 func (bot *Bot) UnpinAllForumTopicMessagesWithContext(ctx context.Context, chatId int64, messageThreadId int64, opts *UnpinAllForumTopicMessagesOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
-	v["message_thread_id"] = strconv.FormatInt(messageThreadId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
+	v["message_thread_id"] = messageThreadId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -8280,8 +7533,8 @@ func (bot *Bot) UnpinAllGeneralForumTopicMessages(chatId int64, opts *UnpinAllGe
 
 // UnpinAllGeneralForumTopicMessagesWithContext is the same as Bot.UnpinAllGeneralForumTopicMessages, but with a context.Context parameter
 func (bot *Bot) UnpinAllGeneralForumTopicMessagesWithContext(ctx context.Context, chatId int64, opts *UnpinAllGeneralForumTopicMessagesOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -8318,12 +7571,12 @@ func (bot *Bot) UnpinChatMessage(chatId int64, opts *UnpinChatMessageOpts) (bool
 
 // UnpinChatMessageWithContext is the same as Bot.UnpinChatMessage, but with a context.Context parameter
 func (bot *Bot) UnpinChatMessageWithContext(ctx context.Context, chatId int64, opts *UnpinChatMessageOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
 		if opts.MessageId != nil {
-			v["message_id"] = strconv.FormatInt(*opts.MessageId, 10)
+			v["message_id"] = opts.MessageId
 		}
 	}
 
@@ -8363,14 +7616,12 @@ func (bot *Bot) UpgradeGift(businessConnectionId string, ownedGiftId string, opt
 
 // UpgradeGiftWithContext is the same as Bot.UpgradeGift, but with a context.Context parameter
 func (bot *Bot) UpgradeGiftWithContext(ctx context.Context, businessConnectionId string, ownedGiftId string, opts *UpgradeGiftOpts) (bool, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
 	v["owned_gift_id"] = ownedGiftId
 	if opts != nil {
-		v["keep_original_details"] = strconv.FormatBool(opts.KeepOriginalDetails)
-		if opts.StarCount != 0 {
-			v["star_count"] = strconv.FormatInt(opts.StarCount, 10)
-		}
+		v["keep_original_details"] = opts.KeepOriginalDetails
+		v["star_count"] = opts.StarCount
 	}
 
 	var reqOpts *RequestOpts
@@ -8406,9 +7657,9 @@ func (bot *Bot) UploadStickerFile(userId int64, sticker InputFile, stickerFormat
 
 // UploadStickerFileWithContext is the same as Bot.UploadStickerFile, but with a context.Context parameter
 func (bot *Bot) UploadStickerFileWithContext(ctx context.Context, userId int64, sticker InputFile, stickerFormat string, opts *UploadStickerFileOpts) (*File, error) {
-	v := map[string]string{}
+	v := map[string]any{}
 	data := map[string]FileReader{}
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v["user_id"] = userId
 	if sticker != nil {
 		err := sticker.Attach("sticker", data)
 		if err != nil {
@@ -8451,8 +7702,8 @@ func (bot *Bot) VerifyChat(chatId int64, opts *VerifyChatOpts) (bool, error) {
 
 // VerifyChatWithContext is the same as Bot.VerifyChat, but with a context.Context parameter
 func (bot *Bot) VerifyChatWithContext(ctx context.Context, chatId int64, opts *VerifyChatOpts) (bool, error) {
-	v := map[string]string{}
-	v["chat_id"] = strconv.FormatInt(chatId, 10)
+	v := map[string]any{}
+	v["chat_id"] = chatId
 	if opts != nil {
 		v["custom_description"] = opts.CustomDescription
 	}
@@ -8490,8 +7741,8 @@ func (bot *Bot) VerifyUser(userId int64, opts *VerifyUserOpts) (bool, error) {
 
 // VerifyUserWithContext is the same as Bot.VerifyUser, but with a context.Context parameter
 func (bot *Bot) VerifyUserWithContext(ctx context.Context, userId int64, opts *VerifyUserOpts) (bool, error) {
-	v := map[string]string{}
-	v["user_id"] = strconv.FormatInt(userId, 10)
+	v := map[string]any{}
+	v["user_id"] = userId
 	if opts != nil {
 		v["custom_description"] = opts.CustomDescription
 	}

--- a/gen_methods.go
+++ b/gen_methods.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 // AddStickerToSetOpts is the set of optional fields for Bot.AddStickerToSet and Bot.AddStickerToSetWithContext.
@@ -34,7 +35,7 @@ func (bot *Bot) AddStickerToSetWithContext(ctx context.Context, userId int64, na
 	v["name"] = name
 	err := sticker.InputParams("sticker", data)
 	if err != nil {
-		return false, fmt.Errorf("failed to marshal field sticker: %w", err)
+		return false, fmt.Errorf("failed to attach input file sticker: %w", err)
 	}
 	v["sticker"] = sticker
 
@@ -983,6 +984,12 @@ func (bot *Bot) CreateNewStickerSetWithContext(ctx context.Context, userId int64
 	v["name"] = name
 	v["title"] = title
 	if stickers != nil {
+		for idx, im := range stickers {
+			err := im.InputParams("stickers"+strconv.Itoa(idx), data)
+			if err != nil {
+				return false, fmt.Errorf("failed to attach input field for list item %d stickers: %w", idx, err)
+			}
+		}
 		v["stickers"] = stickers
 	}
 	if opts != nil {
@@ -1891,7 +1898,7 @@ func (bot *Bot) EditMessageMediaWithContext(ctx context.Context, media InputMedi
 	data := map[string]FileReader{}
 	err := media.InputParams("media", data)
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to marshal field media: %w", err)
+		return nil, false, fmt.Errorf("failed to attach input file media: %w", err)
 	}
 	v["media"] = media
 	if opts != nil {
@@ -3882,7 +3889,7 @@ func (bot *Bot) ReplaceStickerInSetWithContext(ctx context.Context, userId int64
 	v["old_sticker"] = oldSticker
 	err := sticker.InputParams("sticker", data)
 	if err != nil {
-		return false, fmt.Errorf("failed to marshal field sticker: %w", err)
+		return false, fmt.Errorf("failed to attach input file sticker: %w", err)
 	}
 	v["sticker"] = sticker
 
@@ -4997,6 +5004,12 @@ func (bot *Bot) SendMediaGroupWithContext(ctx context.Context, chatId int64, med
 	data := map[string]FileReader{}
 	v["chat_id"] = chatId
 	if media != nil {
+		for idx, im := range media {
+			err := im.InputParams("media"+strconv.Itoa(idx), data)
+			if err != nil {
+				return nil, fmt.Errorf("failed to attach input field for list item %d media: %w", idx, err)
+			}
+		}
 		v["media"] = media
 	}
 	if opts != nil {
@@ -5165,6 +5178,12 @@ func (bot *Bot) SendPaidMediaWithContext(ctx context.Context, chatId int64, star
 	v["chat_id"] = chatId
 	v["star_count"] = starCount
 	if media != nil {
+		for idx, im := range media {
+			err := im.InputParams("media"+strconv.Itoa(idx), data)
+			if err != nil {
+				return nil, fmt.Errorf("failed to attach input field for list item %d media: %w", idx, err)
+			}
+		}
 		v["media"] = media
 	}
 	if opts != nil {

--- a/gen_methods.go
+++ b/gen_methods.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 )
 
 // AddStickerToSetOpts is the set of optional fields for Bot.AddStickerToSet and Bot.AddStickerToSetWithContext.
@@ -30,13 +29,8 @@ func (bot *Bot) AddStickerToSet(userId int64, name string, sticker InputSticker,
 // AddStickerToSetWithContext is the same as Bot.AddStickerToSet, but with a context.Context parameter
 func (bot *Bot) AddStickerToSetWithContext(ctx context.Context, userId int64, name string, sticker InputSticker, opts *AddStickerToSetOpts) (bool, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
 	v["user_id"] = userId
 	v["name"] = name
-	err := sticker.InputParams("sticker", data)
-	if err != nil {
-		return false, fmt.Errorf("failed to attach input file sticker: %w", err)
-	}
 	v["sticker"] = sticker
 
 	var reqOpts *RequestOpts
@@ -44,7 +38,7 @@ func (bot *Bot) AddStickerToSetWithContext(ctx context.Context, userId int64, na
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "addStickerToSet", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "addStickerToSet", v, nil, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -979,17 +973,10 @@ func (bot *Bot) CreateNewStickerSet(userId int64, name string, title string, sti
 // CreateNewStickerSetWithContext is the same as Bot.CreateNewStickerSet, but with a context.Context parameter
 func (bot *Bot) CreateNewStickerSetWithContext(ctx context.Context, userId int64, name string, title string, stickers []InputSticker, opts *CreateNewStickerSetOpts) (bool, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
 	v["user_id"] = userId
 	v["name"] = name
 	v["title"] = title
 	if stickers != nil {
-		for idx, im := range stickers {
-			err := im.InputParams("stickers"+strconv.Itoa(idx), data)
-			if err != nil {
-				return false, fmt.Errorf("failed to attach input field for list item %d stickers: %w", idx, err)
-			}
-		}
 		v["stickers"] = stickers
 	}
 	if opts != nil {
@@ -1002,7 +989,7 @@ func (bot *Bot) CreateNewStickerSetWithContext(ctx context.Context, userId int64
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "createNewStickerSet", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "createNewStickerSet", v, nil, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -1895,11 +1882,6 @@ func (bot *Bot) EditMessageMedia(media InputMedia, opts *EditMessageMediaOpts) (
 // EditMessageMediaWithContext is the same as Bot.EditMessageMedia, but with a context.Context parameter
 func (bot *Bot) EditMessageMediaWithContext(ctx context.Context, media InputMedia, opts *EditMessageMediaOpts) (*Message, bool, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
-	err := media.InputParams("media", data)
-	if err != nil {
-		return nil, false, fmt.Errorf("failed to attach input file media: %w", err)
-	}
 	v["media"] = media
 	if opts != nil {
 		v["business_connection_id"] = opts.BusinessConnectionId
@@ -1914,7 +1896,7 @@ func (bot *Bot) EditMessageMediaWithContext(ctx context.Context, media InputMedi
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "editMessageMedia", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "editMessageMedia", v, nil, reqOpts)
 	if err != nil {
 		return nil, false, err
 	}
@@ -3883,14 +3865,9 @@ func (bot *Bot) ReplaceStickerInSet(userId int64, name string, oldSticker string
 // ReplaceStickerInSetWithContext is the same as Bot.ReplaceStickerInSet, but with a context.Context parameter
 func (bot *Bot) ReplaceStickerInSetWithContext(ctx context.Context, userId int64, name string, oldSticker string, sticker InputSticker, opts *ReplaceStickerInSetOpts) (bool, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
 	v["user_id"] = userId
 	v["name"] = name
 	v["old_sticker"] = oldSticker
-	err := sticker.InputParams("sticker", data)
-	if err != nil {
-		return false, fmt.Errorf("failed to attach input file sticker: %w", err)
-	}
 	v["sticker"] = sticker
 
 	var reqOpts *RequestOpts
@@ -3898,7 +3875,7 @@ func (bot *Bot) ReplaceStickerInSetWithContext(ctx context.Context, userId int64
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "replaceStickerInSet", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "replaceStickerInSet", v, nil, reqOpts)
 	if err != nil {
 		return false, err
 	}
@@ -5001,15 +4978,8 @@ func (bot *Bot) SendMediaGroup(chatId int64, media []InputMedia, opts *SendMedia
 // SendMediaGroupWithContext is the same as Bot.SendMediaGroup, but with a context.Context parameter
 func (bot *Bot) SendMediaGroupWithContext(ctx context.Context, chatId int64, media []InputMedia, opts *SendMediaGroupOpts) ([]Message, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
 	v["chat_id"] = chatId
 	if media != nil {
-		for idx, im := range media {
-			err := im.InputParams("media"+strconv.Itoa(idx), data)
-			if err != nil {
-				return nil, fmt.Errorf("failed to attach input field for list item %d media: %w", idx, err)
-			}
-		}
 		v["media"] = media
 	}
 	if opts != nil {
@@ -5030,7 +5000,7 @@ func (bot *Bot) SendMediaGroupWithContext(ctx context.Context, chatId int64, med
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendMediaGroup", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendMediaGroup", v, nil, reqOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -5174,16 +5144,9 @@ func (bot *Bot) SendPaidMedia(chatId int64, starCount int64, media []InputPaidMe
 // SendPaidMediaWithContext is the same as Bot.SendPaidMedia, but with a context.Context parameter
 func (bot *Bot) SendPaidMediaWithContext(ctx context.Context, chatId int64, starCount int64, media []InputPaidMedia, opts *SendPaidMediaOpts) (*Message, error) {
 	v := map[string]any{}
-	data := map[string]FileReader{}
 	v["chat_id"] = chatId
 	v["star_count"] = starCount
 	if media != nil {
-		for idx, im := range media {
-			err := im.InputParams("media"+strconv.Itoa(idx), data)
-			if err != nil {
-				return nil, fmt.Errorf("failed to attach input field for list item %d media: %w", idx, err)
-			}
-		}
 		v["media"] = media
 	}
 	if opts != nil {
@@ -5216,7 +5179,7 @@ func (bot *Bot) SendPaidMediaWithContext(ctx context.Context, chatId int64, star
 		reqOpts = opts.RequestOpts
 	}
 
-	r, err := bot.RequestWithContext(ctx, "sendPaidMedia", v, data, reqOpts)
+	r, err := bot.RequestWithContext(ctx, "sendPaidMedia", v, nil, reqOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/gen_types.go
+++ b/gen_types.go
@@ -6,6 +6,7 @@ package gotgbot
 import (
 	"encoding/json"
 	"fmt"
+	"mime/multipart"
 )
 
 type ReplyMarkup interface {
@@ -4956,7 +4957,7 @@ type InputMedia interface {
 	GetType() string
 	GetMedia() InputFileOrString
 	// InputParams allows for uploading attachments with files.
-	InputParams(string, map[string]FileReader) error
+	InputParams(string, *multipart.Writer) error
 	// MergeInputMedia returns a MergedInputMedia struct to simplify working with complex telegram types in a non-generic world.
 	MergeInputMedia() MergedInputMedia
 	// inputMedia exists to avoid external types implementing this interface.
@@ -5097,16 +5098,16 @@ func (v InputMediaAnimation) MarshalJSON() ([]byte, error) {
 // InputMediaAnimation.inputMedia is a dummy method to avoid interface implementation.
 func (v InputMediaAnimation) inputMedia() {}
 
-func (v InputMediaAnimation) InputParams(mediaName string, data map[string]FileReader) error {
+func (v InputMediaAnimation) InputParams(mediaName string, w *multipart.Writer) error {
 	if v.Media != nil {
-		err := v.Media.Attach(mediaName, data)
+		err := v.Media.Attach(mediaName, w)
 		if err != nil {
 			return fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
 		}
 	}
 
 	if v.Thumbnail != nil {
-		err := v.Thumbnail.Attach(mediaName+"-thumbnail", data)
+		err := v.Thumbnail.Attach(mediaName+"-thumbnail", w)
 		if err != nil {
 			return fmt.Errorf("failed to attach 'thumbnail' input file for %s: %w", mediaName, err)
 		}
@@ -5178,16 +5179,16 @@ func (v InputMediaAudio) MarshalJSON() ([]byte, error) {
 // InputMediaAudio.inputMedia is a dummy method to avoid interface implementation.
 func (v InputMediaAudio) inputMedia() {}
 
-func (v InputMediaAudio) InputParams(mediaName string, data map[string]FileReader) error {
+func (v InputMediaAudio) InputParams(mediaName string, w *multipart.Writer) error {
 	if v.Media != nil {
-		err := v.Media.Attach(mediaName, data)
+		err := v.Media.Attach(mediaName, w)
 		if err != nil {
 			return fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
 		}
 	}
 
 	if v.Thumbnail != nil {
-		err := v.Thumbnail.Attach(mediaName+"-thumbnail", data)
+		err := v.Thumbnail.Attach(mediaName+"-thumbnail", w)
 		if err != nil {
 			return fmt.Errorf("failed to attach 'thumbnail' input file for %s: %w", mediaName, err)
 		}
@@ -5253,16 +5254,16 @@ func (v InputMediaDocument) MarshalJSON() ([]byte, error) {
 // InputMediaDocument.inputMedia is a dummy method to avoid interface implementation.
 func (v InputMediaDocument) inputMedia() {}
 
-func (v InputMediaDocument) InputParams(mediaName string, data map[string]FileReader) error {
+func (v InputMediaDocument) InputParams(mediaName string, w *multipart.Writer) error {
 	if v.Media != nil {
-		err := v.Media.Attach(mediaName, data)
+		err := v.Media.Attach(mediaName, w)
 		if err != nil {
 			return fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
 		}
 	}
 
 	if v.Thumbnail != nil {
-		err := v.Thumbnail.Attach(mediaName+"-thumbnail", data)
+		err := v.Thumbnail.Attach(mediaName+"-thumbnail", w)
 		if err != nil {
 			return fmt.Errorf("failed to attach 'thumbnail' input file for %s: %w", mediaName, err)
 		}
@@ -5328,9 +5329,9 @@ func (v InputMediaPhoto) MarshalJSON() ([]byte, error) {
 // InputMediaPhoto.inputMedia is a dummy method to avoid interface implementation.
 func (v InputMediaPhoto) inputMedia() {}
 
-func (v InputMediaPhoto) InputParams(mediaName string, data map[string]FileReader) error {
+func (v InputMediaPhoto) InputParams(mediaName string, w *multipart.Writer) error {
 	if v.Media != nil {
-		err := v.Media.Attach(mediaName, data)
+		err := v.Media.Attach(mediaName, w)
 		if err != nil {
 			return fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
 		}
@@ -5417,16 +5418,16 @@ func (v InputMediaVideo) MarshalJSON() ([]byte, error) {
 // InputMediaVideo.inputMedia is a dummy method to avoid interface implementation.
 func (v InputMediaVideo) inputMedia() {}
 
-func (v InputMediaVideo) InputParams(mediaName string, data map[string]FileReader) error {
+func (v InputMediaVideo) InputParams(mediaName string, w *multipart.Writer) error {
 	if v.Media != nil {
-		err := v.Media.Attach(mediaName, data)
+		err := v.Media.Attach(mediaName, w)
 		if err != nil {
 			return fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
 		}
 	}
 
 	if v.Thumbnail != nil {
-		err := v.Thumbnail.Attach(mediaName+"-thumbnail", data)
+		err := v.Thumbnail.Attach(mediaName+"-thumbnail", w)
 		if err != nil {
 			return fmt.Errorf("failed to attach 'thumbnail' input file for %s: %w", mediaName, err)
 		}
@@ -5466,7 +5467,7 @@ type InputPaidMedia interface {
 	GetType() string
 	GetMedia() InputFileOrString
 	// InputParams allows for uploading attachments with files.
-	InputParams(string, map[string]FileReader) error
+	InputParams(string, *multipart.Writer) error
 	// MergeInputPaidMedia returns a MergedInputPaidMedia struct to simplify working with complex telegram types in a non-generic world.
 	MergeInputPaidMedia() MergedInputPaidMedia
 	// inputPaidMedia exists to avoid external types implementing this interface.
@@ -5561,9 +5562,9 @@ func (v InputPaidMediaPhoto) MarshalJSON() ([]byte, error) {
 // InputPaidMediaPhoto.inputPaidMedia is a dummy method to avoid interface implementation.
 func (v InputPaidMediaPhoto) inputPaidMedia() {}
 
-func (v InputPaidMediaPhoto) InputParams(mediaName string, data map[string]FileReader) error {
+func (v InputPaidMediaPhoto) InputParams(mediaName string, w *multipart.Writer) error {
 	if v.Media != nil {
-		err := v.Media.Attach(mediaName, data)
+		err := v.Media.Attach(mediaName, w)
 		if err != nil {
 			return fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
 		}
@@ -5635,16 +5636,16 @@ func (v InputPaidMediaVideo) MarshalJSON() ([]byte, error) {
 // InputPaidMediaVideo.inputPaidMedia is a dummy method to avoid interface implementation.
 func (v InputPaidMediaVideo) inputPaidMedia() {}
 
-func (v InputPaidMediaVideo) InputParams(mediaName string, data map[string]FileReader) error {
+func (v InputPaidMediaVideo) InputParams(mediaName string, w *multipart.Writer) error {
 	if v.Media != nil {
-		err := v.Media.Attach(mediaName, data)
+		err := v.Media.Attach(mediaName, w)
 		if err != nil {
 			return fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
 		}
 	}
 
 	if v.Thumbnail != nil {
-		err := v.Thumbnail.Attach(mediaName+"-thumbnail", data)
+		err := v.Thumbnail.Attach(mediaName+"-thumbnail", w)
 		if err != nil {
 			return fmt.Errorf("failed to attach 'thumbnail' input file for %s: %w", mediaName, err)
 		}
@@ -5802,9 +5803,9 @@ type InputSticker struct {
 	Keywords []string `json:"keywords,omitempty"`
 }
 
-func (v InputSticker) InputParams(mediaName string, data map[string]FileReader) error {
+func (v InputSticker) InputParams(mediaName string, w *multipart.Writer) error {
 	if v.Sticker != nil {
-		err := v.Sticker.Attach(mediaName, data)
+		err := v.Sticker.Attach(mediaName, w)
 		if err != nil {
 			return fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
 		}

--- a/gen_types.go
+++ b/gen_types.go
@@ -4956,7 +4956,7 @@ type InputMedia interface {
 	GetType() string
 	GetMedia() InputFileOrString
 	// InputParams allows for uploading attachments with files.
-	InputParams(string, map[string]FileReader) ([]byte, error)
+	InputParams(string, map[string]FileReader) error
 	// MergeInputMedia returns a MergedInputMedia struct to simplify working with complex telegram types in a non-generic world.
 	MergeInputMedia() MergedInputMedia
 	// inputMedia exists to avoid external types implementing this interface.
@@ -5097,22 +5097,22 @@ func (v InputMediaAnimation) MarshalJSON() ([]byte, error) {
 // InputMediaAnimation.inputMedia is a dummy method to avoid interface implementation.
 func (v InputMediaAnimation) inputMedia() {}
 
-func (v InputMediaAnimation) InputParams(mediaName string, data map[string]FileReader) ([]byte, error) {
+func (v InputMediaAnimation) InputParams(mediaName string, data map[string]FileReader) error {
 	if v.Media != nil {
 		err := v.Media.Attach(mediaName, data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
+			return fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
 		}
 	}
 
 	if v.Thumbnail != nil {
 		err := v.Thumbnail.Attach(mediaName+"-thumbnail", data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to attach 'thumbnail' input file for %s: %w", mediaName, err)
+			return fmt.Errorf("failed to attach 'thumbnail' input file for %s: %w", mediaName, err)
 		}
 	}
 
-	return json.Marshal(v)
+	return nil
 }
 
 // InputMediaAudio (https://core.telegram.org/bots/api#inputmediaaudio)
@@ -5178,22 +5178,22 @@ func (v InputMediaAudio) MarshalJSON() ([]byte, error) {
 // InputMediaAudio.inputMedia is a dummy method to avoid interface implementation.
 func (v InputMediaAudio) inputMedia() {}
 
-func (v InputMediaAudio) InputParams(mediaName string, data map[string]FileReader) ([]byte, error) {
+func (v InputMediaAudio) InputParams(mediaName string, data map[string]FileReader) error {
 	if v.Media != nil {
 		err := v.Media.Attach(mediaName, data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
+			return fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
 		}
 	}
 
 	if v.Thumbnail != nil {
 		err := v.Thumbnail.Attach(mediaName+"-thumbnail", data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to attach 'thumbnail' input file for %s: %w", mediaName, err)
+			return fmt.Errorf("failed to attach 'thumbnail' input file for %s: %w", mediaName, err)
 		}
 	}
 
-	return json.Marshal(v)
+	return nil
 }
 
 // InputMediaDocument (https://core.telegram.org/bots/api#inputmediadocument)
@@ -5253,22 +5253,22 @@ func (v InputMediaDocument) MarshalJSON() ([]byte, error) {
 // InputMediaDocument.inputMedia is a dummy method to avoid interface implementation.
 func (v InputMediaDocument) inputMedia() {}
 
-func (v InputMediaDocument) InputParams(mediaName string, data map[string]FileReader) ([]byte, error) {
+func (v InputMediaDocument) InputParams(mediaName string, data map[string]FileReader) error {
 	if v.Media != nil {
 		err := v.Media.Attach(mediaName, data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
+			return fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
 		}
 	}
 
 	if v.Thumbnail != nil {
 		err := v.Thumbnail.Attach(mediaName+"-thumbnail", data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to attach 'thumbnail' input file for %s: %w", mediaName, err)
+			return fmt.Errorf("failed to attach 'thumbnail' input file for %s: %w", mediaName, err)
 		}
 	}
 
-	return json.Marshal(v)
+	return nil
 }
 
 // InputMediaPhoto (https://core.telegram.org/bots/api#inputmediaphoto)
@@ -5328,15 +5328,15 @@ func (v InputMediaPhoto) MarshalJSON() ([]byte, error) {
 // InputMediaPhoto.inputMedia is a dummy method to avoid interface implementation.
 func (v InputMediaPhoto) inputMedia() {}
 
-func (v InputMediaPhoto) InputParams(mediaName string, data map[string]FileReader) ([]byte, error) {
+func (v InputMediaPhoto) InputParams(mediaName string, data map[string]FileReader) error {
 	if v.Media != nil {
 		err := v.Media.Attach(mediaName, data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
+			return fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
 		}
 	}
 
-	return json.Marshal(v)
+	return nil
 }
 
 // InputMediaVideo (https://core.telegram.org/bots/api#inputmediavideo)
@@ -5417,22 +5417,22 @@ func (v InputMediaVideo) MarshalJSON() ([]byte, error) {
 // InputMediaVideo.inputMedia is a dummy method to avoid interface implementation.
 func (v InputMediaVideo) inputMedia() {}
 
-func (v InputMediaVideo) InputParams(mediaName string, data map[string]FileReader) ([]byte, error) {
+func (v InputMediaVideo) InputParams(mediaName string, data map[string]FileReader) error {
 	if v.Media != nil {
 		err := v.Media.Attach(mediaName, data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
+			return fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
 		}
 	}
 
 	if v.Thumbnail != nil {
 		err := v.Thumbnail.Attach(mediaName+"-thumbnail", data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to attach 'thumbnail' input file for %s: %w", mediaName, err)
+			return fmt.Errorf("failed to attach 'thumbnail' input file for %s: %w", mediaName, err)
 		}
 	}
 
-	return json.Marshal(v)
+	return nil
 }
 
 // InputMessageContent (https://core.telegram.org/bots/api#inputmessagecontent)
@@ -5466,7 +5466,7 @@ type InputPaidMedia interface {
 	GetType() string
 	GetMedia() InputFileOrString
 	// InputParams allows for uploading attachments with files.
-	InputParams(string, map[string]FileReader) ([]byte, error)
+	InputParams(string, map[string]FileReader) error
 	// MergeInputPaidMedia returns a MergedInputPaidMedia struct to simplify working with complex telegram types in a non-generic world.
 	MergeInputPaidMedia() MergedInputPaidMedia
 	// inputPaidMedia exists to avoid external types implementing this interface.
@@ -5561,15 +5561,15 @@ func (v InputPaidMediaPhoto) MarshalJSON() ([]byte, error) {
 // InputPaidMediaPhoto.inputPaidMedia is a dummy method to avoid interface implementation.
 func (v InputPaidMediaPhoto) inputPaidMedia() {}
 
-func (v InputPaidMediaPhoto) InputParams(mediaName string, data map[string]FileReader) ([]byte, error) {
+func (v InputPaidMediaPhoto) InputParams(mediaName string, data map[string]FileReader) error {
 	if v.Media != nil {
 		err := v.Media.Attach(mediaName, data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
+			return fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
 		}
 	}
 
-	return json.Marshal(v)
+	return nil
 }
 
 // InputPaidMediaVideo (https://core.telegram.org/bots/api#inputpaidmediavideo)
@@ -5635,22 +5635,22 @@ func (v InputPaidMediaVideo) MarshalJSON() ([]byte, error) {
 // InputPaidMediaVideo.inputPaidMedia is a dummy method to avoid interface implementation.
 func (v InputPaidMediaVideo) inputPaidMedia() {}
 
-func (v InputPaidMediaVideo) InputParams(mediaName string, data map[string]FileReader) ([]byte, error) {
+func (v InputPaidMediaVideo) InputParams(mediaName string, data map[string]FileReader) error {
 	if v.Media != nil {
 		err := v.Media.Attach(mediaName, data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
+			return fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
 		}
 	}
 
 	if v.Thumbnail != nil {
 		err := v.Thumbnail.Attach(mediaName+"-thumbnail", data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to attach 'thumbnail' input file for %s: %w", mediaName, err)
+			return fmt.Errorf("failed to attach 'thumbnail' input file for %s: %w", mediaName, err)
 		}
 	}
 
-	return json.Marshal(v)
+	return nil
 }
 
 // InputPollOption (https://core.telegram.org/bots/api#inputpolloption)
@@ -5802,15 +5802,15 @@ type InputSticker struct {
 	Keywords []string `json:"keywords,omitempty"`
 }
 
-func (v InputSticker) InputParams(mediaName string, data map[string]FileReader) ([]byte, error) {
+func (v InputSticker) InputParams(mediaName string, data map[string]FileReader) error {
 	if v.Sticker != nil {
 		err := v.Sticker.Attach(mediaName, data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
+			return fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
 		}
 	}
 
-	return json.Marshal(v)
+	return nil
 }
 
 // InputStoryContent (https://core.telegram.org/bots/api#inputstorycontent)

--- a/request.go
+++ b/request.go
@@ -21,7 +21,7 @@ const (
 
 type BotClient interface {
 	// RequestWithContext submits a POST HTTP request a bot API instance.
-	RequestWithContext(ctx context.Context, token string, method string, params map[string]string, data map[string]FileReader, opts *RequestOpts) (json.RawMessage, error)
+	RequestWithContext(ctx context.Context, token string, method string, params map[string]any, data map[string]FileReader, opts *RequestOpts) (json.RawMessage, error)
 	// GetAPIURL gets the URL of the API either in use by the bot or defined in the request opts.
 	GetAPIURL(opts *RequestOpts) string
 	// FileURL gets the URL of a file at the API address that the bot is interacting with.
@@ -59,7 +59,7 @@ type TelegramError struct {
 	// The telegram method which raised the error.
 	Method string
 	// The HTTP parameters which raised the error.
-	Params map[string]string
+	Params map[string]any
 	// The error code returned by telegram.
 	Code int
 	// The error description returned by telegram.
@@ -130,32 +130,16 @@ func timeoutFromOpts(parentCtx context.Context, opts *RequestOpts) (context.Cont
 //   - params: map of parameters to be sending to the telegram API. eg: chat_id, user_id, etc.
 //   - data: map of any files to be sending to the telegram API.
 //   - opts: request opts to use.
-func (bot *BaseBotClient) RequestWithContext(parentCtx context.Context, token string, method string, params map[string]string, data map[string]FileReader, opts *RequestOpts) (json.RawMessage, error) {
+func (bot *BaseBotClient) RequestWithContext(parentCtx context.Context, token string, method string, params map[string]any, data map[string]FileReader, opts *RequestOpts) (json.RawMessage, error) {
 	ctx, cancel := bot.getTimeoutContext(parentCtx, opts)
 	defer cancel()
 
-	var bodyData []byte
-	var contentType string
-	var err error
-
-	// Check if there are any files to upload. If yes, use multipart; else, use JSON.
-	if len(data) > 0 {
-		// For multipart, we need to buffer the entire body for retries
-		var buf bytes.Buffer
-		contentType, err = fillBuffer(&buf, params, data)
-		if err != nil {
-			return nil, fmt.Errorf("failed to write multipart data: %w", err)
-		}
-
-		bodyData = buf.Bytes()
-
-	} else {
-		contentType = "application/json"
-		bodyData, err = json.Marshal(params)
-		if err != nil {
-			return nil, fmt.Errorf("failed to encode parameters as JSON: %w", err)
-		}
+	buf := bytes.NewBuffer(nil)
+	contentType, err := fillBuffer(buf, params, data)
+	if err != nil {
+		return nil, err
 	}
+	bodyData := buf.Bytes()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, bot.methodEndpoint(token, method, opts), bytes.NewReader(bodyData))
 	if err != nil {
@@ -193,14 +177,34 @@ func (bot *BaseBotClient) RequestWithContext(parentCtx context.Context, token st
 	return r.Result, nil
 }
 
-// fillBuffer fills a byte buffer with data which is going to be sent.
-func fillBuffer(buf *bytes.Buffer, params map[string]string, data map[string]FileReader) (string, error) {
+// fillBuffer fills a buffer with the multipart writer data which is going to be sent.
+func fillBuffer(buf *bytes.Buffer, params map[string]any, data map[string]FileReader) (string, error) {
 	w := multipart.NewWriter(buf)
 
+	if err := w.WriteField("_empty", ""); err != nil {
+		return "", fmt.Errorf("failed to write empty multipart field: %w", err)
+	}
+
 	for k, v := range params {
-		err := w.WriteField(k, v)
-		if err != nil {
-			return "", fmt.Errorf("failed to write multipart field %s with value %s: %w", k, v, err)
+		var strValue string
+
+		// Check if the value is a simple type that can be converted directly
+		switch val := v.(type) {
+		case string:
+			strValue = val
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, bool:
+			strValue = fmt.Sprint(val)
+		default:
+			// For complex types (structs, maps, slices, etc.), marshal as JSON
+			jsonBytes, err := json.Marshal(val)
+			if err != nil {
+				return "", fmt.Errorf("failed to marshal field %s to JSON: %w", k, err)
+			}
+			strValue = string(jsonBytes)
+		}
+
+		if err := w.WriteField(k, strValue); err != nil {
+			return "", fmt.Errorf("failed to write multipart field %s with value %v: %w", k, v, err)
 		}
 	}
 

--- a/request.go
+++ b/request.go
@@ -181,8 +181,10 @@ func (bot *BaseBotClient) RequestWithContext(parentCtx context.Context, token st
 func fillBuffer(buf *bytes.Buffer, params map[string]any, data map[string]FileReader) (string, error) {
 	w := multipart.NewWriter(buf)
 
-	if err := w.WriteField("_empty", ""); err != nil {
-		return "", fmt.Errorf("failed to write empty multipart field: %w", err)
+	if len(params) == 0 {
+		if err := w.WriteField("_empty", ""); err != nil {
+			return "", fmt.Errorf("failed to write empty multipart field: %w", err)
+		}
 	}
 
 	for k, v := range params {

--- a/request.go
+++ b/request.go
@@ -79,7 +79,7 @@ type RequestOpts struct {
 	// Custom API URL to use for requests.
 	APIURL string
 	// OverrideParams can be used to override existing parameters, or override existing ones.
-	OverrideParams map[string]string
+	OverrideParams map[string]any
 }
 
 // getTimeoutContext returns the appropriate context for the current settings.

--- a/request.go
+++ b/request.go
@@ -188,7 +188,6 @@ func (bot *BaseBotClient) RequestWithContext(parentCtx context.Context, token st
 
 // fillBuffer fills a buffer with the multipart writer data which is going to be sent.
 func fillBuffer(buf *bytes.Buffer, params map[string]any) (string, error) {
-	data := map[string]FileReader{}
 	w := multipart.NewWriter(buf)
 
 	if len(params) == 0 {
@@ -207,7 +206,7 @@ func fillBuffer(buf *bytes.Buffer, params map[string]any) (string, error) {
 		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, bool:
 			strValue = fmt.Sprint(val)
 		case InputMedia:
-			err := val.InputParams(k, data)
+			err := val.InputParams(k, w)
 			if err != nil {
 				return "", fmt.Errorf("failed to read input multipart field: %w", err)
 			}
@@ -220,7 +219,7 @@ func fillBuffer(buf *bytes.Buffer, params map[string]any) (string, error) {
 
 		case []InputMedia:
 			for idx, item := range val {
-				err := item.InputParams(k+"_"+strconv.Itoa(idx), data)
+				err := item.InputParams(k+"_"+strconv.Itoa(idx), w)
 				if err != nil {
 					return "", fmt.Errorf("failed to read input multipart field: %w", err)
 				}
@@ -233,7 +232,7 @@ func fillBuffer(buf *bytes.Buffer, params map[string]any) (string, error) {
 			strValue = string(bs)
 
 		case InputFile:
-			err := val.Attach(k, data)
+			err := val.Attach(k, w)
 			if err != nil {
 				return "", fmt.Errorf("failed to attach field %s: %w", k, err)
 			}
@@ -254,23 +253,6 @@ func fillBuffer(buf *bytes.Buffer, params map[string]any) (string, error) {
 
 		if err := w.WriteField(k, strValue); err != nil {
 			return "", fmt.Errorf("failed to write multipart field %s with value %v: %w", k, v, err)
-		}
-	}
-
-	for field, file := range data {
-		fileName := file.Name
-		if fileName == "" {
-			fileName = field
-		}
-
-		part, err := w.CreateFormFile(field, fileName)
-		if err != nil {
-			return "", fmt.Errorf("failed to create form file for field %s and fileName %s: %w", field, fileName, err)
-		}
-
-		_, err = io.Copy(part, file.Data)
-		if err != nil {
-			return "", fmt.Errorf("failed to copy file contents of field %s to form: %w", field, err)
 		}
 	}
 

--- a/request.go
+++ b/request.go
@@ -22,7 +22,7 @@ const (
 
 type BotClient interface {
 	// RequestWithContext submits a POST HTTP request a bot API instance.
-	RequestWithContext(ctx context.Context, token string, method string, params map[string]any, data map[string]FileReader, opts *RequestOpts) (json.RawMessage, error)
+	RequestWithContext(ctx context.Context, token string, method string, params map[string]any, opts *RequestOpts) (json.RawMessage, error)
 	// GetAPIURL gets the URL of the API either in use by the bot or defined in the request opts.
 	GetAPIURL(opts *RequestOpts) string
 	// FileURL gets the URL of a file at the API address that the bot is interacting with.
@@ -133,7 +133,7 @@ func timeoutFromOpts(parentCtx context.Context, opts *RequestOpts) (context.Cont
 //   - params: map of parameters to be sending to the telegram API. eg: chat_id, user_id, etc.
 //   - data: map of any files to be sending to the telegram API.
 //   - opts: request opts to use.
-func (bot *BaseBotClient) RequestWithContext(parentCtx context.Context, token string, method string, params map[string]any, data map[string]FileReader, opts *RequestOpts) (json.RawMessage, error) {
+func (bot *BaseBotClient) RequestWithContext(parentCtx context.Context, token string, method string, params map[string]any, opts *RequestOpts) (json.RawMessage, error) {
 	ctx, cancel := bot.getTimeoutContext(parentCtx, opts)
 	defer cancel()
 
@@ -144,7 +144,7 @@ func (bot *BaseBotClient) RequestWithContext(parentCtx context.Context, token st
 	}
 
 	buf := bytes.NewBuffer(nil)
-	contentType, err := fillBuffer(buf, params, data)
+	contentType, err := fillBuffer(buf, params)
 	if err != nil {
 		return nil, err
 	}
@@ -187,11 +187,8 @@ func (bot *BaseBotClient) RequestWithContext(parentCtx context.Context, token st
 }
 
 // fillBuffer fills a buffer with the multipart writer data which is going to be sent.
-func fillBuffer(buf *bytes.Buffer, params map[string]any, data map[string]FileReader) (string, error) {
-	if data == nil {
-		data = map[string]FileReader{}
-	}
-
+func fillBuffer(buf *bytes.Buffer, params map[string]any) (string, error) {
+	data := map[string]FileReader{}
 	w := multipart.NewWriter(buf)
 
 	if len(params) == 0 {
@@ -234,6 +231,17 @@ func fillBuffer(buf *bytes.Buffer, params map[string]any, data map[string]FileRe
 				return "", fmt.Errorf("failed to marshal field %s to JSON: %w", k, err)
 			}
 			strValue = string(bs)
+
+		case InputFile:
+			err := val.Attach(k, data)
+			if err != nil {
+				return "", fmt.Errorf("failed to attach field %s: %w", k, err)
+			}
+
+			err = w.WriteField(k, val.getValue())
+			if err != nil {
+				return "", fmt.Errorf("failed to write field %s to multipart field: %w", k, err)
+			}
 
 		default:
 			// For complex types (structs, maps, slices, etc.), marshal as JSON

--- a/request.go
+++ b/request.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -187,6 +188,10 @@ func (bot *BaseBotClient) RequestWithContext(parentCtx context.Context, token st
 
 // fillBuffer fills a buffer with the multipart writer data which is going to be sent.
 func fillBuffer(buf *bytes.Buffer, params map[string]any, data map[string]FileReader) (string, error) {
+	if data == nil {
+		data = map[string]FileReader{}
+	}
+
 	w := multipart.NewWriter(buf)
 
 	if len(params) == 0 {
@@ -204,13 +209,39 @@ func fillBuffer(buf *bytes.Buffer, params map[string]any, data map[string]FileRe
 			strValue = val
 		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, bool:
 			strValue = fmt.Sprint(val)
-		default:
-			// For complex types (structs, maps, slices, etc.), marshal as JSON
-			jsonBytes, err := json.Marshal(val)
+		case InputMedia:
+			err := val.InputParams(k, data)
+			if err != nil {
+				return "", fmt.Errorf("failed to read input multipart field: %w", err)
+			}
+
+			bs, err := json.Marshal(val)
 			if err != nil {
 				return "", fmt.Errorf("failed to marshal field %s to JSON: %w", k, err)
 			}
-			strValue = string(jsonBytes)
+			strValue = string(bs)
+
+		case []InputMedia:
+			for idx, item := range val {
+				err := item.InputParams(k+"_"+strconv.Itoa(idx), data)
+				if err != nil {
+					return "", fmt.Errorf("failed to read input multipart field: %w", err)
+				}
+			}
+
+			bs, err := json.Marshal(val)
+			if err != nil {
+				return "", fmt.Errorf("failed to marshal field %s to JSON: %w", k, err)
+			}
+			strValue = string(bs)
+
+		default:
+			// For complex types (structs, maps, slices, etc.), marshal as JSON
+			bs, err := json.Marshal(val)
+			if err != nil {
+				return "", fmt.Errorf("failed to marshal field %s to JSON: %w", k, err)
+			}
+			strValue = string(bs)
 		}
 
 		if err := w.WriteField(k, strValue); err != nil {

--- a/request.go
+++ b/request.go
@@ -210,61 +210,12 @@ func fillBuffer(buf *bytes.Buffer, params map[string]any) (string, error) {
 	}
 
 	for k, v := range params {
-		var strValue string
-
-		// Check if the value is a simple type that can be converted directly
-		switch val := v.(type) {
-		case string:
-			strValue = val
-		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, bool:
-			strValue = fmt.Sprint(val)
-		case InputMedia:
-			err := val.InputParams(k, w)
-			if err != nil {
-				return "", fmt.Errorf("failed to read input multipart field: %w", err)
-			}
-
-			bs, err := json.Marshal(val)
-			if err != nil {
-				return "", fmt.Errorf("failed to marshal field %s to JSON: %w", k, err)
-			}
-			strValue = string(bs)
-
-		case []InputMedia:
-			for idx, item := range val {
-				err := item.InputParams(k+"_"+strconv.Itoa(idx), w)
-				if err != nil {
-					return "", fmt.Errorf("failed to read input multipart field: %w", err)
-				}
-			}
-
-			bs, err := json.Marshal(val)
-			if err != nil {
-				return "", fmt.Errorf("failed to marshal field %s to JSON: %w", k, err)
-			}
-			strValue = string(bs)
-
-		case InputFile:
-			err := val.Attach(k, w)
-			if err != nil {
-				return "", fmt.Errorf("failed to attach field %s: %w", k, err)
-			}
-
-			err = w.WriteField(k, val.getValue())
-			if err != nil {
-				return "", fmt.Errorf("failed to write field %s to multipart field: %w", k, err)
-			}
-
-		default:
-			// For complex types (structs, maps, slices, etc.), marshal as JSON
-			bs, err := json.Marshal(val)
-			if err != nil {
-				return "", fmt.Errorf("failed to marshal field %s to JSON: %w", k, err)
-			}
-			strValue = string(bs)
+		contents, err := getFieldContents(v, k, w)
+		if err != nil {
+			return "", err
 		}
 
-		if err := w.WriteField(k, strValue); err != nil {
+		if err := w.WriteField(k, contents); err != nil {
 			return "", fmt.Errorf("failed to write multipart field %s with value %v: %w", k, v, err)
 		}
 	}
@@ -274,6 +225,58 @@ func fillBuffer(buf *bytes.Buffer, params map[string]any) (string, error) {
 	}
 
 	return w.FormDataContentType(), nil
+}
+
+func getFieldContents(v any, k string, w *multipart.Writer) (string, error) {
+	// Check if the value is a simple type that can be converted directly
+	switch val := v.(type) {
+	case string:
+		return val, nil
+
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, bool:
+		return fmt.Sprint(val), nil
+
+	case InputMedia:
+		err := val.InputParams(k, w)
+		if err != nil {
+			return "", fmt.Errorf("failed to read input multipart field: %w", err)
+		}
+
+		bs, err := json.Marshal(val)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal field %s to JSON: %w", k, err)
+		}
+		return string(bs), nil
+
+	case []InputMedia:
+		for idx, item := range val {
+			err := item.InputParams(k+"_"+strconv.Itoa(idx), w)
+			if err != nil {
+				return "", fmt.Errorf("failed to read input multipart field: %w", err)
+			}
+		}
+
+		bs, err := json.Marshal(val)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal field %s to JSON: %w", k, err)
+		}
+		return string(bs), nil
+
+	case InputFile:
+		err := val.Attach(k, w)
+		if err != nil {
+			return "", fmt.Errorf("failed to attach field %s: %w", k, err)
+		}
+		return val.getValue(), nil
+
+	default:
+		// For complex types (structs, maps, slices, etc.), marshal as JSON
+		bs, err := json.Marshal(val)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal field %s to JSON: %w", k, err)
+		}
+		return string(bs), nil
+	}
 }
 
 // GetAPIURL returns the currently used API endpoint.

--- a/samples/commandBot/main.go
+++ b/samples/commandBot/main.go
@@ -73,13 +73,24 @@ func source(b *gotgbot.Bot, ctx *ext.Context) error {
 	m, err := b.SendDocument(ctx.EffectiveChat.Id,
 		gotgbot.InputFileByReader("source.go", f),
 		&gotgbot.SendDocumentOpts{
-			Caption: "Here is my source code, by file handle.",
+			Caption: "Here is my source code, sent by file handle.",
 			ReplyParameters: &gotgbot.ReplyParameters{
 				MessageId: ctx.EffectiveMessage.MessageId,
 			},
 		})
 	if err != nil {
 		return fmt.Errorf("failed to send source: %w", err)
+	}
+
+	_, err = b.SendMediaGroup(ctx.EffectiveChat.Id, []gotgbot.InputMedia{
+		gotgbot.InputMediaDocument{Media: gotgbot.InputFileByID(m.Document.FileId), Caption: "Here is my source code, sent as a mediagroup."},
+	}, &gotgbot.SendMediaGroupOpts{
+		ReplyParameters: &gotgbot.ReplyParameters{
+			MessageId: ctx.EffectiveMessage.MessageId,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to send mediagroup: %w", err)
 	}
 
 	// Or sending a file by file ID

--- a/samples/commandBot/main.go
+++ b/samples/commandBot/main.go
@@ -64,7 +64,7 @@ func main() {
 
 func source(b *gotgbot.Bot, ctx *ext.Context) error {
 	// Sending a file by file handle
-	f, err := os.Open("samples/commandBot/main.go")
+	f, err := os.Open("main.go")
 	if err != nil {
 		return fmt.Errorf("failed to open source: %w", err)
 	}

--- a/samples/commandBot/main.go
+++ b/samples/commandBot/main.go
@@ -68,6 +68,7 @@ func source(b *gotgbot.Bot, ctx *ext.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to open source: %w", err)
 	}
+	defer f.Close()
 
 	m, err := b.SendDocument(ctx.EffectiveChat.Id,
 		gotgbot.InputFileByReader("source.go", f),

--- a/samples/echoBot/main_test.go
+++ b/samples/echoBot/main_test.go
@@ -51,15 +51,19 @@ func Test_echo(t *testing.T) {
 			t.Fatalf("Only expected API calls to sendMessage, got %s", method)
 		}
 
-		sentText := params["text"]
-		if sentText != echoMessage {
+		sentText, ok := params["text"]
+		if !ok || sentText != echoMessage {
 			t.Errorf("expected text to be %s, got %s", echoMessage, sentText)
 		}
 
 		sendMessageCount++
+		text, ok := sentText.(string)
+		if !ok {
+			t.Errorf("expected text to be a string, got %T", sentText)
+		}
 		return json.Marshal(gotgbot.Message{
 			MessageId: rand.Int63(),
-			Text:      sentText.(string),
+			Text:      text,
 		})
 	})
 

--- a/samples/echoBot/main_test.go
+++ b/samples/echoBot/main_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/PaulSonOfLars/gotgbot/v2/ext"
 )
 
-type RequestFunc func(ctx context.Context, token string, method string, params map[string]string, opts *gotgbot.RequestOpts) (json.RawMessage, error)
+type RequestFunc func(ctx context.Context, token string, method string, params map[string]any, opts *gotgbot.RequestOpts) (json.RawMessage, error)
 
 // We define a TestBotClient which allows us to overwrite a single method on a per-test basis; meaning each test can verify specific behaviour.
 type TestBotClient struct {
@@ -29,7 +29,7 @@ func (b TestBotClient) FileURL(token string, tgFilePath string, opts *gotgbot.Re
 }
 
 // Define wrapper around existing RequestWithContext method.
-func (b TestBotClient) RequestWithContext(ctx context.Context, token string, method string, params map[string]string, opts *gotgbot.RequestOpts) (json.RawMessage, error) {
+func (b TestBotClient) RequestWithContext(ctx context.Context, token string, method string, params map[string]any, opts *gotgbot.RequestOpts) (json.RawMessage, error) {
 	if b.RequestFunc == nil {
 		panic("no requestfunc provided for test")
 	}
@@ -46,7 +46,7 @@ func Test_echo(t *testing.T) {
 	const echoMessage = "Hello"
 	sendMessageCount := 0
 
-	b := testBot(func(ctx context.Context, token string, method string, params map[string]string, opts *gotgbot.RequestOpts) (json.RawMessage, error) {
+	b := testBot(func(ctx context.Context, token string, method string, params map[string]any, opts *gotgbot.RequestOpts) (json.RawMessage, error) {
 		if method != "sendMessage" {
 			t.Fatalf("Only expected API calls to sendMessage, got %s", method)
 		}
@@ -59,7 +59,7 @@ func Test_echo(t *testing.T) {
 		sendMessageCount++
 		return json.Marshal(gotgbot.Message{
 			MessageId: rand.Int63(),
-			Text:      sentText,
+			Text:      sentText.(string),
 		})
 	})
 

--- a/samples/echoBot/main_test.go
+++ b/samples/echoBot/main_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/PaulSonOfLars/gotgbot/v2/ext"
 )
 
-type RequestFunc func(ctx context.Context, token string, method string, params map[string]string, data map[string]gotgbot.FileReader, opts *gotgbot.RequestOpts) (json.RawMessage, error)
+type RequestFunc func(ctx context.Context, token string, method string, params map[string]string, opts *gotgbot.RequestOpts) (json.RawMessage, error)
 
 // We define a TestBotClient which allows us to overwrite a single method on a per-test basis; meaning each test can verify specific behaviour.
 type TestBotClient struct {
@@ -29,11 +29,11 @@ func (b TestBotClient) FileURL(token string, tgFilePath string, opts *gotgbot.Re
 }
 
 // Define wrapper around existing RequestWithContext method.
-func (b TestBotClient) RequestWithContext(ctx context.Context, token string, method string, params map[string]string, data map[string]gotgbot.FileReader, opts *gotgbot.RequestOpts) (json.RawMessage, error) {
+func (b TestBotClient) RequestWithContext(ctx context.Context, token string, method string, params map[string]string, opts *gotgbot.RequestOpts) (json.RawMessage, error) {
 	if b.RequestFunc == nil {
 		panic("no requestfunc provided for test")
 	}
-	return b.RequestFunc(ctx, token, method, params, data, opts)
+	return b.RequestFunc(ctx, token, method, params, opts)
 }
 
 func NewBotClient(f RequestFunc) gotgbot.BotClient {
@@ -46,7 +46,7 @@ func Test_echo(t *testing.T) {
 	const echoMessage = "Hello"
 	sendMessageCount := 0
 
-	b := testBot(func(ctx context.Context, token string, method string, params map[string]string, data map[string]gotgbot.FileReader, opts *gotgbot.RequestOpts) (json.RawMessage, error) {
+	b := testBot(func(ctx context.Context, token string, method string, params map[string]string, opts *gotgbot.RequestOpts) (json.RawMessage, error) {
 		if method != "sendMessage" {
 			t.Fatalf("Only expected API calls to sendMessage, got %s", method)
 		}

--- a/samples/metricsBot/metricsMiddleware.go
+++ b/samples/metricsBot/metricsMiddleware.go
@@ -67,13 +67,13 @@ type metricsBotClient struct {
 
 // Define wrapper around existing RequestWithContext method.
 // Note: this is the only method that needs redefining.
-func (b metricsBotClient) RequestWithContext(ctx context.Context, token string, method string, params map[string]string, opts *gotgbot.RequestOpts) (json.RawMessage, error) {
+func (b metricsBotClient) RequestWithContext(ctx context.Context, token string, method string, params map[string]any, opts *gotgbot.RequestOpts) (json.RawMessage, error) {
 	totalRequests.WithLabelValues(method).Inc()
 	timer := prometheus.NewTimer(requestDuration.With(prometheus.Labels{
 		"api_method": method,
 	}))
 
-	val, err := b.BotClient.RequestWithContext(ctx, token, method, params, data, opts)
+	val, err := b.BotClient.RequestWithContext(ctx, token, method, params, opts)
 	timer.ObserveDuration()
 	if err != nil {
 		tgErr := &gotgbot.TelegramError{}

--- a/samples/metricsBot/metricsMiddleware.go
+++ b/samples/metricsBot/metricsMiddleware.go
@@ -67,7 +67,7 @@ type metricsBotClient struct {
 
 // Define wrapper around existing RequestWithContext method.
 // Note: this is the only method that needs redefining.
-func (b metricsBotClient) RequestWithContext(ctx context.Context, token string, method string, params map[string]string, data map[string]gotgbot.FileReader, opts *gotgbot.RequestOpts) (json.RawMessage, error) {
+func (b metricsBotClient) RequestWithContext(ctx context.Context, token string, method string, params map[string]string, opts *gotgbot.RequestOpts) (json.RawMessage, error) {
 	totalRequests.WithLabelValues(method).Inc()
 	timer := prometheus.NewTimer(requestDuration.With(prometheus.Labels{
 		"api_method": method,

--- a/samples/middlewareBot/middleware.go
+++ b/samples/middlewareBot/middleware.go
@@ -19,7 +19,7 @@ type sendWithoutReplyBotClient struct {
 
 // Define wrapper around existing RequestWithContext method.
 // Note: this is the only method that needs redefining.
-func (b sendWithoutReplyBotClient) RequestWithContext(ctx context.Context, token string, method string, params map[string]string, data map[string]gotgbot.FileReader, opts *gotgbot.RequestOpts) (json.RawMessage, error) {
+func (b sendWithoutReplyBotClient) RequestWithContext(ctx context.Context, token string, method string, params map[string]string, opts *gotgbot.RequestOpts) (json.RawMessage, error) {
 	// For all sendable methods, we want to allow sending if the message has been deleted.
 	// So, we edit the params to allow for that.
 	// We also log this, for the sake of the example. :)

--- a/samples/middlewareBot/middleware.go
+++ b/samples/middlewareBot/middleware.go
@@ -19,7 +19,7 @@ type sendWithoutReplyBotClient struct {
 
 // Define wrapper around existing RequestWithContext method.
 // Note: this is the only method that needs redefining.
-func (b sendWithoutReplyBotClient) RequestWithContext(ctx context.Context, token string, method string, params map[string]string, opts *gotgbot.RequestOpts) (json.RawMessage, error) {
+func (b sendWithoutReplyBotClient) RequestWithContext(ctx context.Context, token string, method string, params map[string]any, opts *gotgbot.RequestOpts) (json.RawMessage, error) {
 	// For all sendable methods, we want to allow sending if the message has been deleted.
 	// So, we edit the params to allow for that.
 	// We also log this, for the sake of the example. :)
@@ -29,7 +29,7 @@ func (b sendWithoutReplyBotClient) RequestWithContext(ctx context.Context, token
 	}
 
 	// Call the next bot client instance in the middleware chain.
-	val, err := b.BotClient.RequestWithContext(ctx, token, method, params, data, opts)
+	val, err := b.BotClient.RequestWithContext(ctx, token, method, params, opts)
 	if err != nil {
 		// Middlewares can also be used to increase error visibility, in case they aren't logged elsewhere.
 		log.Println("warning, got an error:", err)

--- a/scripts/generate/common.go
+++ b/scripts/generate/common.go
@@ -86,7 +86,9 @@ func isTgArray(s string) bool {
 }
 
 func isPointer(s string) bool {
-	return strings.HasPrefix(s, "*")
+	return strings.HasPrefix(s, "*") ||
+		s == tgTypeInputFile || s == typeInputFileOrString || s == typeInputString ||
+		s == tgTypeInputMedia || s == tgTypeInputPaidMedia
 }
 
 func isArray(s string) bool {

--- a/scripts/generate/methods.go
+++ b/scripts/generate/methods.go
@@ -7,9 +7,7 @@ import (
 )
 
 var (
-	inputFileBranchTmpl        = template.Must(template.New("inputFileBranch").Parse(inputFileBranch))
-	inputParamsBranchTmpl      = template.Must(template.New("inputParamsBranch").Parse(inputParamsBranch))
-	inputArrayParamsBranchTmpl = template.Must(template.New("inputArrayParamsBranch").Parse(inputArrayParamsBranch))
+	inputFileBranchTmpl = template.Must(template.New("inputFileBranch").Parse(inputFileBranch))
 )
 
 func generateMethods(d APIDescription) error {
@@ -24,7 +22,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 )
 `)
 
@@ -310,35 +307,6 @@ func stringComplexField(d APIDescription, f Field, fieldType string, goParam str
 		return bd.String(), true, nil
 	}
 
-	hasData, err := fieldContainsInputFile(d, f)
-	if err != nil {
-		return "", false, fmt.Errorf("failed to check if field %s contains inputfiles: %w", f.Name, err)
-	}
-	if hasData {
-		// If the field contains data, it cannot be simply json marshalled, so we our own methods to include it.
-		// We need to do this slightly differently if we are dealing with arrays or not.
-		if isArray(fieldType) {
-			err = inputArrayParamsBranchTmpl.Execute(&bd, readerBranchesData{
-				GoParam:       goParam,
-				DefaultReturn: defaultRetVal,
-				Name:          f.Name,
-			})
-			if err != nil {
-				return "", false, fmt.Errorf("failed to execute inputmedia/inputsticker array branch template: %w", err)
-			}
-		} else {
-			err = inputParamsBranchTmpl.Execute(&bd, readerBranchesData{
-				GoParam:       goParam,
-				DefaultReturn: defaultRetVal,
-				Name:          f.Name,
-			})
-			if err != nil {
-				return "", false, fmt.Errorf("failed to execute inputmedia/inputsticker branch template: %w", err)
-			}
-		}
-		return bd.String(), true, nil
-	}
-
 	// If we aren't sending data, then we can just do it regularly.
 	bd.WriteString("\n	v[\"" + f.Name + "\"] = " + goParam)
 
@@ -438,19 +406,3 @@ if {{.GoParam}} != nil {
 	}
 	v["{{.Name}}"] = {{.GoParam}}.getValue()
 }`
-
-const inputParamsBranch = `
-err := {{.GoParam}}.InputParams("{{.Name}}" , data)
-if err != nil {
-	return {{.DefaultReturn}}, fmt.Errorf("failed to attach input file {{.Name}}: %w", err)
-}
-v["{{.Name}}"] = {{.GoParam}}`
-
-const inputArrayParamsBranch = `
-for idx, im := range {{.GoParam}} {
-	err := im.InputParams("{{.Name}}" + strconv.Itoa(idx), data)
-	if err != nil {
-		return {{.DefaultReturn}}, fmt.Errorf("failed to attach input field for list item %d {{.Name}}: %w", idx, err)
-	}
-}
-v["{{.Name}}"] = {{.GoParam}}`

--- a/scripts/generate/methods.go
+++ b/scripts/generate/methods.go
@@ -3,11 +3,6 @@ package main
 import (
 	"fmt"
 	"strings"
-	"text/template"
-)
-
-var (
-	inputFileBranchTmpl = template.Must(template.New("inputFileBranch").Parse(inputFileBranch))
 )
 
 func generateMethods(d APIDescription) error {
@@ -21,7 +16,6 @@ package gotgbot
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 )
 `)
 
@@ -72,7 +66,7 @@ func generateMethodDef(d APIDescription, tgMethod MethodDescription) (string, er
 	defaultRetVals := strings.Join(getDefaultReturnVals(d, retTypes), ", ")
 
 	// Generate method contents, setting up values in expected format
-	valueGen, hasData, err := tgMethod.argsToValues(d, tgMethod.Name, defaultRetVals)
+	valueGen, err := tgMethod.argsToValues(d, tgMethod.Name, defaultRetVals)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate url values for method %s: %w", tgMethod.Name, err)
 	}
@@ -104,15 +98,10 @@ func generateMethodDef(d APIDescription, tgMethod MethodDescription) (string, er
 	method.WriteString("\n")
 
 	// If sending data, we need to do it over POST
-	if hasData {
-		method.WriteString("\nr, err := bot.RequestWithContext(ctx, \"" + tgMethod.Name + "\", v, data, reqOpts)")
-	} else {
-		method.WriteString("\nr, err := bot.RequestWithContext(ctx, \"" + tgMethod.Name + "\", v, nil, reqOpts)")
-	}
-
-	method.WriteString("\n	if err != nil {")
-	method.WriteString("\n		return " + defaultRetVals + ", err")
-	method.WriteString("\n	}")
+	method.WriteString("\nr, err := bot.RequestWithContext(ctx, \"" + tgMethod.Name + "\", v, reqOpts)")
+	method.WriteString("\nif err != nil {")
+	method.WriteString("\n	return " + defaultRetVals + ", err")
+	method.WriteString("\n}")
 	method.WriteString("\n")
 
 	method.WriteString(returnGen)
@@ -192,8 +181,7 @@ func (m MethodDescription) description(d APIDescription) (string, error) {
 	return description.String(), nil
 }
 
-func (m MethodDescription) argsToValues(d APIDescription, methodName string, defaultRetVal string) (string, bool, error) {
-	hasData := false
+func (m MethodDescription) argsToValues(d APIDescription, methodName string, defaultRetVal string) (string, error) {
 	bd := strings.Builder{}
 
 	var optionals []Field
@@ -204,40 +192,34 @@ func (m MethodDescription) argsToValues(d APIDescription, methodName string, def
 			continue
 		}
 
-		contents, data, err := generateValue(d, methodName, f, goParam, defaultRetVal)
+		contents, err := generateValue(d, methodName, f, goParam)
 		if err != nil {
-			return "", false, err
+			return "", err
 		}
 		bd.WriteString(contents)
-		hasData = hasData || data
 	}
 
 	if len(optionals) > 0 {
 		bd.WriteString("\nif opts != nil {")
 		for _, f := range optionals {
 			goParam := "opts." + snakeToTitle(f.Name)
-			contents, data, err := generateValue(d, methodName, f, goParam, defaultRetVal)
+			contents, err := generateValue(d, methodName, f, goParam)
 			if err != nil {
-				return "", false, err
+				return "", err
 			}
 
 			bd.WriteString(contents)
-			hasData = hasData || data
 		}
 		bd.WriteString("\n}")
 	}
 
-	if hasData {
-		return "\ndata := map[string]FileReader{}" + bd.String(), true, nil
-	}
-
-	return bd.String(), false, nil
+	return bd.String(), nil
 }
 
-func generateValue(d APIDescription, methodName string, f Field, goParam string, defaultRetVal string) (string, bool, error) {
+func generateValue(d APIDescription, methodName string, f Field, goParam string) (string, error) {
 	fieldType, err := f.getPreferredType(d)
 	if err != nil {
-		return "", false, fmt.Errorf("failed to get preferred type: %w", err)
+		return "", fmt.Errorf("failed to get preferred type: %w", err)
 	}
 
 	stringer := goTypeStringer(fieldType)
@@ -257,60 +239,31 @@ func generateValue(d APIDescription, methodName string, f Field, goParam string,
 if opts.Type == "quiz" {
 	// correct_option_id should always be set when the type is "quiz" - it doesnt need to be set for type "regular".
 	%s
-}`, fmt.Sprintf(`v["%s"] = %s`, f.Name, goParam)), false, nil
+}`, fmt.Sprintf(`v["%s"] = %s`, f.Name, goParam)), nil
 				}
 
-				return fmt.Sprintf("\nv[\"%s\"] = %s", f.Name, goParam), false, nil
+				return fmt.Sprintf("\nv[\"%s\"] = %s", f.Name, goParam), nil
 			}
 
 			if isPointer(fieldType) {
 				return fmt.Sprintf(`
 if %s != nil {
 	v["%s"] = %s
-}`, goParam, f.Name, goParam), false, nil
+}`, goParam, f.Name, goParam), nil
 			}
 		}
 
-		return fmt.Sprintf("\nv[\"%s\"] = %s", f.Name, goParam), false, nil
-	}
-
-	complexString, hasData, err := stringComplexField(d, f, fieldType, goParam, defaultRetVal)
-	if err != nil {
-		return "", false, err
+		return fmt.Sprintf("\nv[\"%s\"] = %s", f.Name, goParam), nil
 	}
 
 	if isPointer(fieldType) || isArray(fieldType) || fieldType == typeReplyMarkup {
 		return fmt.Sprintf(`
 if %s != nil {
-%s
-}`, goParam, strings.TrimSpace(complexString)), hasData, nil
+  v["%s"] = %s
+}`, goParam, f.Name, goParam), nil
 	}
 
-	return complexString, hasData, nil
-}
-
-// stringComplexField allows us to string any complex types.
-// This includes custom tg structs, as well anything which might contain data.
-func stringComplexField(d APIDescription, f Field, fieldType string, goParam string, defaultRetVal string) (string, bool, error) {
-	bd := strings.Builder{}
-
-	// Special case for InputFiles.
-	if fieldType == tgTypeInputFile || fieldType == typeInputFileOrString {
-		err := inputFileBranchTmpl.Execute(&bd, readerBranchesData{
-			GoParam:       goParam,
-			DefaultReturn: defaultRetVal,
-			Name:          f.Name,
-		})
-		if err != nil {
-			return "", false, fmt.Errorf("failed to execute branch reader template: %w", err)
-		}
-		return bd.String(), true, nil
-	}
-
-	// If we aren't sending data, then we can just do it regularly.
-	bd.WriteString("\n	v[\"" + f.Name + "\"] = " + goParam)
-
-	return bd.String(), false, nil
+	return "\n	v[\"" + f.Name + "\"] = " + goParam, nil
 }
 
 func getRetVarName(retType string) string {
@@ -390,19 +343,3 @@ func (m MethodDescription) getOptionalsStruct(d APIDescription) (string, error) 
 
 	return optionalsStructBuilder.String(), nil
 }
-
-type readerBranchesData struct {
-	GoParam       string
-	DefaultReturn string
-	Name          string
-}
-
-// TODO: Make sure this doesn't allow strings, ONLY readers!
-const inputFileBranch = `
-if {{.GoParam}} != nil {
-	err := {{.GoParam}}.Attach("{{.Name}}", data)
-	if err != nil {
-		return {{.DefaultReturn}}, fmt.Errorf("failed to attach '{{.Name}}' input file: %w", err)
-	}
-	v["{{.Name}}"] = {{.GoParam}}.getValue()
-}`

--- a/scripts/generate/methods.go
+++ b/scripts/generate/methods.go
@@ -7,9 +7,8 @@ import (
 )
 
 var (
-	inputFileBranchTmpl        = template.Must(template.New("inputFileBranch").Parse(inputFileBranch))
-	inputParamsBranchTmpl      = template.Must(template.New("inputParamsBranch").Parse(inputParamsBranch))
-	inputArrayParamsBranchTmpl = template.Must(template.New("inputArrayParamsBranch").Parse(inputArrayParamsBranch))
+	inputFileBranchTmpl   = template.Must(template.New("inputFileBranch").Parse(inputFileBranch))
+	inputParamsBranchTmpl = template.Must(template.New("inputParamsBranch").Parse(inputParamsBranch))
 )
 
 func generateMethods(d APIDescription) error {
@@ -23,7 +22,6 @@ package gotgbot
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"context"
 )
 `)
@@ -96,7 +94,7 @@ func generateMethodDef(d APIDescription, tgMethod MethodDescription) (string, er
 
 	method.WriteString("\n// " + strings.Title(tgMethod.Name) + "WithContext is the same as Bot." + strings.Title(tgMethod.Name) + ", but with a context.Context parameter")
 	method.WriteString("\nfunc (bot *Bot) " + strings.Title(tgMethod.Name) + "WithContext(ctx context.Context, " + joinedArgs + ") (" + joinedRetTypes + ", error) {")
-	method.WriteString("\n	v := map[string]string{}")
+	method.WriteString("\n	v := map[string]any{}")
 	method.WriteString(valueGen)
 	method.WriteString("\n")
 
@@ -260,25 +258,21 @@ func generateValue(d APIDescription, methodName string, f Field, goParam string,
 if opts.Type == "quiz" {
 	// correct_option_id should always be set when the type is "quiz" - it doesnt need to be set for type "regular".
 	%s
-}`, addURLParam(f, stringer, goParam)), false, nil
+}`, fmt.Sprintf(`v["%s"] = %s`, f.Name, goParam)), false, nil
 				}
 
-				// TODO: Simplify this to avoid ANY unrequired default values instead of just int/float?
-				return fmt.Sprintf(`
-if %s != %s {
-	%s
-}`, goParam, getDefaultTypeVal(d, fieldType), addURLParam(f, stringer, goParam)), false, nil
+				return fmt.Sprintf("\nv[\"%s\"] = %s", f.Name, goParam), false, nil
 			}
 
 			if isPointer(fieldType) {
 				return fmt.Sprintf(`
 if %s != nil {
 	v["%s"] = %s
-}`, goParam, f.Name, fmt.Sprintf(goTypeStringer(fieldType), goParam)), false, nil
+}`, goParam, f.Name, goParam), false, nil
 			}
 		}
 
-		return "\n" + addURLParam(f, stringer, goParam), false, nil
+		return fmt.Sprintf("\nv[\"%s\"] = %s", f.Name, goParam), false, nil
 	}
 
 	complexString, hasData, err := stringComplexField(d, f, fieldType, goParam, defaultRetVal)
@@ -322,14 +316,7 @@ func stringComplexField(d APIDescription, f Field, fieldType string, goParam str
 		// If the field contains data, it cannot be simply json marshalled, so we our own methods to include it.
 		// We need to do this slightly differently if we are dealing with arrays or not.
 		if isArray(fieldType) {
-			err = inputArrayParamsBranchTmpl.Execute(&bd, readerBranchesData{
-				GoParam:       goParam,
-				DefaultReturn: defaultRetVal,
-				Name:          f.Name,
-			})
-			if err != nil {
-				return "", false, fmt.Errorf("failed to execute inputmedia/inputsticker array branch template: %w", err)
-			}
+			bd.WriteString(fmt.Sprintf("\nv[\"%s\"] = %s", f.Name, goParam))
 		} else {
 			err = inputParamsBranchTmpl.Execute(&bd, readerBranchesData{
 				GoParam:       goParam,
@@ -344,11 +331,7 @@ func stringComplexField(d APIDescription, f Field, fieldType string, goParam str
 	}
 
 	// If we aren't sending data, then we can just do it regularly.
-	bd.WriteString("\n	bs, err := json.Marshal(" + goParam + ")")
-	bd.WriteString("\n	if err != nil {")
-	bd.WriteString("\n		return " + defaultRetVal + ", fmt.Errorf(\"failed to marshal field " + f.Name + ": %w\", err)")
-	bd.WriteString("\n	}")
-	bd.WriteString("\n	v[\"" + f.Name + "\"] = string(bs)")
+	bd.WriteString("\n	v[\"" + f.Name + "\"] = " + goParam)
 
 	return bd.String(), false, nil
 }
@@ -457,18 +440,3 @@ if err != nil {
 	return {{.DefaultReturn}}, fmt.Errorf("failed to marshal field {{.Name}}: %w", err)
 }
 v["{{.Name}}"] = string(inputBs)`
-
-const inputArrayParamsBranch = `
-var rawList []json.RawMessage
-for idx, im := range {{.GoParam}} {
-	inputBs, err := im.InputParams("{{.Name}}" + strconv.Itoa(idx), data)
-	if err != nil {
-		return {{.DefaultReturn}}, fmt.Errorf("failed to marshal list item %d for field {{.Name}}: %w", idx, err)
-	}
-	rawList = append(rawList, inputBs)
-}
-bs, err := json.Marshal(rawList)
-if err != nil {
-	return {{.DefaultReturn}}, fmt.Errorf("failed to marshal raw json list for field: {{.Name}} %w", err)
-}
-v["{{.Name}}"] = string(bs)`

--- a/scripts/generate/methods.go
+++ b/scripts/generate/methods.go
@@ -336,10 +336,6 @@ func stringComplexField(d APIDescription, f Field, fieldType string, goParam str
 	return bd.String(), false, nil
 }
 
-func addURLParam(f Field, stringer string, goParam string) string {
-	return fmt.Sprintf(`v["%s"] = %s`, f.Name, fmt.Sprintf(stringer, goParam))
-}
-
 func getRetVarName(retType string) string {
 	retType = stripPointersAndArrays(retType)
 

--- a/scripts/generate/methods.go
+++ b/scripts/generate/methods.go
@@ -435,8 +435,8 @@ if {{.GoParam}} != nil {
 }`
 
 const inputParamsBranch = `
-inputBs, err := {{.GoParam}}.InputParams("{{.Name}}" , data)
+err := {{.GoParam}}.InputParams("{{.Name}}" , data)
 if err != nil {
 	return {{.DefaultReturn}}, fmt.Errorf("failed to marshal field {{.Name}}: %w", err)
 }
-v["{{.Name}}"] = string(inputBs)`
+v["{{.Name}}"] = {{.GoParam}}`

--- a/scripts/generate/methods.go
+++ b/scripts/generate/methods.go
@@ -62,11 +62,8 @@ func generateMethodDef(d APIDescription, tgMethod MethodDescription) (string, er
 		return "", fmt.Errorf("failed to generate method description for %s: %w", tgMethod.Name, err)
 	}
 
-	// Generate list of default return values (for error handling).
-	defaultRetVals := strings.Join(getDefaultReturnVals(d, retTypes), ", ")
-
 	// Generate method contents, setting up values in expected format
-	valueGen, err := tgMethod.argsToValues(d, tgMethod.Name, defaultRetVals)
+	valueGen, err := tgMethod.argsToValues(d, tgMethod.Name)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate url values for method %s: %w", tgMethod.Name, err)
 	}
@@ -100,7 +97,7 @@ func generateMethodDef(d APIDescription, tgMethod MethodDescription) (string, er
 	// If sending data, we need to do it over POST
 	method.WriteString("\nr, err := bot.RequestWithContext(ctx, \"" + tgMethod.Name + "\", v, reqOpts)")
 	method.WriteString("\nif err != nil {")
-	method.WriteString("\n	return " + defaultRetVals + ", err")
+	method.WriteString("\n	return " + strings.Join(getDefaultReturnVals(d, retTypes), ", ") + ", err")
 	method.WriteString("\n}")
 	method.WriteString("\n")
 
@@ -181,7 +178,7 @@ func (m MethodDescription) description(d APIDescription) (string, error) {
 	return description.String(), nil
 }
 
-func (m MethodDescription) argsToValues(d APIDescription, methodName string, defaultRetVal string) (string, error) {
+func (m MethodDescription) argsToValues(d APIDescription, methodName string) (string, error) {
 	bd := strings.Builder{}
 
 	var optionals []Field

--- a/scripts/generate/methods.go
+++ b/scripts/generate/methods.go
@@ -7,8 +7,9 @@ import (
 )
 
 var (
-	inputFileBranchTmpl   = template.Must(template.New("inputFileBranch").Parse(inputFileBranch))
-	inputParamsBranchTmpl = template.Must(template.New("inputParamsBranch").Parse(inputParamsBranch))
+	inputFileBranchTmpl        = template.Must(template.New("inputFileBranch").Parse(inputFileBranch))
+	inputParamsBranchTmpl      = template.Must(template.New("inputParamsBranch").Parse(inputParamsBranch))
+	inputArrayParamsBranchTmpl = template.Must(template.New("inputArrayParamsBranch").Parse(inputArrayParamsBranch))
 )
 
 func generateMethods(d APIDescription) error {
@@ -20,9 +21,10 @@ func generateMethods(d APIDescription) error {
 package gotgbot
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	"context"
+	"strconv"
 )
 `)
 
@@ -316,7 +318,14 @@ func stringComplexField(d APIDescription, f Field, fieldType string, goParam str
 		// If the field contains data, it cannot be simply json marshalled, so we our own methods to include it.
 		// We need to do this slightly differently if we are dealing with arrays or not.
 		if isArray(fieldType) {
-			bd.WriteString(fmt.Sprintf("\nv[\"%s\"] = %s", f.Name, goParam))
+			err = inputArrayParamsBranchTmpl.Execute(&bd, readerBranchesData{
+				GoParam:       goParam,
+				DefaultReturn: defaultRetVal,
+				Name:          f.Name,
+			})
+			if err != nil {
+				return "", false, fmt.Errorf("failed to execute inputmedia/inputsticker array branch template: %w", err)
+			}
 		} else {
 			err = inputParamsBranchTmpl.Execute(&bd, readerBranchesData{
 				GoParam:       goParam,
@@ -433,6 +442,15 @@ if {{.GoParam}} != nil {
 const inputParamsBranch = `
 err := {{.GoParam}}.InputParams("{{.Name}}" , data)
 if err != nil {
-	return {{.DefaultReturn}}, fmt.Errorf("failed to marshal field {{.Name}}: %w", err)
+	return {{.DefaultReturn}}, fmt.Errorf("failed to attach input file {{.Name}}: %w", err)
+}
+v["{{.Name}}"] = {{.GoParam}}`
+
+const inputArrayParamsBranch = `
+for idx, im := range {{.GoParam}} {
+	err := im.InputParams("{{.Name}}" + strconv.Itoa(idx), data)
+	if err != nil {
+		return {{.DefaultReturn}}, fmt.Errorf("failed to attach input field for list item %d {{.Name}}: %w", idx, err)
+	}
 }
 v["{{.Name}}"] = {{.GoParam}}`

--- a/scripts/generate/types.go
+++ b/scripts/generate/types.go
@@ -26,6 +26,7 @@ package gotgbot
 import (
 	"encoding/json"
 	"fmt"
+	"mime/multipart"
 )
 `)
 
@@ -483,7 +484,7 @@ func generateGenericInterfaceType(d APIDescription, name string, subtypes []Type
 	}
 	if hasInputFile {
 		bd.WriteString("\n// InputParams allows for uploading attachments with files.")
-		bd.WriteString("\nInputParams(string, map[string]FileReader) error")
+		bd.WriteString("\nInputParams(string, *multipart.Writer) error")
 	}
 
 	// Only require merge funcs when there are common fields, one is a constant, and all types match across types.
@@ -756,16 +757,16 @@ type inputParamsMethodData struct {
 }
 
 const inputParamsMethod = `
-func (v {{.Type}}) InputParams(mediaName string, data map[string]FileReader) error {
+func (v {{.Type}}) InputParams(mediaName string, w *multipart.Writer) error {
 	if v.{{.Field}} != nil {
-		err := v.{{.Field}}.Attach(mediaName, data)
+		err := v.{{.Field}}.Attach(mediaName, w)
 		if err != nil {
 			return fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
 		}
 	}
 	{{ if .Thumbnail }}
 	if v.Thumbnail != nil {
-		err := v.Thumbnail.Attach(mediaName+"-thumbnail", data)
+		err := v.Thumbnail.Attach(mediaName+"-thumbnail", w)
 		if err != nil {
 			return fmt.Errorf("failed to attach 'thumbnail' input file for %s: %w", mediaName, err)
 		}

--- a/scripts/generate/types.go
+++ b/scripts/generate/types.go
@@ -117,22 +117,6 @@ func enforceTypeAssertion(name string, subtypes []TypeDescription) string {
 	return bd.String()
 }
 
-// fieldContainsInputFile checks whether the field's type contains any inputfiles, and thus might be used to send data.
-func fieldContainsInputFile(d APIDescription, field Field) (bool, error) {
-	goType, err := field.getPreferredType(d)
-	if err != nil {
-		return false, err
-	}
-	cleanName := strings.TrimPrefix(goType, "[]")
-	tgType, ok := d.Types[cleanName]
-	if !ok {
-		return false, nil
-	}
-
-	ok, _, err = containsInputFile(d, tgType, map[string]bool{})
-	return ok, err
-}
-
 // containsInputFile returns a boolean to indicate whether or not tgType contains an InputFile.
 // If true, it also returns the field name of that inputfile.
 func containsInputFile(d APIDescription, tgType TypeDescription, checked map[string]bool) (bool, string, error) {

--- a/scripts/generate/types.go
+++ b/scripts/generate/types.go
@@ -499,7 +499,7 @@ func generateGenericInterfaceType(d APIDescription, name string, subtypes []Type
 	}
 	if hasInputFile {
 		bd.WriteString("\n// InputParams allows for uploading attachments with files.")
-		bd.WriteString("\nInputParams(string, map[string]FileReader) ([]byte, error)")
+		bd.WriteString("\nInputParams(string, map[string]FileReader) error")
 	}
 
 	// Only require merge funcs when there are common fields, one is a constant, and all types match across types.
@@ -772,22 +772,22 @@ type inputParamsMethodData struct {
 }
 
 const inputParamsMethod = `
-func (v {{.Type}}) InputParams(mediaName string, data map[string]FileReader) ([]byte, error) {
+func (v {{.Type}}) InputParams(mediaName string, data map[string]FileReader) error {
 	if v.{{.Field}} != nil {
 		err := v.{{.Field}}.Attach(mediaName, data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
+			return fmt.Errorf("failed to attach input file for %s: %w", mediaName, err)
 		}
 	}
 	{{ if .Thumbnail }}
 	if v.Thumbnail != nil {
 		err := v.Thumbnail.Attach(mediaName+"-thumbnail", data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to attach 'thumbnail' input file for %s: %w", mediaName, err)
+			return fmt.Errorf("failed to attach 'thumbnail' input file for %s: %w", mediaName, err)
 		}
 	}
 	{{- end }}
 
-	return json.Marshal(v)
+	return nil
 }
 `


### PR DESCRIPTION
# What

It should be possible to simplify our existing requests code to something slightly more reasonable, removing the existing `application/json` logic. We also change the RequestParams from `params map[string]string` to `params map[string]any`.

This should help by reducing the number of json.marshal calls, thus hopefully reducing CPU and memory usage.

# Impact

- Are your changes backwards compatible? No. This changes method definitions and types.
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
