### PR TITLE
Reduce request size by skipping empty fields

### DIFF
--- a/custom_helpers.go
+++ b/custom_helpers.go
@@ -154,3 +154,12 @@ func unmarshalMaybeInaccessibleMessage(d json.RawMessage) (MaybeInaccessibleMess
 	}
 	return s, nil
 }
+
+// addIfValueNotZero is a helper method to avoid having thousands of if checks for each optional value.
+func addIfValueNotZero[T any](m map[string]any, k string, v T, isZero bool) {
+	if isZero {
+		return
+	}
+
+	m[k] = v
+}

--- a/gen_methods.go
+++ b/gen_methods.go
@@ -74,10 +74,10 @@ func (bot *Bot) AnswerCallbackQueryWithContext(ctx context.Context, callbackQuer
 	v := map[string]any{}
 	v["callback_query_id"] = callbackQueryId
 	if opts != nil {
-		v["text"] = opts.Text
-		v["show_alert"] = opts.ShowAlert
-		v["url"] = opts.Url
-		v["cache_time"] = opts.CacheTime
+		addIfValueNotZero(v, "text", opts.Text, opts.Text == "")
+		addIfValueNotZero(v, "show_alert", opts.ShowAlert, opts.ShowAlert == false)
+		addIfValueNotZero(v, "url", opts.Url, opts.Url == "")
+		addIfValueNotZero(v, "cache_time", opts.CacheTime, opts.CacheTime == 0)
 	}
 
 	var reqOpts *RequestOpts
@@ -123,16 +123,12 @@ func (bot *Bot) AnswerInlineQuery(inlineQueryId string, results []InlineQueryRes
 func (bot *Bot) AnswerInlineQueryWithContext(ctx context.Context, inlineQueryId string, results []InlineQueryResult, opts *AnswerInlineQueryOpts) (bool, error) {
 	v := map[string]any{}
 	v["inline_query_id"] = inlineQueryId
-	if results != nil {
-		v["results"] = results
-	}
+	v["results"] = results
 	if opts != nil {
-		v["cache_time"] = opts.CacheTime
-		v["is_personal"] = opts.IsPersonal
-		v["next_offset"] = opts.NextOffset
-		if opts.Button != nil {
-			v["button"] = opts.Button
-		}
+		addIfValueNotZero(v, "cache_time", opts.CacheTime, opts.CacheTime == 0)
+		addIfValueNotZero(v, "is_personal", opts.IsPersonal, opts.IsPersonal == false)
+		addIfValueNotZero(v, "next_offset", opts.NextOffset, opts.NextOffset == "")
+		addIfValueNotZero(v, "button", opts.Button, opts.Button == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -173,7 +169,7 @@ func (bot *Bot) AnswerPreCheckoutQueryWithContext(ctx context.Context, preChecko
 	v["pre_checkout_query_id"] = preCheckoutQueryId
 	v["ok"] = ok
 	if opts != nil {
-		v["error_message"] = opts.ErrorMessage
+		addIfValueNotZero(v, "error_message", opts.ErrorMessage, opts.ErrorMessage == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -216,10 +212,8 @@ func (bot *Bot) AnswerShippingQueryWithContext(ctx context.Context, shippingQuer
 	v["shipping_query_id"] = shippingQueryId
 	v["ok"] = ok
 	if opts != nil {
-		if opts.ShippingOptions != nil {
-			v["shipping_options"] = opts.ShippingOptions
-		}
-		v["error_message"] = opts.ErrorMessage
+		addIfValueNotZero(v, "shipping_options", opts.ShippingOptions, opts.ShippingOptions == nil)
+		addIfValueNotZero(v, "error_message", opts.ErrorMessage, opts.ErrorMessage == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -332,7 +326,7 @@ func (bot *Bot) ApproveSuggestedPostWithContext(ctx context.Context, chatId int6
 	v["chat_id"] = chatId
 	v["message_id"] = messageId
 	if opts != nil {
-		v["send_date"] = opts.SendDate
+		addIfValueNotZero(v, "send_date", opts.SendDate, opts.SendDate == 0)
 	}
 
 	var reqOpts *RequestOpts
@@ -375,8 +369,8 @@ func (bot *Bot) BanChatMemberWithContext(ctx context.Context, chatId int64, user
 	v["chat_id"] = chatId
 	v["user_id"] = userId
 	if opts != nil {
-		v["until_date"] = opts.UntilDate
-		v["revoke_messages"] = opts.RevokeMessages
+		addIfValueNotZero(v, "until_date", opts.UntilDate, opts.UntilDate == 0)
+		addIfValueNotZero(v, "revoke_messages", opts.RevokeMessages, opts.RevokeMessages == false)
 	}
 
 	var reqOpts *RequestOpts
@@ -617,29 +611,19 @@ func (bot *Bot) CopyMessageWithContext(ctx context.Context, chatId int64, fromCh
 	v["from_chat_id"] = fromChatId
 	v["message_id"] = messageId
 	if opts != nil {
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["video_start_timestamp"] = opts.VideoStartTimestamp
-		if opts.Caption != nil {
-			v["caption"] = opts.Caption
-		}
-		v["parse_mode"] = opts.ParseMode
-		if opts.CaptionEntities != nil {
-			v["caption_entities"] = opts.CaptionEntities
-		}
-		v["show_caption_above_media"] = opts.ShowCaptionAboveMedia
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
-		if opts.SuggestedPostParameters != nil {
-			v["suggested_post_parameters"] = opts.SuggestedPostParameters
-		}
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
-		if opts.ReplyMarkup != nil {
-			v["reply_markup"] = opts.ReplyMarkup
-		}
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		addIfValueNotZero(v, "video_start_timestamp", opts.VideoStartTimestamp, opts.VideoStartTimestamp == 0)
+		addIfValueNotZero(v, "caption", opts.Caption, opts.Caption == nil)
+		addIfValueNotZero(v, "parse_mode", opts.ParseMode, opts.ParseMode == "")
+		addIfValueNotZero(v, "caption_entities", opts.CaptionEntities, opts.CaptionEntities == nil)
+		addIfValueNotZero(v, "show_caption_above_media", opts.ShowCaptionAboveMedia, opts.ShowCaptionAboveMedia == false)
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "allow_paid_broadcast", opts.AllowPaidBroadcast, opts.AllowPaidBroadcast == false)
+		addIfValueNotZero(v, "suggested_post_parameters", opts.SuggestedPostParameters, opts.SuggestedPostParameters == nil)
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
+		addIfValueNotZero(v, "reply_markup", opts.ReplyMarkup, opts.ReplyMarkup == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -688,15 +672,13 @@ func (bot *Bot) CopyMessagesWithContext(ctx context.Context, chatId int64, fromC
 	v := map[string]any{}
 	v["chat_id"] = chatId
 	v["from_chat_id"] = fromChatId
-	if messageIds != nil {
-		v["message_ids"] = messageIds
-	}
+	v["message_ids"] = messageIds
 	if opts != nil {
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["remove_caption"] = opts.RemoveCaption
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "remove_caption", opts.RemoveCaption, opts.RemoveCaption == false)
 	}
 
 	var reqOpts *RequestOpts
@@ -741,10 +723,10 @@ func (bot *Bot) CreateChatInviteLinkWithContext(ctx context.Context, chatId int6
 	v := map[string]any{}
 	v["chat_id"] = chatId
 	if opts != nil {
-		v["name"] = opts.Name
-		v["expire_date"] = opts.ExpireDate
-		v["member_limit"] = opts.MemberLimit
-		v["creates_join_request"] = opts.CreatesJoinRequest
+		addIfValueNotZero(v, "name", opts.Name, opts.Name == "")
+		addIfValueNotZero(v, "expire_date", opts.ExpireDate, opts.ExpireDate == 0)
+		addIfValueNotZero(v, "member_limit", opts.MemberLimit, opts.MemberLimit == 0)
+		addIfValueNotZero(v, "creates_join_request", opts.CreatesJoinRequest, opts.CreatesJoinRequest == false)
 	}
 
 	var reqOpts *RequestOpts
@@ -787,7 +769,7 @@ func (bot *Bot) CreateChatSubscriptionInviteLinkWithContext(ctx context.Context,
 	v["subscription_period"] = subscriptionPeriod
 	v["subscription_price"] = subscriptionPrice
 	if opts != nil {
-		v["name"] = opts.Name
+		addIfValueNotZero(v, "name", opts.Name, opts.Name == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -830,8 +812,8 @@ func (bot *Bot) CreateForumTopicWithContext(ctx context.Context, chatId int64, n
 	v["chat_id"] = chatId
 	v["name"] = name
 	if opts != nil {
-		v["icon_color"] = opts.IconColor
-		v["icon_custom_emoji_id"] = opts.IconCustomEmojiId
+		addIfValueNotZero(v, "icon_color", opts.IconColor, opts.IconColor == 0)
+		addIfValueNotZero(v, "icon_custom_emoji_id", opts.IconCustomEmojiId, opts.IconCustomEmojiId == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -908,29 +890,25 @@ func (bot *Bot) CreateInvoiceLinkWithContext(ctx context.Context, title string, 
 	v["description"] = description
 	v["payload"] = payload
 	v["currency"] = currency
-	if prices != nil {
-		v["prices"] = prices
-	}
+	v["prices"] = prices
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["provider_token"] = opts.ProviderToken
-		v["subscription_period"] = opts.SubscriptionPeriod
-		v["max_tip_amount"] = opts.MaxTipAmount
-		if opts.SuggestedTipAmounts != nil {
-			v["suggested_tip_amounts"] = opts.SuggestedTipAmounts
-		}
-		v["provider_data"] = opts.ProviderData
-		v["photo_url"] = opts.PhotoUrl
-		v["photo_size"] = opts.PhotoSize
-		v["photo_width"] = opts.PhotoWidth
-		v["photo_height"] = opts.PhotoHeight
-		v["need_name"] = opts.NeedName
-		v["need_phone_number"] = opts.NeedPhoneNumber
-		v["need_email"] = opts.NeedEmail
-		v["need_shipping_address"] = opts.NeedShippingAddress
-		v["send_phone_number_to_provider"] = opts.SendPhoneNumberToProvider
-		v["send_email_to_provider"] = opts.SendEmailToProvider
-		v["is_flexible"] = opts.IsFlexible
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "provider_token", opts.ProviderToken, opts.ProviderToken == "")
+		addIfValueNotZero(v, "subscription_period", opts.SubscriptionPeriod, opts.SubscriptionPeriod == 0)
+		addIfValueNotZero(v, "max_tip_amount", opts.MaxTipAmount, opts.MaxTipAmount == 0)
+		addIfValueNotZero(v, "suggested_tip_amounts", opts.SuggestedTipAmounts, opts.SuggestedTipAmounts == nil)
+		addIfValueNotZero(v, "provider_data", opts.ProviderData, opts.ProviderData == "")
+		addIfValueNotZero(v, "photo_url", opts.PhotoUrl, opts.PhotoUrl == "")
+		addIfValueNotZero(v, "photo_size", opts.PhotoSize, opts.PhotoSize == 0)
+		addIfValueNotZero(v, "photo_width", opts.PhotoWidth, opts.PhotoWidth == 0)
+		addIfValueNotZero(v, "photo_height", opts.PhotoHeight, opts.PhotoHeight == 0)
+		addIfValueNotZero(v, "need_name", opts.NeedName, opts.NeedName == false)
+		addIfValueNotZero(v, "need_phone_number", opts.NeedPhoneNumber, opts.NeedPhoneNumber == false)
+		addIfValueNotZero(v, "need_email", opts.NeedEmail, opts.NeedEmail == false)
+		addIfValueNotZero(v, "need_shipping_address", opts.NeedShippingAddress, opts.NeedShippingAddress == false)
+		addIfValueNotZero(v, "send_phone_number_to_provider", opts.SendPhoneNumberToProvider, opts.SendPhoneNumberToProvider == false)
+		addIfValueNotZero(v, "send_email_to_provider", opts.SendEmailToProvider, opts.SendEmailToProvider == false)
+		addIfValueNotZero(v, "is_flexible", opts.IsFlexible, opts.IsFlexible == false)
 	}
 
 	var reqOpts *RequestOpts
@@ -975,12 +953,10 @@ func (bot *Bot) CreateNewStickerSetWithContext(ctx context.Context, userId int64
 	v["user_id"] = userId
 	v["name"] = name
 	v["title"] = title
-	if stickers != nil {
-		v["stickers"] = stickers
-	}
+	v["stickers"] = stickers
 	if opts != nil {
-		v["sticker_type"] = opts.StickerType
-		v["needs_repainting"] = opts.NeedsRepainting
+		addIfValueNotZero(v, "sticker_type", opts.StickerType, opts.StickerType == "")
+		addIfValueNotZero(v, "needs_repainting", opts.NeedsRepainting, opts.NeedsRepainting == false)
 	}
 
 	var reqOpts *RequestOpts
@@ -1057,7 +1033,7 @@ func (bot *Bot) DeclineSuggestedPostWithContext(ctx context.Context, chatId int6
 	v["chat_id"] = chatId
 	v["message_id"] = messageId
 	if opts != nil {
-		v["comment"] = opts.Comment
+		addIfValueNotZero(v, "comment", opts.Comment, opts.Comment == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -1094,9 +1070,7 @@ func (bot *Bot) DeleteBusinessMessages(businessConnectionId string, messageIds [
 func (bot *Bot) DeleteBusinessMessagesWithContext(ctx context.Context, businessConnectionId string, messageIds []int64, opts *DeleteBusinessMessagesOpts) (bool, error) {
 	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
-	if messageIds != nil {
-		v["message_ids"] = messageIds
-	}
+	v["message_ids"] = messageIds
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -1283,9 +1257,7 @@ func (bot *Bot) DeleteMessages(chatId int64, messageIds []int64, opts *DeleteMes
 func (bot *Bot) DeleteMessagesWithContext(ctx context.Context, chatId int64, messageIds []int64, opts *DeleteMessagesOpts) (bool, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	if messageIds != nil {
-		v["message_ids"] = messageIds
-	}
+	v["message_ids"] = messageIds
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -1324,7 +1296,7 @@ func (bot *Bot) DeleteMyCommandsWithContext(ctx context.Context, opts *DeleteMyC
 	v := map[string]any{}
 	if opts != nil {
 		v["scope"] = opts.Scope
-		v["language_code"] = opts.LanguageCode
+		addIfValueNotZero(v, "language_code", opts.LanguageCode, opts.LanguageCode == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -1359,9 +1331,7 @@ func (bot *Bot) DeleteStickerFromSet(sticker InputFileOrString, opts *DeleteStic
 // DeleteStickerFromSetWithContext is the same as Bot.DeleteStickerFromSet, but with a context.Context parameter
 func (bot *Bot) DeleteStickerFromSetWithContext(ctx context.Context, sticker InputFileOrString, opts *DeleteStickerFromSetOpts) (bool, error) {
 	v := map[string]any{}
-	if sticker != nil {
-		v["sticker"] = sticker
-	}
+	v["sticker"] = sticker
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -1467,7 +1437,7 @@ func (bot *Bot) DeleteWebhook(opts *DeleteWebhookOpts) (bool, error) {
 func (bot *Bot) DeleteWebhookWithContext(ctx context.Context, opts *DeleteWebhookOpts) (bool, error) {
 	v := map[string]any{}
 	if opts != nil {
-		v["drop_pending_updates"] = opts.DropPendingUpdates
+		addIfValueNotZero(v, "drop_pending_updates", opts.DropPendingUpdates, opts.DropPendingUpdates == false)
 	}
 
 	var reqOpts *RequestOpts
@@ -1514,10 +1484,10 @@ func (bot *Bot) EditChatInviteLinkWithContext(ctx context.Context, chatId int64,
 	v["chat_id"] = chatId
 	v["invite_link"] = inviteLink
 	if opts != nil {
-		v["name"] = opts.Name
-		v["expire_date"] = opts.ExpireDate
-		v["member_limit"] = opts.MemberLimit
-		v["creates_join_request"] = opts.CreatesJoinRequest
+		addIfValueNotZero(v, "name", opts.Name, opts.Name == "")
+		addIfValueNotZero(v, "expire_date", opts.ExpireDate, opts.ExpireDate == 0)
+		addIfValueNotZero(v, "member_limit", opts.MemberLimit, opts.MemberLimit == 0)
+		addIfValueNotZero(v, "creates_join_request", opts.CreatesJoinRequest, opts.CreatesJoinRequest == false)
 	}
 
 	var reqOpts *RequestOpts
@@ -1558,7 +1528,7 @@ func (bot *Bot) EditChatSubscriptionInviteLinkWithContext(ctx context.Context, c
 	v["chat_id"] = chatId
 	v["invite_link"] = inviteLink
 	if opts != nil {
-		v["name"] = opts.Name
+		addIfValueNotZero(v, "name", opts.Name, opts.Name == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -1601,10 +1571,8 @@ func (bot *Bot) EditForumTopicWithContext(ctx context.Context, chatId int64, mes
 	v["chat_id"] = chatId
 	v["message_thread_id"] = messageThreadId
 	if opts != nil {
-		v["name"] = opts.Name
-		if opts.IconCustomEmojiId != nil {
-			v["icon_custom_emoji_id"] = opts.IconCustomEmojiId
-		}
+		addIfValueNotZero(v, "name", opts.Name, opts.Name == "")
+		addIfValueNotZero(v, "icon_custom_emoji_id", opts.IconCustomEmojiId, opts.IconCustomEmojiId == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -1693,16 +1661,14 @@ func (bot *Bot) EditMessageCaption(opts *EditMessageCaptionOpts) (*Message, bool
 func (bot *Bot) EditMessageCaptionWithContext(ctx context.Context, opts *EditMessageCaptionOpts) (*Message, bool, error) {
 	v := map[string]any{}
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["chat_id"] = opts.ChatId
-		v["message_id"] = opts.MessageId
-		v["inline_message_id"] = opts.InlineMessageId
-		v["caption"] = opts.Caption
-		v["parse_mode"] = opts.ParseMode
-		if opts.CaptionEntities != nil {
-			v["caption_entities"] = opts.CaptionEntities
-		}
-		v["show_caption_above_media"] = opts.ShowCaptionAboveMedia
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "chat_id", opts.ChatId, opts.ChatId == 0)
+		addIfValueNotZero(v, "message_id", opts.MessageId, opts.MessageId == 0)
+		addIfValueNotZero(v, "inline_message_id", opts.InlineMessageId, opts.InlineMessageId == "")
+		addIfValueNotZero(v, "caption", opts.Caption, opts.Caption == "")
+		addIfValueNotZero(v, "parse_mode", opts.ParseMode, opts.ParseMode == "")
+		addIfValueNotZero(v, "caption_entities", opts.CaptionEntities, opts.CaptionEntities == nil)
+		addIfValueNotZero(v, "show_caption_above_media", opts.ShowCaptionAboveMedia, opts.ShowCaptionAboveMedia == false)
 		v["reply_markup"] = opts.ReplyMarkup
 	}
 
@@ -1813,16 +1779,14 @@ func (bot *Bot) EditMessageLiveLocationWithContext(ctx context.Context, latitude
 	v["latitude"] = latitude
 	v["longitude"] = longitude
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["chat_id"] = opts.ChatId
-		v["message_id"] = opts.MessageId
-		v["inline_message_id"] = opts.InlineMessageId
-		if opts.LivePeriod != nil {
-			v["live_period"] = opts.LivePeriod
-		}
-		v["horizontal_accuracy"] = opts.HorizontalAccuracy
-		v["heading"] = opts.Heading
-		v["proximity_alert_radius"] = opts.ProximityAlertRadius
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "chat_id", opts.ChatId, opts.ChatId == 0)
+		addIfValueNotZero(v, "message_id", opts.MessageId, opts.MessageId == 0)
+		addIfValueNotZero(v, "inline_message_id", opts.InlineMessageId, opts.InlineMessageId == "")
+		addIfValueNotZero(v, "live_period", opts.LivePeriod, opts.LivePeriod == nil)
+		addIfValueNotZero(v, "horizontal_accuracy", opts.HorizontalAccuracy, opts.HorizontalAccuracy == 0.0)
+		addIfValueNotZero(v, "heading", opts.Heading, opts.Heading == 0)
+		addIfValueNotZero(v, "proximity_alert_radius", opts.ProximityAlertRadius, opts.ProximityAlertRadius == 0)
 		v["reply_markup"] = opts.ReplyMarkup
 	}
 
@@ -1876,14 +1840,12 @@ func (bot *Bot) EditMessageMedia(media InputMedia, opts *EditMessageMediaOpts) (
 // EditMessageMediaWithContext is the same as Bot.EditMessageMedia, but with a context.Context parameter
 func (bot *Bot) EditMessageMediaWithContext(ctx context.Context, media InputMedia, opts *EditMessageMediaOpts) (*Message, bool, error) {
 	v := map[string]any{}
-	if media != nil {
-		v["media"] = media
-	}
+	v["media"] = media
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["chat_id"] = opts.ChatId
-		v["message_id"] = opts.MessageId
-		v["inline_message_id"] = opts.InlineMessageId
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "chat_id", opts.ChatId, opts.ChatId == 0)
+		addIfValueNotZero(v, "message_id", opts.MessageId, opts.MessageId == 0)
+		addIfValueNotZero(v, "inline_message_id", opts.InlineMessageId, opts.InlineMessageId == "")
 		v["reply_markup"] = opts.ReplyMarkup
 	}
 
@@ -1937,10 +1899,10 @@ func (bot *Bot) EditMessageReplyMarkup(opts *EditMessageReplyMarkupOpts) (*Messa
 func (bot *Bot) EditMessageReplyMarkupWithContext(ctx context.Context, opts *EditMessageReplyMarkupOpts) (*Message, bool, error) {
 	v := map[string]any{}
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["chat_id"] = opts.ChatId
-		v["message_id"] = opts.MessageId
-		v["inline_message_id"] = opts.InlineMessageId
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "chat_id", opts.ChatId, opts.ChatId == 0)
+		addIfValueNotZero(v, "message_id", opts.MessageId, opts.MessageId == 0)
+		addIfValueNotZero(v, "inline_message_id", opts.InlineMessageId, opts.InlineMessageId == "")
 		v["reply_markup"] = opts.ReplyMarkup
 	}
 
@@ -2002,17 +1964,13 @@ func (bot *Bot) EditMessageTextWithContext(ctx context.Context, text string, opt
 	v := map[string]any{}
 	v["text"] = text
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["chat_id"] = opts.ChatId
-		v["message_id"] = opts.MessageId
-		v["inline_message_id"] = opts.InlineMessageId
-		v["parse_mode"] = opts.ParseMode
-		if opts.Entities != nil {
-			v["entities"] = opts.Entities
-		}
-		if opts.LinkPreviewOptions != nil {
-			v["link_preview_options"] = opts.LinkPreviewOptions
-		}
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "chat_id", opts.ChatId, opts.ChatId == 0)
+		addIfValueNotZero(v, "message_id", opts.MessageId, opts.MessageId == 0)
+		addIfValueNotZero(v, "inline_message_id", opts.InlineMessageId, opts.InlineMessageId == "")
+		addIfValueNotZero(v, "parse_mode", opts.ParseMode, opts.ParseMode == "")
+		addIfValueNotZero(v, "entities", opts.Entities, opts.Entities == nil)
+		addIfValueNotZero(v, "link_preview_options", opts.LinkPreviewOptions, opts.LinkPreviewOptions == nil)
 		v["reply_markup"] = opts.ReplyMarkup
 	}
 
@@ -2070,14 +2028,10 @@ func (bot *Bot) EditStoryWithContext(ctx context.Context, businessConnectionId s
 	v["story_id"] = storyId
 	v["content"] = content
 	if opts != nil {
-		v["caption"] = opts.Caption
-		v["parse_mode"] = opts.ParseMode
-		if opts.CaptionEntities != nil {
-			v["caption_entities"] = opts.CaptionEntities
-		}
-		if opts.Areas != nil {
-			v["areas"] = opts.Areas
-		}
+		addIfValueNotZero(v, "caption", opts.Caption, opts.Caption == "")
+		addIfValueNotZero(v, "parse_mode", opts.ParseMode, opts.ParseMode == "")
+		addIfValueNotZero(v, "caption_entities", opts.CaptionEntities, opts.CaptionEntities == nil)
+		addIfValueNotZero(v, "areas", opts.Areas, opts.Areas == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -2202,14 +2156,12 @@ func (bot *Bot) ForwardMessageWithContext(ctx context.Context, chatId int64, fro
 	v["from_chat_id"] = fromChatId
 	v["message_id"] = messageId
 	if opts != nil {
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["video_start_timestamp"] = opts.VideoStartTimestamp
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		if opts.SuggestedPostParameters != nil {
-			v["suggested_post_parameters"] = opts.SuggestedPostParameters
-		}
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		addIfValueNotZero(v, "video_start_timestamp", opts.VideoStartTimestamp, opts.VideoStartTimestamp == 0)
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "suggested_post_parameters", opts.SuggestedPostParameters, opts.SuggestedPostParameters == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -2256,14 +2208,12 @@ func (bot *Bot) ForwardMessagesWithContext(ctx context.Context, chatId int64, fr
 	v := map[string]any{}
 	v["chat_id"] = chatId
 	v["from_chat_id"] = fromChatId
-	if messageIds != nil {
-		v["message_ids"] = messageIds
-	}
+	v["message_ids"] = messageIds
 	if opts != nil {
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
 	}
 
 	var reqOpts *RequestOpts
@@ -2348,14 +2298,14 @@ func (bot *Bot) GetBusinessAccountGiftsWithContext(ctx context.Context, business
 	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
 	if opts != nil {
-		v["exclude_unsaved"] = opts.ExcludeUnsaved
-		v["exclude_saved"] = opts.ExcludeSaved
-		v["exclude_unlimited"] = opts.ExcludeUnlimited
-		v["exclude_limited"] = opts.ExcludeLimited
-		v["exclude_unique"] = opts.ExcludeUnique
-		v["sort_by_price"] = opts.SortByPrice
-		v["offset"] = opts.Offset
-		v["limit"] = opts.Limit
+		addIfValueNotZero(v, "exclude_unsaved", opts.ExcludeUnsaved, opts.ExcludeUnsaved == false)
+		addIfValueNotZero(v, "exclude_saved", opts.ExcludeSaved, opts.ExcludeSaved == false)
+		addIfValueNotZero(v, "exclude_unlimited", opts.ExcludeUnlimited, opts.ExcludeUnlimited == false)
+		addIfValueNotZero(v, "exclude_limited", opts.ExcludeLimited, opts.ExcludeLimited == false)
+		addIfValueNotZero(v, "exclude_unique", opts.ExcludeUnique, opts.ExcludeUnique == false)
+		addIfValueNotZero(v, "sort_by_price", opts.SortByPrice, opts.SortByPrice == false)
+		addIfValueNotZero(v, "offset", opts.Offset, opts.Offset == "")
+		addIfValueNotZero(v, "limit", opts.Limit, opts.Limit == 0)
 	}
 
 	var reqOpts *RequestOpts
@@ -2596,9 +2546,7 @@ func (bot *Bot) GetChatMenuButton(opts *GetChatMenuButtonOpts) (MenuButton, erro
 func (bot *Bot) GetChatMenuButtonWithContext(ctx context.Context, opts *GetChatMenuButtonOpts) (MenuButton, error) {
 	v := map[string]any{}
 	if opts != nil {
-		if opts.ChatId != nil {
-			v["chat_id"] = opts.ChatId
-		}
+		addIfValueNotZero(v, "chat_id", opts.ChatId, opts.ChatId == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -2632,9 +2580,7 @@ func (bot *Bot) GetCustomEmojiStickers(customEmojiIds []string, opts *GetCustomE
 // GetCustomEmojiStickersWithContext is the same as Bot.GetCustomEmojiStickers, but with a context.Context parameter
 func (bot *Bot) GetCustomEmojiStickersWithContext(ctx context.Context, customEmojiIds []string, opts *GetCustomEmojiStickersOpts) ([]Sticker, error) {
 	v := map[string]any{}
-	if customEmojiIds != nil {
-		v["custom_emoji_ids"] = customEmojiIds
-	}
+	v["custom_emoji_ids"] = customEmojiIds
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -2743,9 +2689,9 @@ func (bot *Bot) GetGameHighScoresWithContext(ctx context.Context, userId int64, 
 	v := map[string]any{}
 	v["user_id"] = userId
 	if opts != nil {
-		v["chat_id"] = opts.ChatId
-		v["message_id"] = opts.MessageId
-		v["inline_message_id"] = opts.InlineMessageId
+		addIfValueNotZero(v, "chat_id", opts.ChatId, opts.ChatId == 0)
+		addIfValueNotZero(v, "message_id", opts.MessageId, opts.MessageId == 0)
+		addIfValueNotZero(v, "inline_message_id", opts.InlineMessageId, opts.InlineMessageId == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -2817,7 +2763,7 @@ func (bot *Bot) GetMyCommandsWithContext(ctx context.Context, opts *GetMyCommand
 	v := map[string]any{}
 	if opts != nil {
 		v["scope"] = opts.Scope
-		v["language_code"] = opts.LanguageCode
+		addIfValueNotZero(v, "language_code", opts.LanguageCode, opts.LanguageCode == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -2854,7 +2800,7 @@ func (bot *Bot) GetMyDefaultAdministratorRights(opts *GetMyDefaultAdministratorR
 func (bot *Bot) GetMyDefaultAdministratorRightsWithContext(ctx context.Context, opts *GetMyDefaultAdministratorRightsOpts) (*ChatAdministratorRights, error) {
 	v := map[string]any{}
 	if opts != nil {
-		v["for_channels"] = opts.ForChannels
+		addIfValueNotZero(v, "for_channels", opts.ForChannels, opts.ForChannels == false)
 	}
 
 	var reqOpts *RequestOpts
@@ -2891,7 +2837,7 @@ func (bot *Bot) GetMyDescription(opts *GetMyDescriptionOpts) (*BotDescription, e
 func (bot *Bot) GetMyDescriptionWithContext(ctx context.Context, opts *GetMyDescriptionOpts) (*BotDescription, error) {
 	v := map[string]any{}
 	if opts != nil {
-		v["language_code"] = opts.LanguageCode
+		addIfValueNotZero(v, "language_code", opts.LanguageCode, opts.LanguageCode == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -2928,7 +2874,7 @@ func (bot *Bot) GetMyName(opts *GetMyNameOpts) (*BotName, error) {
 func (bot *Bot) GetMyNameWithContext(ctx context.Context, opts *GetMyNameOpts) (*BotName, error) {
 	v := map[string]any{}
 	if opts != nil {
-		v["language_code"] = opts.LanguageCode
+		addIfValueNotZero(v, "language_code", opts.LanguageCode, opts.LanguageCode == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -2965,7 +2911,7 @@ func (bot *Bot) GetMyShortDescription(opts *GetMyShortDescriptionOpts) (*BotShor
 func (bot *Bot) GetMyShortDescriptionWithContext(ctx context.Context, opts *GetMyShortDescriptionOpts) (*BotShortDescription, error) {
 	v := map[string]any{}
 	if opts != nil {
-		v["language_code"] = opts.LanguageCode
+		addIfValueNotZero(v, "language_code", opts.LanguageCode, opts.LanguageCode == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -3036,8 +2982,8 @@ func (bot *Bot) GetStarTransactions(opts *GetStarTransactionsOpts) (*StarTransac
 func (bot *Bot) GetStarTransactionsWithContext(ctx context.Context, opts *GetStarTransactionsOpts) (*StarTransactions, error) {
 	v := map[string]any{}
 	if opts != nil {
-		v["offset"] = opts.Offset
-		v["limit"] = opts.Limit
+		addIfValueNotZero(v, "offset", opts.Offset, opts.Offset == 0)
+		addIfValueNotZero(v, "limit", opts.Limit, opts.Limit == 0)
 	}
 
 	var reqOpts *RequestOpts
@@ -3114,12 +3060,10 @@ func (bot *Bot) GetUpdates(opts *GetUpdatesOpts) ([]Update, error) {
 func (bot *Bot) GetUpdatesWithContext(ctx context.Context, opts *GetUpdatesOpts) ([]Update, error) {
 	v := map[string]any{}
 	if opts != nil {
-		v["offset"] = opts.Offset
-		v["limit"] = opts.Limit
-		v["timeout"] = opts.Timeout
-		if opts.AllowedUpdates != nil {
-			v["allowed_updates"] = opts.AllowedUpdates
-		}
+		addIfValueNotZero(v, "offset", opts.Offset, opts.Offset == 0)
+		addIfValueNotZero(v, "limit", opts.Limit, opts.Limit == 0)
+		addIfValueNotZero(v, "timeout", opts.Timeout, opts.Timeout == 0)
+		addIfValueNotZero(v, "allowed_updates", opts.AllowedUpdates, opts.AllowedUpdates == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -3196,8 +3140,8 @@ func (bot *Bot) GetUserProfilePhotosWithContext(ctx context.Context, userId int6
 	v := map[string]any{}
 	v["user_id"] = userId
 	if opts != nil {
-		v["offset"] = opts.Offset
-		v["limit"] = opts.Limit
+		addIfValueNotZero(v, "offset", opts.Offset, opts.Offset == 0)
+		addIfValueNotZero(v, "limit", opts.Limit, opts.Limit == 0)
 	}
 
 	var reqOpts *RequestOpts
@@ -3276,11 +3220,9 @@ func (bot *Bot) GiftPremiumSubscriptionWithContext(ctx context.Context, userId i
 	v["month_count"] = monthCount
 	v["star_count"] = starCount
 	if opts != nil {
-		v["text"] = opts.Text
-		v["text_parse_mode"] = opts.TextParseMode
-		if opts.TextEntities != nil {
-			v["text_entities"] = opts.TextEntities
-		}
+		addIfValueNotZero(v, "text", opts.Text, opts.Text == "")
+		addIfValueNotZero(v, "text_parse_mode", opts.TextParseMode, opts.TextParseMode == "")
+		addIfValueNotZero(v, "text_entities", opts.TextEntities, opts.TextEntities == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -3423,8 +3365,8 @@ func (bot *Bot) PinChatMessageWithContext(ctx context.Context, chatId int64, mes
 	v["chat_id"] = chatId
 	v["message_id"] = messageId
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["disable_notification"] = opts.DisableNotification
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
 	}
 
 	var reqOpts *RequestOpts
@@ -3477,16 +3419,12 @@ func (bot *Bot) PostStoryWithContext(ctx context.Context, businessConnectionId s
 	v["content"] = content
 	v["active_period"] = activePeriod
 	if opts != nil {
-		v["caption"] = opts.Caption
-		v["parse_mode"] = opts.ParseMode
-		if opts.CaptionEntities != nil {
-			v["caption_entities"] = opts.CaptionEntities
-		}
-		if opts.Areas != nil {
-			v["areas"] = opts.Areas
-		}
-		v["post_to_chat_page"] = opts.PostToChatPage
-		v["protect_content"] = opts.ProtectContent
+		addIfValueNotZero(v, "caption", opts.Caption, opts.Caption == "")
+		addIfValueNotZero(v, "parse_mode", opts.ParseMode, opts.ParseMode == "")
+		addIfValueNotZero(v, "caption_entities", opts.CaptionEntities, opts.CaptionEntities == nil)
+		addIfValueNotZero(v, "areas", opts.Areas, opts.Areas == nil)
+		addIfValueNotZero(v, "post_to_chat_page", opts.PostToChatPage, opts.PostToChatPage == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
 	}
 
 	var reqOpts *RequestOpts
@@ -3557,22 +3495,22 @@ func (bot *Bot) PromoteChatMemberWithContext(ctx context.Context, chatId int64, 
 	v["chat_id"] = chatId
 	v["user_id"] = userId
 	if opts != nil {
-		v["is_anonymous"] = opts.IsAnonymous
-		v["can_manage_chat"] = opts.CanManageChat
-		v["can_delete_messages"] = opts.CanDeleteMessages
-		v["can_manage_video_chats"] = opts.CanManageVideoChats
-		v["can_restrict_members"] = opts.CanRestrictMembers
-		v["can_promote_members"] = opts.CanPromoteMembers
-		v["can_change_info"] = opts.CanChangeInfo
-		v["can_invite_users"] = opts.CanInviteUsers
-		v["can_post_stories"] = opts.CanPostStories
-		v["can_edit_stories"] = opts.CanEditStories
-		v["can_delete_stories"] = opts.CanDeleteStories
-		v["can_post_messages"] = opts.CanPostMessages
-		v["can_edit_messages"] = opts.CanEditMessages
-		v["can_pin_messages"] = opts.CanPinMessages
-		v["can_manage_topics"] = opts.CanManageTopics
-		v["can_manage_direct_messages"] = opts.CanManageDirectMessages
+		addIfValueNotZero(v, "is_anonymous", opts.IsAnonymous, opts.IsAnonymous == false)
+		addIfValueNotZero(v, "can_manage_chat", opts.CanManageChat, opts.CanManageChat == false)
+		addIfValueNotZero(v, "can_delete_messages", opts.CanDeleteMessages, opts.CanDeleteMessages == false)
+		addIfValueNotZero(v, "can_manage_video_chats", opts.CanManageVideoChats, opts.CanManageVideoChats == false)
+		addIfValueNotZero(v, "can_restrict_members", opts.CanRestrictMembers, opts.CanRestrictMembers == false)
+		addIfValueNotZero(v, "can_promote_members", opts.CanPromoteMembers, opts.CanPromoteMembers == false)
+		addIfValueNotZero(v, "can_change_info", opts.CanChangeInfo, opts.CanChangeInfo == false)
+		addIfValueNotZero(v, "can_invite_users", opts.CanInviteUsers, opts.CanInviteUsers == false)
+		addIfValueNotZero(v, "can_post_stories", opts.CanPostStories, opts.CanPostStories == false)
+		addIfValueNotZero(v, "can_edit_stories", opts.CanEditStories, opts.CanEditStories == false)
+		addIfValueNotZero(v, "can_delete_stories", opts.CanDeleteStories, opts.CanDeleteStories == false)
+		addIfValueNotZero(v, "can_post_messages", opts.CanPostMessages, opts.CanPostMessages == false)
+		addIfValueNotZero(v, "can_edit_messages", opts.CanEditMessages, opts.CanEditMessages == false)
+		addIfValueNotZero(v, "can_pin_messages", opts.CanPinMessages, opts.CanPinMessages == false)
+		addIfValueNotZero(v, "can_manage_topics", opts.CanManageTopics, opts.CanManageTopics == false)
+		addIfValueNotZero(v, "can_manage_direct_messages", opts.CanManageDirectMessages, opts.CanManageDirectMessages == false)
 	}
 
 	var reqOpts *RequestOpts
@@ -3685,7 +3623,7 @@ func (bot *Bot) RemoveBusinessAccountProfilePhotoWithContext(ctx context.Context
 	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
 	if opts != nil {
-		v["is_public"] = opts.IsPublic
+		addIfValueNotZero(v, "is_public", opts.IsPublic, opts.IsPublic == false)
 	}
 
 	var reqOpts *RequestOpts
@@ -3908,8 +3846,8 @@ func (bot *Bot) RestrictChatMemberWithContext(ctx context.Context, chatId int64,
 	v["user_id"] = userId
 	v["permissions"] = permissions
 	if opts != nil {
-		v["use_independent_chat_permissions"] = opts.UseIndependentChatPermissions
-		v["until_date"] = opts.UntilDate
+		addIfValueNotZero(v, "use_independent_chat_permissions", opts.UseIndependentChatPermissions, opts.UseIndependentChatPermissions == false)
+		addIfValueNotZero(v, "until_date", opts.UntilDate, opts.UntilDate == 0)
 	}
 
 	var reqOpts *RequestOpts
@@ -3992,10 +3930,10 @@ func (bot *Bot) SavePreparedInlineMessageWithContext(ctx context.Context, userId
 	v["user_id"] = userId
 	v["result"] = result
 	if opts != nil {
-		v["allow_user_chats"] = opts.AllowUserChats
-		v["allow_bot_chats"] = opts.AllowBotChats
-		v["allow_group_chats"] = opts.AllowGroupChats
-		v["allow_channel_chats"] = opts.AllowChannelChats
+		addIfValueNotZero(v, "allow_user_chats", opts.AllowUserChats, opts.AllowUserChats == false)
+		addIfValueNotZero(v, "allow_bot_chats", opts.AllowBotChats, opts.AllowBotChats == false)
+		addIfValueNotZero(v, "allow_group_chats", opts.AllowGroupChats, opts.AllowGroupChats == false)
+		addIfValueNotZero(v, "allow_channel_chats", opts.AllowChannelChats, opts.AllowChannelChats == false)
 	}
 
 	var reqOpts *RequestOpts
@@ -4070,39 +4008,27 @@ func (bot *Bot) SendAnimation(chatId int64, animation InputFileOrString, opts *S
 func (bot *Bot) SendAnimationWithContext(ctx context.Context, chatId int64, animation InputFileOrString, opts *SendAnimationOpts) (*Message, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	if animation != nil {
-		v["animation"] = animation
-	}
+	v["animation"] = animation
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["duration"] = opts.Duration
-		v["width"] = opts.Width
-		v["height"] = opts.Height
-		if opts.Thumbnail != nil {
-			v["thumbnail"] = opts.Thumbnail
-		}
-		v["caption"] = opts.Caption
-		v["parse_mode"] = opts.ParseMode
-		if opts.CaptionEntities != nil {
-			v["caption_entities"] = opts.CaptionEntities
-		}
-		v["show_caption_above_media"] = opts.ShowCaptionAboveMedia
-		v["has_spoiler"] = opts.HasSpoiler
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
-		v["message_effect_id"] = opts.MessageEffectId
-		if opts.SuggestedPostParameters != nil {
-			v["suggested_post_parameters"] = opts.SuggestedPostParameters
-		}
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
-		if opts.ReplyMarkup != nil {
-			v["reply_markup"] = opts.ReplyMarkup
-		}
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		addIfValueNotZero(v, "duration", opts.Duration, opts.Duration == 0)
+		addIfValueNotZero(v, "width", opts.Width, opts.Width == 0)
+		addIfValueNotZero(v, "height", opts.Height, opts.Height == 0)
+		v["thumbnail"] = opts.Thumbnail
+		addIfValueNotZero(v, "caption", opts.Caption, opts.Caption == "")
+		addIfValueNotZero(v, "parse_mode", opts.ParseMode, opts.ParseMode == "")
+		addIfValueNotZero(v, "caption_entities", opts.CaptionEntities, opts.CaptionEntities == nil)
+		addIfValueNotZero(v, "show_caption_above_media", opts.ShowCaptionAboveMedia, opts.ShowCaptionAboveMedia == false)
+		addIfValueNotZero(v, "has_spoiler", opts.HasSpoiler, opts.HasSpoiler == false)
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "allow_paid_broadcast", opts.AllowPaidBroadcast, opts.AllowPaidBroadcast == false)
+		addIfValueNotZero(v, "message_effect_id", opts.MessageEffectId, opts.MessageEffectId == "")
+		addIfValueNotZero(v, "suggested_post_parameters", opts.SuggestedPostParameters, opts.SuggestedPostParameters == nil)
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
+		addIfValueNotZero(v, "reply_markup", opts.ReplyMarkup, opts.ReplyMarkup == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -4174,37 +4100,25 @@ func (bot *Bot) SendAudio(chatId int64, audio InputFileOrString, opts *SendAudio
 func (bot *Bot) SendAudioWithContext(ctx context.Context, chatId int64, audio InputFileOrString, opts *SendAudioOpts) (*Message, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	if audio != nil {
-		v["audio"] = audio
-	}
+	v["audio"] = audio
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["caption"] = opts.Caption
-		v["parse_mode"] = opts.ParseMode
-		if opts.CaptionEntities != nil {
-			v["caption_entities"] = opts.CaptionEntities
-		}
-		v["duration"] = opts.Duration
-		v["performer"] = opts.Performer
-		v["title"] = opts.Title
-		if opts.Thumbnail != nil {
-			v["thumbnail"] = opts.Thumbnail
-		}
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
-		v["message_effect_id"] = opts.MessageEffectId
-		if opts.SuggestedPostParameters != nil {
-			v["suggested_post_parameters"] = opts.SuggestedPostParameters
-		}
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
-		if opts.ReplyMarkup != nil {
-			v["reply_markup"] = opts.ReplyMarkup
-		}
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		addIfValueNotZero(v, "caption", opts.Caption, opts.Caption == "")
+		addIfValueNotZero(v, "parse_mode", opts.ParseMode, opts.ParseMode == "")
+		addIfValueNotZero(v, "caption_entities", opts.CaptionEntities, opts.CaptionEntities == nil)
+		addIfValueNotZero(v, "duration", opts.Duration, opts.Duration == 0)
+		addIfValueNotZero(v, "performer", opts.Performer, opts.Performer == "")
+		addIfValueNotZero(v, "title", opts.Title, opts.Title == "")
+		v["thumbnail"] = opts.Thumbnail
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "allow_paid_broadcast", opts.AllowPaidBroadcast, opts.AllowPaidBroadcast == false)
+		addIfValueNotZero(v, "message_effect_id", opts.MessageEffectId, opts.MessageEffectId == "")
+		addIfValueNotZero(v, "suggested_post_parameters", opts.SuggestedPostParameters, opts.SuggestedPostParameters == nil)
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
+		addIfValueNotZero(v, "reply_markup", opts.ReplyMarkup, opts.ReplyMarkup == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -4248,8 +4162,8 @@ func (bot *Bot) SendChatActionWithContext(ctx context.Context, chatId int64, act
 	v["chat_id"] = chatId
 	v["action"] = action
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["message_thread_id"] = opts.MessageThreadId
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
 	}
 
 	var reqOpts *RequestOpts
@@ -4300,12 +4214,10 @@ func (bot *Bot) SendChecklistWithContext(ctx context.Context, businessConnection
 	v["chat_id"] = chatId
 	v["checklist"] = checklist
 	if opts != nil {
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["message_effect_id"] = opts.MessageEffectId
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "message_effect_id", opts.MessageEffectId, opts.MessageEffectId == "")
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
 		v["reply_markup"] = opts.ReplyMarkup
 	}
 
@@ -4371,24 +4283,18 @@ func (bot *Bot) SendContactWithContext(ctx context.Context, chatId int64, phoneN
 	v["phone_number"] = phoneNumber
 	v["first_name"] = firstName
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["last_name"] = opts.LastName
-		v["vcard"] = opts.Vcard
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
-		v["message_effect_id"] = opts.MessageEffectId
-		if opts.SuggestedPostParameters != nil {
-			v["suggested_post_parameters"] = opts.SuggestedPostParameters
-		}
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
-		if opts.ReplyMarkup != nil {
-			v["reply_markup"] = opts.ReplyMarkup
-		}
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		addIfValueNotZero(v, "last_name", opts.LastName, opts.LastName == "")
+		addIfValueNotZero(v, "vcard", opts.Vcard, opts.Vcard == "")
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "allow_paid_broadcast", opts.AllowPaidBroadcast, opts.AllowPaidBroadcast == false)
+		addIfValueNotZero(v, "message_effect_id", opts.MessageEffectId, opts.MessageEffectId == "")
+		addIfValueNotZero(v, "suggested_post_parameters", opts.SuggestedPostParameters, opts.SuggestedPostParameters == nil)
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
+		addIfValueNotZero(v, "reply_markup", opts.ReplyMarkup, opts.ReplyMarkup == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -4447,23 +4353,17 @@ func (bot *Bot) SendDiceWithContext(ctx context.Context, chatId int64, opts *Sen
 	v := map[string]any{}
 	v["chat_id"] = chatId
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["emoji"] = opts.Emoji
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
-		v["message_effect_id"] = opts.MessageEffectId
-		if opts.SuggestedPostParameters != nil {
-			v["suggested_post_parameters"] = opts.SuggestedPostParameters
-		}
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
-		if opts.ReplyMarkup != nil {
-			v["reply_markup"] = opts.ReplyMarkup
-		}
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		addIfValueNotZero(v, "emoji", opts.Emoji, opts.Emoji == "")
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "allow_paid_broadcast", opts.AllowPaidBroadcast, opts.AllowPaidBroadcast == false)
+		addIfValueNotZero(v, "message_effect_id", opts.MessageEffectId, opts.MessageEffectId == "")
+		addIfValueNotZero(v, "suggested_post_parameters", opts.SuggestedPostParameters, opts.SuggestedPostParameters == nil)
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
+		addIfValueNotZero(v, "reply_markup", opts.ReplyMarkup, opts.ReplyMarkup == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -4530,35 +4430,23 @@ func (bot *Bot) SendDocument(chatId int64, document InputFileOrString, opts *Sen
 func (bot *Bot) SendDocumentWithContext(ctx context.Context, chatId int64, document InputFileOrString, opts *SendDocumentOpts) (*Message, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	if document != nil {
-		v["document"] = document
-	}
+	v["document"] = document
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		if opts.Thumbnail != nil {
-			v["thumbnail"] = opts.Thumbnail
-		}
-		v["caption"] = opts.Caption
-		v["parse_mode"] = opts.ParseMode
-		if opts.CaptionEntities != nil {
-			v["caption_entities"] = opts.CaptionEntities
-		}
-		v["disable_content_type_detection"] = opts.DisableContentTypeDetection
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
-		v["message_effect_id"] = opts.MessageEffectId
-		if opts.SuggestedPostParameters != nil {
-			v["suggested_post_parameters"] = opts.SuggestedPostParameters
-		}
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
-		if opts.ReplyMarkup != nil {
-			v["reply_markup"] = opts.ReplyMarkup
-		}
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		v["thumbnail"] = opts.Thumbnail
+		addIfValueNotZero(v, "caption", opts.Caption, opts.Caption == "")
+		addIfValueNotZero(v, "parse_mode", opts.ParseMode, opts.ParseMode == "")
+		addIfValueNotZero(v, "caption_entities", opts.CaptionEntities, opts.CaptionEntities == nil)
+		addIfValueNotZero(v, "disable_content_type_detection", opts.DisableContentTypeDetection, opts.DisableContentTypeDetection == false)
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "allow_paid_broadcast", opts.AllowPaidBroadcast, opts.AllowPaidBroadcast == false)
+		addIfValueNotZero(v, "message_effect_id", opts.MessageEffectId, opts.MessageEffectId == "")
+		addIfValueNotZero(v, "suggested_post_parameters", opts.SuggestedPostParameters, opts.SuggestedPostParameters == nil)
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
+		addIfValueNotZero(v, "reply_markup", opts.ReplyMarkup, opts.ReplyMarkup == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -4613,15 +4501,13 @@ func (bot *Bot) SendGameWithContext(ctx context.Context, chatId int64, gameShort
 	v["chat_id"] = chatId
 	v["game_short_name"] = gameShortName
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["message_thread_id"] = opts.MessageThreadId
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
-		v["message_effect_id"] = opts.MessageEffectId
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "allow_paid_broadcast", opts.AllowPaidBroadcast, opts.AllowPaidBroadcast == false)
+		addIfValueNotZero(v, "message_effect_id", opts.MessageEffectId, opts.MessageEffectId == "")
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
 		v["reply_markup"] = opts.ReplyMarkup
 	}
 
@@ -4671,14 +4557,12 @@ func (bot *Bot) SendGiftWithContext(ctx context.Context, giftId string, opts *Se
 	v := map[string]any{}
 	v["gift_id"] = giftId
 	if opts != nil {
-		v["user_id"] = opts.UserId
-		v["chat_id"] = opts.ChatId
-		v["pay_for_upgrade"] = opts.PayForUpgrade
-		v["text"] = opts.Text
-		v["text_parse_mode"] = opts.TextParseMode
-		if opts.TextEntities != nil {
-			v["text_entities"] = opts.TextEntities
-		}
+		addIfValueNotZero(v, "user_id", opts.UserId, opts.UserId == 0)
+		addIfValueNotZero(v, "chat_id", opts.ChatId, opts.ChatId == 0)
+		addIfValueNotZero(v, "pay_for_upgrade", opts.PayForUpgrade, opts.PayForUpgrade == false)
+		addIfValueNotZero(v, "text", opts.Text, opts.Text == "")
+		addIfValueNotZero(v, "text_parse_mode", opts.TextParseMode, opts.TextParseMode == "")
+		addIfValueNotZero(v, "text_entities", opts.TextEntities, opts.TextEntities == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -4773,40 +4657,32 @@ func (bot *Bot) SendInvoiceWithContext(ctx context.Context, chatId int64, title 
 	v["description"] = description
 	v["payload"] = payload
 	v["currency"] = currency
-	if prices != nil {
-		v["prices"] = prices
-	}
+	v["prices"] = prices
 	if opts != nil {
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["provider_token"] = opts.ProviderToken
-		v["max_tip_amount"] = opts.MaxTipAmount
-		if opts.SuggestedTipAmounts != nil {
-			v["suggested_tip_amounts"] = opts.SuggestedTipAmounts
-		}
-		v["start_parameter"] = opts.StartParameter
-		v["provider_data"] = opts.ProviderData
-		v["photo_url"] = opts.PhotoUrl
-		v["photo_size"] = opts.PhotoSize
-		v["photo_width"] = opts.PhotoWidth
-		v["photo_height"] = opts.PhotoHeight
-		v["need_name"] = opts.NeedName
-		v["need_phone_number"] = opts.NeedPhoneNumber
-		v["need_email"] = opts.NeedEmail
-		v["need_shipping_address"] = opts.NeedShippingAddress
-		v["send_phone_number_to_provider"] = opts.SendPhoneNumberToProvider
-		v["send_email_to_provider"] = opts.SendEmailToProvider
-		v["is_flexible"] = opts.IsFlexible
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
-		v["message_effect_id"] = opts.MessageEffectId
-		if opts.SuggestedPostParameters != nil {
-			v["suggested_post_parameters"] = opts.SuggestedPostParameters
-		}
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		addIfValueNotZero(v, "provider_token", opts.ProviderToken, opts.ProviderToken == "")
+		addIfValueNotZero(v, "max_tip_amount", opts.MaxTipAmount, opts.MaxTipAmount == 0)
+		addIfValueNotZero(v, "suggested_tip_amounts", opts.SuggestedTipAmounts, opts.SuggestedTipAmounts == nil)
+		addIfValueNotZero(v, "start_parameter", opts.StartParameter, opts.StartParameter == "")
+		addIfValueNotZero(v, "provider_data", opts.ProviderData, opts.ProviderData == "")
+		addIfValueNotZero(v, "photo_url", opts.PhotoUrl, opts.PhotoUrl == "")
+		addIfValueNotZero(v, "photo_size", opts.PhotoSize, opts.PhotoSize == 0)
+		addIfValueNotZero(v, "photo_width", opts.PhotoWidth, opts.PhotoWidth == 0)
+		addIfValueNotZero(v, "photo_height", opts.PhotoHeight, opts.PhotoHeight == 0)
+		addIfValueNotZero(v, "need_name", opts.NeedName, opts.NeedName == false)
+		addIfValueNotZero(v, "need_phone_number", opts.NeedPhoneNumber, opts.NeedPhoneNumber == false)
+		addIfValueNotZero(v, "need_email", opts.NeedEmail, opts.NeedEmail == false)
+		addIfValueNotZero(v, "need_shipping_address", opts.NeedShippingAddress, opts.NeedShippingAddress == false)
+		addIfValueNotZero(v, "send_phone_number_to_provider", opts.SendPhoneNumberToProvider, opts.SendPhoneNumberToProvider == false)
+		addIfValueNotZero(v, "send_email_to_provider", opts.SendEmailToProvider, opts.SendEmailToProvider == false)
+		addIfValueNotZero(v, "is_flexible", opts.IsFlexible, opts.IsFlexible == false)
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "allow_paid_broadcast", opts.AllowPaidBroadcast, opts.AllowPaidBroadcast == false)
+		addIfValueNotZero(v, "message_effect_id", opts.MessageEffectId, opts.MessageEffectId == "")
+		addIfValueNotZero(v, "suggested_post_parameters", opts.SuggestedPostParameters, opts.SuggestedPostParameters == nil)
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
 		v["reply_markup"] = opts.ReplyMarkup
 	}
 
@@ -4876,26 +4752,20 @@ func (bot *Bot) SendLocationWithContext(ctx context.Context, chatId int64, latit
 	v["latitude"] = latitude
 	v["longitude"] = longitude
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["horizontal_accuracy"] = opts.HorizontalAccuracy
-		v["live_period"] = opts.LivePeriod
-		v["heading"] = opts.Heading
-		v["proximity_alert_radius"] = opts.ProximityAlertRadius
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
-		v["message_effect_id"] = opts.MessageEffectId
-		if opts.SuggestedPostParameters != nil {
-			v["suggested_post_parameters"] = opts.SuggestedPostParameters
-		}
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
-		if opts.ReplyMarkup != nil {
-			v["reply_markup"] = opts.ReplyMarkup
-		}
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		addIfValueNotZero(v, "horizontal_accuracy", opts.HorizontalAccuracy, opts.HorizontalAccuracy == 0.0)
+		addIfValueNotZero(v, "live_period", opts.LivePeriod, opts.LivePeriod == 0)
+		addIfValueNotZero(v, "heading", opts.Heading, opts.Heading == 0)
+		addIfValueNotZero(v, "proximity_alert_radius", opts.ProximityAlertRadius, opts.ProximityAlertRadius == 0)
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "allow_paid_broadcast", opts.AllowPaidBroadcast, opts.AllowPaidBroadcast == false)
+		addIfValueNotZero(v, "message_effect_id", opts.MessageEffectId, opts.MessageEffectId == "")
+		addIfValueNotZero(v, "suggested_post_parameters", opts.SuggestedPostParameters, opts.SuggestedPostParameters == nil)
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
+		addIfValueNotZero(v, "reply_markup", opts.ReplyMarkup, opts.ReplyMarkup == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -4948,20 +4818,16 @@ func (bot *Bot) SendMediaGroup(chatId int64, media []InputMedia, opts *SendMedia
 func (bot *Bot) SendMediaGroupWithContext(ctx context.Context, chatId int64, media []InputMedia, opts *SendMediaGroupOpts) ([]Message, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	if media != nil {
-		v["media"] = media
-	}
+	v["media"] = media
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
-		v["message_effect_id"] = opts.MessageEffectId
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "allow_paid_broadcast", opts.AllowPaidBroadcast, opts.AllowPaidBroadcast == false)
+		addIfValueNotZero(v, "message_effect_id", opts.MessageEffectId, opts.MessageEffectId == "")
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -5026,29 +4892,19 @@ func (bot *Bot) SendMessageWithContext(ctx context.Context, chatId int64, text s
 	v["chat_id"] = chatId
 	v["text"] = text
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["parse_mode"] = opts.ParseMode
-		if opts.Entities != nil {
-			v["entities"] = opts.Entities
-		}
-		if opts.LinkPreviewOptions != nil {
-			v["link_preview_options"] = opts.LinkPreviewOptions
-		}
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
-		v["message_effect_id"] = opts.MessageEffectId
-		if opts.SuggestedPostParameters != nil {
-			v["suggested_post_parameters"] = opts.SuggestedPostParameters
-		}
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
-		if opts.ReplyMarkup != nil {
-			v["reply_markup"] = opts.ReplyMarkup
-		}
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		addIfValueNotZero(v, "parse_mode", opts.ParseMode, opts.ParseMode == "")
+		addIfValueNotZero(v, "entities", opts.Entities, opts.Entities == nil)
+		addIfValueNotZero(v, "link_preview_options", opts.LinkPreviewOptions, opts.LinkPreviewOptions == nil)
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "allow_paid_broadcast", opts.AllowPaidBroadcast, opts.AllowPaidBroadcast == false)
+		addIfValueNotZero(v, "message_effect_id", opts.MessageEffectId, opts.MessageEffectId == "")
+		addIfValueNotZero(v, "suggested_post_parameters", opts.SuggestedPostParameters, opts.SuggestedPostParameters == nil)
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
+		addIfValueNotZero(v, "reply_markup", opts.ReplyMarkup, opts.ReplyMarkup == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -5115,32 +4971,22 @@ func (bot *Bot) SendPaidMediaWithContext(ctx context.Context, chatId int64, star
 	v := map[string]any{}
 	v["chat_id"] = chatId
 	v["star_count"] = starCount
-	if media != nil {
-		v["media"] = media
-	}
+	v["media"] = media
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["payload"] = opts.Payload
-		v["caption"] = opts.Caption
-		v["parse_mode"] = opts.ParseMode
-		if opts.CaptionEntities != nil {
-			v["caption_entities"] = opts.CaptionEntities
-		}
-		v["show_caption_above_media"] = opts.ShowCaptionAboveMedia
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
-		if opts.SuggestedPostParameters != nil {
-			v["suggested_post_parameters"] = opts.SuggestedPostParameters
-		}
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
-		if opts.ReplyMarkup != nil {
-			v["reply_markup"] = opts.ReplyMarkup
-		}
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		addIfValueNotZero(v, "payload", opts.Payload, opts.Payload == "")
+		addIfValueNotZero(v, "caption", opts.Caption, opts.Caption == "")
+		addIfValueNotZero(v, "parse_mode", opts.ParseMode, opts.ParseMode == "")
+		addIfValueNotZero(v, "caption_entities", opts.CaptionEntities, opts.CaptionEntities == nil)
+		addIfValueNotZero(v, "show_caption_above_media", opts.ShowCaptionAboveMedia, opts.ShowCaptionAboveMedia == false)
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "allow_paid_broadcast", opts.AllowPaidBroadcast, opts.AllowPaidBroadcast == false)
+		addIfValueNotZero(v, "suggested_post_parameters", opts.SuggestedPostParameters, opts.SuggestedPostParameters == nil)
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
+		addIfValueNotZero(v, "reply_markup", opts.ReplyMarkup, opts.ReplyMarkup == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -5207,33 +5053,23 @@ func (bot *Bot) SendPhoto(chatId int64, photo InputFileOrString, opts *SendPhoto
 func (bot *Bot) SendPhotoWithContext(ctx context.Context, chatId int64, photo InputFileOrString, opts *SendPhotoOpts) (*Message, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	if photo != nil {
-		v["photo"] = photo
-	}
+	v["photo"] = photo
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["caption"] = opts.Caption
-		v["parse_mode"] = opts.ParseMode
-		if opts.CaptionEntities != nil {
-			v["caption_entities"] = opts.CaptionEntities
-		}
-		v["show_caption_above_media"] = opts.ShowCaptionAboveMedia
-		v["has_spoiler"] = opts.HasSpoiler
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
-		v["message_effect_id"] = opts.MessageEffectId
-		if opts.SuggestedPostParameters != nil {
-			v["suggested_post_parameters"] = opts.SuggestedPostParameters
-		}
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
-		if opts.ReplyMarkup != nil {
-			v["reply_markup"] = opts.ReplyMarkup
-		}
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		addIfValueNotZero(v, "caption", opts.Caption, opts.Caption == "")
+		addIfValueNotZero(v, "parse_mode", opts.ParseMode, opts.ParseMode == "")
+		addIfValueNotZero(v, "caption_entities", opts.CaptionEntities, opts.CaptionEntities == nil)
+		addIfValueNotZero(v, "show_caption_above_media", opts.ShowCaptionAboveMedia, opts.ShowCaptionAboveMedia == false)
+		addIfValueNotZero(v, "has_spoiler", opts.HasSpoiler, opts.HasSpoiler == false)
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "allow_paid_broadcast", opts.AllowPaidBroadcast, opts.AllowPaidBroadcast == false)
+		addIfValueNotZero(v, "message_effect_id", opts.MessageEffectId, opts.MessageEffectId == "")
+		addIfValueNotZero(v, "suggested_post_parameters", opts.SuggestedPostParameters, opts.SuggestedPostParameters == nil)
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
+		addIfValueNotZero(v, "reply_markup", opts.ReplyMarkup, opts.ReplyMarkup == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -5312,41 +5148,31 @@ func (bot *Bot) SendPollWithContext(ctx context.Context, chatId int64, question 
 	v := map[string]any{}
 	v["chat_id"] = chatId
 	v["question"] = question
-	if options != nil {
-		v["options"] = options
-	}
+	v["options"] = options
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["message_thread_id"] = opts.MessageThreadId
-		v["question_parse_mode"] = opts.QuestionParseMode
-		if opts.QuestionEntities != nil {
-			v["question_entities"] = opts.QuestionEntities
-		}
-		v["is_anonymous"] = opts.IsAnonymous
-		v["type"] = opts.Type
-		v["allows_multiple_answers"] = opts.AllowsMultipleAnswers
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "question_parse_mode", opts.QuestionParseMode, opts.QuestionParseMode == "")
+		addIfValueNotZero(v, "question_entities", opts.QuestionEntities, opts.QuestionEntities == nil)
+		addIfValueNotZero(v, "is_anonymous", opts.IsAnonymous, opts.IsAnonymous == false)
+		addIfValueNotZero(v, "type", opts.Type, opts.Type == "")
+		addIfValueNotZero(v, "allows_multiple_answers", opts.AllowsMultipleAnswers, opts.AllowsMultipleAnswers == false)
 		if opts.Type == "quiz" {
 			// correct_option_id should always be set when the type is "quiz" - it doesnt need to be set for type "regular".
 			v["correct_option_id"] = opts.CorrectOptionId
 		}
-		v["explanation"] = opts.Explanation
-		v["explanation_parse_mode"] = opts.ExplanationParseMode
-		if opts.ExplanationEntities != nil {
-			v["explanation_entities"] = opts.ExplanationEntities
-		}
-		v["open_period"] = opts.OpenPeriod
-		v["close_date"] = opts.CloseDate
-		v["is_closed"] = opts.IsClosed
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
-		v["message_effect_id"] = opts.MessageEffectId
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
-		if opts.ReplyMarkup != nil {
-			v["reply_markup"] = opts.ReplyMarkup
-		}
+		addIfValueNotZero(v, "explanation", opts.Explanation, opts.Explanation == "")
+		addIfValueNotZero(v, "explanation_parse_mode", opts.ExplanationParseMode, opts.ExplanationParseMode == "")
+		addIfValueNotZero(v, "explanation_entities", opts.ExplanationEntities, opts.ExplanationEntities == nil)
+		addIfValueNotZero(v, "open_period", opts.OpenPeriod, opts.OpenPeriod == 0)
+		addIfValueNotZero(v, "close_date", opts.CloseDate, opts.CloseDate == 0)
+		addIfValueNotZero(v, "is_closed", opts.IsClosed, opts.IsClosed == false)
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "allow_paid_broadcast", opts.AllowPaidBroadcast, opts.AllowPaidBroadcast == false)
+		addIfValueNotZero(v, "message_effect_id", opts.MessageEffectId, opts.MessageEffectId == "")
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
+		addIfValueNotZero(v, "reply_markup", opts.ReplyMarkup, opts.ReplyMarkup == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -5405,27 +5231,19 @@ func (bot *Bot) SendSticker(chatId int64, sticker InputFileOrString, opts *SendS
 func (bot *Bot) SendStickerWithContext(ctx context.Context, chatId int64, sticker InputFileOrString, opts *SendStickerOpts) (*Message, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	if sticker != nil {
-		v["sticker"] = sticker
-	}
+	v["sticker"] = sticker
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["emoji"] = opts.Emoji
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
-		v["message_effect_id"] = opts.MessageEffectId
-		if opts.SuggestedPostParameters != nil {
-			v["suggested_post_parameters"] = opts.SuggestedPostParameters
-		}
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
-		if opts.ReplyMarkup != nil {
-			v["reply_markup"] = opts.ReplyMarkup
-		}
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		addIfValueNotZero(v, "emoji", opts.Emoji, opts.Emoji == "")
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "allow_paid_broadcast", opts.AllowPaidBroadcast, opts.AllowPaidBroadcast == false)
+		addIfValueNotZero(v, "message_effect_id", opts.MessageEffectId, opts.MessageEffectId == "")
+		addIfValueNotZero(v, "suggested_post_parameters", opts.SuggestedPostParameters, opts.SuggestedPostParameters == nil)
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
+		addIfValueNotZero(v, "reply_markup", opts.ReplyMarkup, opts.ReplyMarkup == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -5498,26 +5316,20 @@ func (bot *Bot) SendVenueWithContext(ctx context.Context, chatId int64, latitude
 	v["title"] = title
 	v["address"] = address
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["foursquare_id"] = opts.FoursquareId
-		v["foursquare_type"] = opts.FoursquareType
-		v["google_place_id"] = opts.GooglePlaceId
-		v["google_place_type"] = opts.GooglePlaceType
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
-		v["message_effect_id"] = opts.MessageEffectId
-		if opts.SuggestedPostParameters != nil {
-			v["suggested_post_parameters"] = opts.SuggestedPostParameters
-		}
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
-		if opts.ReplyMarkup != nil {
-			v["reply_markup"] = opts.ReplyMarkup
-		}
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		addIfValueNotZero(v, "foursquare_id", opts.FoursquareId, opts.FoursquareId == "")
+		addIfValueNotZero(v, "foursquare_type", opts.FoursquareType, opts.FoursquareType == "")
+		addIfValueNotZero(v, "google_place_id", opts.GooglePlaceId, opts.GooglePlaceId == "")
+		addIfValueNotZero(v, "google_place_type", opts.GooglePlaceType, opts.GooglePlaceType == "")
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "allow_paid_broadcast", opts.AllowPaidBroadcast, opts.AllowPaidBroadcast == false)
+		addIfValueNotZero(v, "message_effect_id", opts.MessageEffectId, opts.MessageEffectId == "")
+		addIfValueNotZero(v, "suggested_post_parameters", opts.SuggestedPostParameters, opts.SuggestedPostParameters == nil)
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
+		addIfValueNotZero(v, "reply_markup", opts.ReplyMarkup, opts.ReplyMarkup == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -5598,44 +5410,30 @@ func (bot *Bot) SendVideo(chatId int64, video InputFileOrString, opts *SendVideo
 func (bot *Bot) SendVideoWithContext(ctx context.Context, chatId int64, video InputFileOrString, opts *SendVideoOpts) (*Message, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	if video != nil {
-		v["video"] = video
-	}
+	v["video"] = video
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["duration"] = opts.Duration
-		v["width"] = opts.Width
-		v["height"] = opts.Height
-		if opts.Thumbnail != nil {
-			v["thumbnail"] = opts.Thumbnail
-		}
-		if opts.Cover != nil {
-			v["cover"] = opts.Cover
-		}
-		v["start_timestamp"] = opts.StartTimestamp
-		v["caption"] = opts.Caption
-		v["parse_mode"] = opts.ParseMode
-		if opts.CaptionEntities != nil {
-			v["caption_entities"] = opts.CaptionEntities
-		}
-		v["show_caption_above_media"] = opts.ShowCaptionAboveMedia
-		v["has_spoiler"] = opts.HasSpoiler
-		v["supports_streaming"] = opts.SupportsStreaming
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
-		v["message_effect_id"] = opts.MessageEffectId
-		if opts.SuggestedPostParameters != nil {
-			v["suggested_post_parameters"] = opts.SuggestedPostParameters
-		}
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
-		if opts.ReplyMarkup != nil {
-			v["reply_markup"] = opts.ReplyMarkup
-		}
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		addIfValueNotZero(v, "duration", opts.Duration, opts.Duration == 0)
+		addIfValueNotZero(v, "width", opts.Width, opts.Width == 0)
+		addIfValueNotZero(v, "height", opts.Height, opts.Height == 0)
+		v["thumbnail"] = opts.Thumbnail
+		addIfValueNotZero(v, "cover", opts.Cover, opts.Cover == nil)
+		addIfValueNotZero(v, "start_timestamp", opts.StartTimestamp, opts.StartTimestamp == 0)
+		addIfValueNotZero(v, "caption", opts.Caption, opts.Caption == "")
+		addIfValueNotZero(v, "parse_mode", opts.ParseMode, opts.ParseMode == "")
+		addIfValueNotZero(v, "caption_entities", opts.CaptionEntities, opts.CaptionEntities == nil)
+		addIfValueNotZero(v, "show_caption_above_media", opts.ShowCaptionAboveMedia, opts.ShowCaptionAboveMedia == false)
+		addIfValueNotZero(v, "has_spoiler", opts.HasSpoiler, opts.HasSpoiler == false)
+		addIfValueNotZero(v, "supports_streaming", opts.SupportsStreaming, opts.SupportsStreaming == false)
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "allow_paid_broadcast", opts.AllowPaidBroadcast, opts.AllowPaidBroadcast == false)
+		addIfValueNotZero(v, "message_effect_id", opts.MessageEffectId, opts.MessageEffectId == "")
+		addIfValueNotZero(v, "suggested_post_parameters", opts.SuggestedPostParameters, opts.SuggestedPostParameters == nil)
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
+		addIfValueNotZero(v, "reply_markup", opts.ReplyMarkup, opts.ReplyMarkup == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -5698,31 +5496,21 @@ func (bot *Bot) SendVideoNote(chatId int64, videoNote InputFileOrString, opts *S
 func (bot *Bot) SendVideoNoteWithContext(ctx context.Context, chatId int64, videoNote InputFileOrString, opts *SendVideoNoteOpts) (*Message, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	if videoNote != nil {
-		v["video_note"] = videoNote
-	}
+	v["video_note"] = videoNote
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["duration"] = opts.Duration
-		v["length"] = opts.Length
-		if opts.Thumbnail != nil {
-			v["thumbnail"] = opts.Thumbnail
-		}
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
-		v["message_effect_id"] = opts.MessageEffectId
-		if opts.SuggestedPostParameters != nil {
-			v["suggested_post_parameters"] = opts.SuggestedPostParameters
-		}
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
-		if opts.ReplyMarkup != nil {
-			v["reply_markup"] = opts.ReplyMarkup
-		}
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		addIfValueNotZero(v, "duration", opts.Duration, opts.Duration == 0)
+		addIfValueNotZero(v, "length", opts.Length, opts.Length == 0)
+		v["thumbnail"] = opts.Thumbnail
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "allow_paid_broadcast", opts.AllowPaidBroadcast, opts.AllowPaidBroadcast == false)
+		addIfValueNotZero(v, "message_effect_id", opts.MessageEffectId, opts.MessageEffectId == "")
+		addIfValueNotZero(v, "suggested_post_parameters", opts.SuggestedPostParameters, opts.SuggestedPostParameters == nil)
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
+		addIfValueNotZero(v, "reply_markup", opts.ReplyMarkup, opts.ReplyMarkup == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -5787,32 +5575,22 @@ func (bot *Bot) SendVoice(chatId int64, voice InputFileOrString, opts *SendVoice
 func (bot *Bot) SendVoiceWithContext(ctx context.Context, chatId int64, voice InputFileOrString, opts *SendVoiceOpts) (*Message, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	if voice != nil {
-		v["voice"] = voice
-	}
+	v["voice"] = voice
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["message_thread_id"] = opts.MessageThreadId
-		v["direct_messages_topic_id"] = opts.DirectMessagesTopicId
-		v["caption"] = opts.Caption
-		v["parse_mode"] = opts.ParseMode
-		if opts.CaptionEntities != nil {
-			v["caption_entities"] = opts.CaptionEntities
-		}
-		v["duration"] = opts.Duration
-		v["disable_notification"] = opts.DisableNotification
-		v["protect_content"] = opts.ProtectContent
-		v["allow_paid_broadcast"] = opts.AllowPaidBroadcast
-		v["message_effect_id"] = opts.MessageEffectId
-		if opts.SuggestedPostParameters != nil {
-			v["suggested_post_parameters"] = opts.SuggestedPostParameters
-		}
-		if opts.ReplyParameters != nil {
-			v["reply_parameters"] = opts.ReplyParameters
-		}
-		if opts.ReplyMarkup != nil {
-			v["reply_markup"] = opts.ReplyMarkup
-		}
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
+		addIfValueNotZero(v, "direct_messages_topic_id", opts.DirectMessagesTopicId, opts.DirectMessagesTopicId == 0)
+		addIfValueNotZero(v, "caption", opts.Caption, opts.Caption == "")
+		addIfValueNotZero(v, "parse_mode", opts.ParseMode, opts.ParseMode == "")
+		addIfValueNotZero(v, "caption_entities", opts.CaptionEntities, opts.CaptionEntities == nil)
+		addIfValueNotZero(v, "duration", opts.Duration, opts.Duration == 0)
+		addIfValueNotZero(v, "disable_notification", opts.DisableNotification, opts.DisableNotification == false)
+		addIfValueNotZero(v, "protect_content", opts.ProtectContent, opts.ProtectContent == false)
+		addIfValueNotZero(v, "allow_paid_broadcast", opts.AllowPaidBroadcast, opts.AllowPaidBroadcast == false)
+		addIfValueNotZero(v, "message_effect_id", opts.MessageEffectId, opts.MessageEffectId == "")
+		addIfValueNotZero(v, "suggested_post_parameters", opts.SuggestedPostParameters, opts.SuggestedPostParameters == nil)
+		addIfValueNotZero(v, "reply_parameters", opts.ReplyParameters, opts.ReplyParameters == nil)
+		addIfValueNotZero(v, "reply_markup", opts.ReplyMarkup, opts.ReplyMarkup == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -5851,7 +5629,7 @@ func (bot *Bot) SetBusinessAccountBioWithContext(ctx context.Context, businessCo
 	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
 	if opts != nil {
-		v["bio"] = opts.Bio
+		addIfValueNotZero(v, "bio", opts.Bio, opts.Bio == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -5930,7 +5708,7 @@ func (bot *Bot) SetBusinessAccountNameWithContext(ctx context.Context, businessC
 	v["business_connection_id"] = businessConnectionId
 	v["first_name"] = firstName
 	if opts != nil {
-		v["last_name"] = opts.LastName
+		addIfValueNotZero(v, "last_name", opts.LastName, opts.LastName == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -5971,7 +5749,7 @@ func (bot *Bot) SetBusinessAccountProfilePhotoWithContext(ctx context.Context, b
 	v["business_connection_id"] = businessConnectionId
 	v["photo"] = photo
 	if opts != nil {
-		v["is_public"] = opts.IsPublic
+		addIfValueNotZero(v, "is_public", opts.IsPublic, opts.IsPublic == false)
 	}
 
 	var reqOpts *RequestOpts
@@ -6010,7 +5788,7 @@ func (bot *Bot) SetBusinessAccountUsernameWithContext(ctx context.Context, busin
 	v := map[string]any{}
 	v["business_connection_id"] = businessConnectionId
 	if opts != nil {
-		v["username"] = opts.Username
+		addIfValueNotZero(v, "username", opts.Username, opts.Username == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -6087,7 +5865,7 @@ func (bot *Bot) SetChatDescriptionWithContext(ctx context.Context, chatId int64,
 	v := map[string]any{}
 	v["chat_id"] = chatId
 	if opts != nil {
-		v["description"] = opts.Description
+		addIfValueNotZero(v, "description", opts.Description, opts.Description == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -6126,9 +5904,7 @@ func (bot *Bot) SetChatMenuButton(opts *SetChatMenuButtonOpts) (bool, error) {
 func (bot *Bot) SetChatMenuButtonWithContext(ctx context.Context, opts *SetChatMenuButtonOpts) (bool, error) {
 	v := map[string]any{}
 	if opts != nil {
-		if opts.ChatId != nil {
-			v["chat_id"] = opts.ChatId
-		}
+		addIfValueNotZero(v, "chat_id", opts.ChatId, opts.ChatId == nil)
 		v["menu_button"] = opts.MenuButton
 	}
 
@@ -6170,7 +5946,7 @@ func (bot *Bot) SetChatPermissionsWithContext(ctx context.Context, chatId int64,
 	v["chat_id"] = chatId
 	v["permissions"] = permissions
 	if opts != nil {
-		v["use_independent_chat_permissions"] = opts.UseIndependentChatPermissions
+		addIfValueNotZero(v, "use_independent_chat_permissions", opts.UseIndependentChatPermissions, opts.UseIndependentChatPermissions == false)
 	}
 
 	var reqOpts *RequestOpts
@@ -6207,9 +5983,7 @@ func (bot *Bot) SetChatPhoto(chatId int64, photo InputFile, opts *SetChatPhotoOp
 func (bot *Bot) SetChatPhotoWithContext(ctx context.Context, chatId int64, photo InputFile, opts *SetChatPhotoOpts) (bool, error) {
 	v := map[string]any{}
 	v["chat_id"] = chatId
-	if photo != nil {
-		v["photo"] = photo
-	}
+	v["photo"] = photo
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -6319,7 +6093,7 @@ func (bot *Bot) SetCustomEmojiStickerSetThumbnailWithContext(ctx context.Context
 	v := map[string]any{}
 	v["name"] = name
 	if opts != nil {
-		v["custom_emoji_id"] = opts.CustomEmojiId
+		addIfValueNotZero(v, "custom_emoji_id", opts.CustomEmojiId, opts.CustomEmojiId == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -6368,11 +6142,11 @@ func (bot *Bot) SetGameScoreWithContext(ctx context.Context, userId int64, score
 	v["user_id"] = userId
 	v["score"] = score
 	if opts != nil {
-		v["force"] = opts.Force
-		v["disable_edit_message"] = opts.DisableEditMessage
-		v["chat_id"] = opts.ChatId
-		v["message_id"] = opts.MessageId
-		v["inline_message_id"] = opts.InlineMessageId
+		addIfValueNotZero(v, "force", opts.Force, opts.Force == false)
+		addIfValueNotZero(v, "disable_edit_message", opts.DisableEditMessage, opts.DisableEditMessage == false)
+		addIfValueNotZero(v, "chat_id", opts.ChatId, opts.ChatId == 0)
+		addIfValueNotZero(v, "message_id", opts.MessageId, opts.MessageId == 0)
+		addIfValueNotZero(v, "inline_message_id", opts.InlineMessageId, opts.InlineMessageId == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -6423,10 +6197,8 @@ func (bot *Bot) SetMessageReactionWithContext(ctx context.Context, chatId int64,
 	v["chat_id"] = chatId
 	v["message_id"] = messageId
 	if opts != nil {
-		if opts.Reaction != nil {
-			v["reaction"] = opts.Reaction
-		}
-		v["is_big"] = opts.IsBig
+		addIfValueNotZero(v, "reaction", opts.Reaction, opts.Reaction == nil)
+		addIfValueNotZero(v, "is_big", opts.IsBig, opts.IsBig == false)
 	}
 
 	var reqOpts *RequestOpts
@@ -6465,12 +6237,10 @@ func (bot *Bot) SetMyCommands(commands []BotCommand, opts *SetMyCommandsOpts) (b
 // SetMyCommandsWithContext is the same as Bot.SetMyCommands, but with a context.Context parameter
 func (bot *Bot) SetMyCommandsWithContext(ctx context.Context, commands []BotCommand, opts *SetMyCommandsOpts) (bool, error) {
 	v := map[string]any{}
-	if commands != nil {
-		v["commands"] = commands
-	}
+	v["commands"] = commands
 	if opts != nil {
 		v["scope"] = opts.Scope
-		v["language_code"] = opts.LanguageCode
+		addIfValueNotZero(v, "language_code", opts.LanguageCode, opts.LanguageCode == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -6509,10 +6279,8 @@ func (bot *Bot) SetMyDefaultAdministratorRights(opts *SetMyDefaultAdministratorR
 func (bot *Bot) SetMyDefaultAdministratorRightsWithContext(ctx context.Context, opts *SetMyDefaultAdministratorRightsOpts) (bool, error) {
 	v := map[string]any{}
 	if opts != nil {
-		if opts.Rights != nil {
-			v["rights"] = opts.Rights
-		}
-		v["for_channels"] = opts.ForChannels
+		addIfValueNotZero(v, "rights", opts.Rights, opts.Rights == nil)
+		addIfValueNotZero(v, "for_channels", opts.ForChannels, opts.ForChannels == false)
 	}
 
 	var reqOpts *RequestOpts
@@ -6551,8 +6319,8 @@ func (bot *Bot) SetMyDescription(opts *SetMyDescriptionOpts) (bool, error) {
 func (bot *Bot) SetMyDescriptionWithContext(ctx context.Context, opts *SetMyDescriptionOpts) (bool, error) {
 	v := map[string]any{}
 	if opts != nil {
-		v["description"] = opts.Description
-		v["language_code"] = opts.LanguageCode
+		addIfValueNotZero(v, "description", opts.Description, opts.Description == "")
+		addIfValueNotZero(v, "language_code", opts.LanguageCode, opts.LanguageCode == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -6591,8 +6359,8 @@ func (bot *Bot) SetMyName(opts *SetMyNameOpts) (bool, error) {
 func (bot *Bot) SetMyNameWithContext(ctx context.Context, opts *SetMyNameOpts) (bool, error) {
 	v := map[string]any{}
 	if opts != nil {
-		v["name"] = opts.Name
-		v["language_code"] = opts.LanguageCode
+		addIfValueNotZero(v, "name", opts.Name, opts.Name == "")
+		addIfValueNotZero(v, "language_code", opts.LanguageCode, opts.LanguageCode == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -6631,8 +6399,8 @@ func (bot *Bot) SetMyShortDescription(opts *SetMyShortDescriptionOpts) (bool, er
 func (bot *Bot) SetMyShortDescriptionWithContext(ctx context.Context, opts *SetMyShortDescriptionOpts) (bool, error) {
 	v := map[string]any{}
 	if opts != nil {
-		v["short_description"] = opts.ShortDescription
-		v["language_code"] = opts.LanguageCode
+		addIfValueNotZero(v, "short_description", opts.ShortDescription, opts.ShortDescription == "")
+		addIfValueNotZero(v, "language_code", opts.LanguageCode, opts.LanguageCode == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -6670,9 +6438,7 @@ func (bot *Bot) SetPassportDataErrors(userId int64, errors []PassportElementErro
 func (bot *Bot) SetPassportDataErrorsWithContext(ctx context.Context, userId int64, errors []PassportElementError, opts *SetPassportDataErrorsOpts) (bool, error) {
 	v := map[string]any{}
 	v["user_id"] = userId
-	if errors != nil {
-		v["errors"] = errors
-	}
+	v["errors"] = errors
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -6707,12 +6473,8 @@ func (bot *Bot) SetStickerEmojiList(sticker InputFileOrString, emojiList []strin
 // SetStickerEmojiListWithContext is the same as Bot.SetStickerEmojiList, but with a context.Context parameter
 func (bot *Bot) SetStickerEmojiListWithContext(ctx context.Context, sticker InputFileOrString, emojiList []string, opts *SetStickerEmojiListOpts) (bool, error) {
 	v := map[string]any{}
-	if sticker != nil {
-		v["sticker"] = sticker
-	}
-	if emojiList != nil {
-		v["emoji_list"] = emojiList
-	}
+	v["sticker"] = sticker
+	v["emoji_list"] = emojiList
 
 	var reqOpts *RequestOpts
 	if opts != nil {
@@ -6748,13 +6510,9 @@ func (bot *Bot) SetStickerKeywords(sticker InputFileOrString, opts *SetStickerKe
 // SetStickerKeywordsWithContext is the same as Bot.SetStickerKeywords, but with a context.Context parameter
 func (bot *Bot) SetStickerKeywordsWithContext(ctx context.Context, sticker InputFileOrString, opts *SetStickerKeywordsOpts) (bool, error) {
 	v := map[string]any{}
-	if sticker != nil {
-		v["sticker"] = sticker
-	}
+	v["sticker"] = sticker
 	if opts != nil {
-		if opts.Keywords != nil {
-			v["keywords"] = opts.Keywords
-		}
+		addIfValueNotZero(v, "keywords", opts.Keywords, opts.Keywords == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -6791,13 +6549,9 @@ func (bot *Bot) SetStickerMaskPosition(sticker InputFileOrString, opts *SetStick
 // SetStickerMaskPositionWithContext is the same as Bot.SetStickerMaskPosition, but with a context.Context parameter
 func (bot *Bot) SetStickerMaskPositionWithContext(ctx context.Context, sticker InputFileOrString, opts *SetStickerMaskPositionOpts) (bool, error) {
 	v := map[string]any{}
-	if sticker != nil {
-		v["sticker"] = sticker
-	}
+	v["sticker"] = sticker
 	if opts != nil {
-		if opts.MaskPosition != nil {
-			v["mask_position"] = opts.MaskPosition
-		}
+		addIfValueNotZero(v, "mask_position", opts.MaskPosition, opts.MaskPosition == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -6833,9 +6587,7 @@ func (bot *Bot) SetStickerPositionInSet(sticker InputFileOrString, position int6
 // SetStickerPositionInSetWithContext is the same as Bot.SetStickerPositionInSet, but with a context.Context parameter
 func (bot *Bot) SetStickerPositionInSetWithContext(ctx context.Context, sticker InputFileOrString, position int64, opts *SetStickerPositionInSetOpts) (bool, error) {
 	v := map[string]any{}
-	if sticker != nil {
-		v["sticker"] = sticker
-	}
+	v["sticker"] = sticker
 	v["position"] = position
 
 	var reqOpts *RequestOpts
@@ -6878,9 +6630,7 @@ func (bot *Bot) SetStickerSetThumbnailWithContext(ctx context.Context, name stri
 	v["user_id"] = userId
 	v["format"] = format
 	if opts != nil {
-		if opts.Thumbnail != nil {
-			v["thumbnail"] = opts.Thumbnail
-		}
+		v["thumbnail"] = opts.Thumbnail
 	}
 
 	var reqOpts *RequestOpts
@@ -6957,8 +6707,8 @@ func (bot *Bot) SetUserEmojiStatusWithContext(ctx context.Context, userId int64,
 	v := map[string]any{}
 	v["user_id"] = userId
 	if opts != nil {
-		v["emoji_status_custom_emoji_id"] = opts.EmojiStatusCustomEmojiId
-		v["emoji_status_expiration_date"] = opts.EmojiStatusExpirationDate
+		addIfValueNotZero(v, "emoji_status_custom_emoji_id", opts.EmojiStatusCustomEmojiId, opts.EmojiStatusCustomEmojiId == "")
+		addIfValueNotZero(v, "emoji_status_expiration_date", opts.EmojiStatusExpirationDate, opts.EmojiStatusExpirationDate == 0)
 	}
 
 	var reqOpts *RequestOpts
@@ -7008,16 +6758,12 @@ func (bot *Bot) SetWebhookWithContext(ctx context.Context, url string, opts *Set
 	v := map[string]any{}
 	v["url"] = url
 	if opts != nil {
-		if opts.Certificate != nil {
-			v["certificate"] = opts.Certificate
-		}
-		v["ip_address"] = opts.IpAddress
-		v["max_connections"] = opts.MaxConnections
-		if opts.AllowedUpdates != nil {
-			v["allowed_updates"] = opts.AllowedUpdates
-		}
-		v["drop_pending_updates"] = opts.DropPendingUpdates
-		v["secret_token"] = opts.SecretToken
+		v["certificate"] = opts.Certificate
+		addIfValueNotZero(v, "ip_address", opts.IpAddress, opts.IpAddress == "")
+		addIfValueNotZero(v, "max_connections", opts.MaxConnections, opts.MaxConnections == 0)
+		addIfValueNotZero(v, "allowed_updates", opts.AllowedUpdates, opts.AllowedUpdates == nil)
+		addIfValueNotZero(v, "drop_pending_updates", opts.DropPendingUpdates, opts.DropPendingUpdates == false)
+		addIfValueNotZero(v, "secret_token", opts.SecretToken, opts.SecretToken == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -7062,10 +6808,10 @@ func (bot *Bot) StopMessageLiveLocation(opts *StopMessageLiveLocationOpts) (*Mes
 func (bot *Bot) StopMessageLiveLocationWithContext(ctx context.Context, opts *StopMessageLiveLocationOpts) (*Message, bool, error) {
 	v := map[string]any{}
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		v["chat_id"] = opts.ChatId
-		v["message_id"] = opts.MessageId
-		v["inline_message_id"] = opts.InlineMessageId
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "chat_id", opts.ChatId, opts.ChatId == 0)
+		addIfValueNotZero(v, "message_id", opts.MessageId, opts.MessageId == 0)
+		addIfValueNotZero(v, "inline_message_id", opts.InlineMessageId, opts.InlineMessageId == "")
 		v["reply_markup"] = opts.ReplyMarkup
 	}
 
@@ -7117,7 +6863,7 @@ func (bot *Bot) StopPollWithContext(ctx context.Context, chatId int64, messageId
 	v["chat_id"] = chatId
 	v["message_id"] = messageId
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
 		v["reply_markup"] = opts.ReplyMarkup
 	}
 
@@ -7197,7 +6943,7 @@ func (bot *Bot) TransferGiftWithContext(ctx context.Context, businessConnectionI
 	v["owned_gift_id"] = ownedGiftId
 	v["new_owner_chat_id"] = newOwnerChatId
 	if opts != nil {
-		v["star_count"] = opts.StarCount
+		addIfValueNotZero(v, "star_count", opts.StarCount, opts.StarCount == 0)
 	}
 
 	var reqOpts *RequestOpts
@@ -7238,7 +6984,7 @@ func (bot *Bot) UnbanChatMemberWithContext(ctx context.Context, chatId int64, us
 	v["chat_id"] = chatId
 	v["user_id"] = userId
 	if opts != nil {
-		v["only_if_banned"] = opts.OnlyIfBanned
+		addIfValueNotZero(v, "only_if_banned", opts.OnlyIfBanned, opts.OnlyIfBanned == false)
 	}
 
 	var reqOpts *RequestOpts
@@ -7453,10 +7199,8 @@ func (bot *Bot) UnpinChatMessageWithContext(ctx context.Context, chatId int64, o
 	v := map[string]any{}
 	v["chat_id"] = chatId
 	if opts != nil {
-		v["business_connection_id"] = opts.BusinessConnectionId
-		if opts.MessageId != nil {
-			v["message_id"] = opts.MessageId
-		}
+		addIfValueNotZero(v, "business_connection_id", opts.BusinessConnectionId, opts.BusinessConnectionId == "")
+		addIfValueNotZero(v, "message_id", opts.MessageId, opts.MessageId == nil)
 	}
 
 	var reqOpts *RequestOpts
@@ -7499,8 +7243,8 @@ func (bot *Bot) UpgradeGiftWithContext(ctx context.Context, businessConnectionId
 	v["business_connection_id"] = businessConnectionId
 	v["owned_gift_id"] = ownedGiftId
 	if opts != nil {
-		v["keep_original_details"] = opts.KeepOriginalDetails
-		v["star_count"] = opts.StarCount
+		addIfValueNotZero(v, "keep_original_details", opts.KeepOriginalDetails, opts.KeepOriginalDetails == false)
+		addIfValueNotZero(v, "star_count", opts.StarCount, opts.StarCount == 0)
 	}
 
 	var reqOpts *RequestOpts
@@ -7538,9 +7282,7 @@ func (bot *Bot) UploadStickerFile(userId int64, sticker InputFile, stickerFormat
 func (bot *Bot) UploadStickerFileWithContext(ctx context.Context, userId int64, sticker InputFile, stickerFormat string, opts *UploadStickerFileOpts) (*File, error) {
 	v := map[string]any{}
 	v["user_id"] = userId
-	if sticker != nil {
-		v["sticker"] = sticker
-	}
+	v["sticker"] = sticker
 	v["sticker_format"] = stickerFormat
 
 	var reqOpts *RequestOpts
@@ -7579,7 +7321,7 @@ func (bot *Bot) VerifyChatWithContext(ctx context.Context, chatId int64, opts *V
 	v := map[string]any{}
 	v["chat_id"] = chatId
 	if opts != nil {
-		v["custom_description"] = opts.CustomDescription
+		addIfValueNotZero(v, "custom_description", opts.CustomDescription, opts.CustomDescription == "")
 	}
 
 	var reqOpts *RequestOpts
@@ -7618,7 +7360,7 @@ func (bot *Bot) VerifyUserWithContext(ctx context.Context, userId int64, opts *V
 	v := map[string]any{}
 	v["user_id"] = userId
 	if opts != nil {
-		v["custom_description"] = opts.CustomDescription
+		addIfValueNotZero(v, "custom_description", opts.CustomDescription, opts.CustomDescription == "")
 	}
 
 	var reqOpts *RequestOpts

--- a/gen_methods.go
+++ b/gen_methods.go
@@ -97,7 +97,7 @@ func (bot *Bot) AnswerCallbackQueryWithContext(ctx context.Context, callbackQuer
 // AnswerInlineQueryOpts is the set of optional fields for Bot.AnswerInlineQuery and Bot.AnswerInlineQueryWithContext.
 type AnswerInlineQueryOpts struct {
 	// The maximum amount of time in seconds that the result of the inline query may be cached on the server. Defaults to 300.
-	CacheTime int64
+	CacheTime *int64
 	// Pass True if results may be cached on the server side only for the user that sent the query. By default, results may be returned to any user who sends the same query.
 	IsPersonal bool
 	// Pass the offset that a client should send in the next query with the same text to receive more results. Pass an empty string if there are no more results or if you don't support pagination. Offset length can't exceed 64 bytes.
@@ -125,7 +125,7 @@ func (bot *Bot) AnswerInlineQueryWithContext(ctx context.Context, inlineQueryId 
 	v["inline_query_id"] = inlineQueryId
 	v["results"] = results
 	if opts != nil {
-		addIfValueNotZero(v, "cache_time", opts.CacheTime, opts.CacheTime == 0)
+		addIfValueNotZero(v, "cache_time", opts.CacheTime, opts.CacheTime == nil)
 		addIfValueNotZero(v, "is_personal", opts.IsPersonal, opts.IsPersonal == false)
 		addIfValueNotZero(v, "next_offset", opts.NextOffset, opts.NextOffset == "")
 		addIfValueNotZero(v, "button", opts.Button, opts.Button == nil)
@@ -5097,7 +5097,7 @@ type SendPollOpts struct {
 	// A JSON-serialized list of special entities that appear in the poll question. It can be specified instead of question_parse_mode
 	QuestionEntities []MessageEntity
 	// True, if the poll needs to be anonymous, defaults to True
-	IsAnonymous bool
+	IsAnonymous *bool
 	// Poll type, "quiz" or "regular", defaults to "regular"
 	Type string
 	// True, if the poll allows multiple answers, ignored for polls in quiz mode, defaults to False
@@ -5154,7 +5154,7 @@ func (bot *Bot) SendPollWithContext(ctx context.Context, chatId int64, question 
 		addIfValueNotZero(v, "message_thread_id", opts.MessageThreadId, opts.MessageThreadId == 0)
 		addIfValueNotZero(v, "question_parse_mode", opts.QuestionParseMode, opts.QuestionParseMode == "")
 		addIfValueNotZero(v, "question_entities", opts.QuestionEntities, opts.QuestionEntities == nil)
-		addIfValueNotZero(v, "is_anonymous", opts.IsAnonymous, opts.IsAnonymous == false)
+		addIfValueNotZero(v, "is_anonymous", opts.IsAnonymous, opts.IsAnonymous == nil)
 		addIfValueNotZero(v, "type", opts.Type, opts.Type == "")
 		addIfValueNotZero(v, "allows_multiple_answers", opts.AllowsMultipleAnswers, opts.AllowsMultipleAnswers == false)
 		if opts.Type == "quiz" {

--- a/gen_methods.go
+++ b/gen_methods.go
@@ -5158,7 +5158,7 @@ func (bot *Bot) SendPollWithContext(ctx context.Context, chatId int64, question 
 		addIfValueNotZero(v, "type", opts.Type, opts.Type == "")
 		addIfValueNotZero(v, "allows_multiple_answers", opts.AllowsMultipleAnswers, opts.AllowsMultipleAnswers == false)
 		if opts.Type == "quiz" {
-			// correct_option_id should always be set when the type is "quiz" - it doesnt need to be set for type "regular".
+			// correct_option_id should always be set when the type is "quiz" - it doesn't need to be set for type "regular".
 			v["correct_option_id"] = opts.CorrectOptionId
 		}
 		addIfValueNotZero(v, "explanation", opts.Explanation, opts.Explanation == "")

--- a/scripts/generate/common.go
+++ b/scripts/generate/common.go
@@ -88,7 +88,8 @@ func isTgArray(s string) bool {
 func isPointer(s string) bool {
 	return strings.HasPrefix(s, "*") ||
 		s == tgTypeInputFile || s == typeInputFileOrString || s == typeInputString ||
-		s == tgTypeInputMedia || s == tgTypeInputPaidMedia
+		s == tgTypeInputMedia || s == tgTypeInputPaidMedia ||
+		s == typeReplyMarkup
 }
 
 func isArray(s string) bool {
@@ -114,8 +115,8 @@ func getDefaultTypeVal(d APIDescription, s string) string {
 			return "nil"
 		}
 
-		// this isnt great
-		return s
+		// this isn't great
+		return s + "{}"
 	}
 }
 
@@ -125,30 +126,6 @@ func getDefaultReturnVals(d APIDescription, types []string) []string {
 		retVals = append(retVals, getDefaultTypeVal(d, retType))
 	}
 	return retVals
-}
-
-// goTypeStringer provides us with the fmt strings that allow us to convert basic types into strings.
-// For example, we define how to handle ints, bools, and strings.
-// More complicated types should be handled separately.
-func goTypeStringer(t string) string {
-	switch t {
-	case "int64":
-		return "strconv.FormatInt(%s, 10)"
-	case "*int64":
-		return "strconv.FormatInt(*%s, 10)"
-	case "float64":
-		return "strconv.FormatFloat(%s, 'f', -1, 64)"
-	case "bool":
-		return "strconv.FormatBool(%s)"
-	case "*bool":
-		return "strconv.FormatBool(*%s)"
-	case "string":
-		return "%s"
-	case "*string":
-		return "*%s"
-	default:
-		return ""
-	}
 }
 
 // getAllFields merges all the fields from list of types.

--- a/scripts/generate/gen.go
+++ b/scripts/generate/gen.go
@@ -199,6 +199,20 @@ type Field struct {
 	Description string   `json:"description"`
 }
 
+var defaultsMatcher = regexp.MustCompile(`(?i)defaults to (true|false|\d+.\d+|\d+)`)
+
+func (f Field) hasDefault() (string, bool) {
+	if !strings.Contains(strings.ToLower(f.Description), "defaults to") {
+		return "", false
+	}
+
+	ms := defaultsMatcher.FindStringSubmatch(f.Description)
+	if len(ms) == 0 {
+		return "", true
+	}
+	return strings.ToLower(ms[1]), true
+}
+
 var usernameDocsMatcher = regexp.MustCompile(` +(or username.*)?\(.+ @[a-z]+\)`)
 
 func (f Field) GetDescription() string {
@@ -409,6 +423,14 @@ func (f Field) getPreferredType(d APIDescription) (string, error) {
 			if f.Name == "text" && strings.Contains(f.Description, "nothing will be shown") {
 				return goType, nil
 			}
+			return "*" + goType, nil
+
+		} else if v, ok := f.hasDefault(); ok && v != "" && v != getDefaultTypeVal(d, goType) {
+			if goType == "int64" && strings.Contains(f.Description, "1-") {
+				// If we have a range of 1-X, it means that the default go-type of 0 is will be ignored the server
+				return goType, nil
+			}
+
 			return "*" + goType, nil
 		}
 

--- a/scripts/generate/methods.go
+++ b/scripts/generate/methods.go
@@ -236,6 +236,9 @@ if opts.Type == "quiz" {
 	// correct_option_id should always be set when the type is "quiz" - it doesn't need to be set for type "regular".
 	%s
 }`, fmt.Sprintf(`v["%s"] = %s`, f.Name, goParam)), nil
+
+	} else if strings.Contains(f.Description, "required for") {
+		return "", fmt.Errorf("method %s contains a 'required for' field %s which may require special handling", methodName, f.Name)
 	}
 
 	// Telegram types can't be compared; we just add them automatically

--- a/scripts/generate/methods.go
+++ b/scripts/generate/methods.go
@@ -219,48 +219,32 @@ func generateValue(d APIDescription, methodName string, f Field, goParam string)
 		return "", fmt.Errorf("failed to get preferred type: %w", err)
 	}
 
-	stringer := goTypeStringer(fieldType)
-	if stringer != "" {
-		if !f.Required {
-			// Ints and Floats should generally not be sent if they're 0.
-			if fieldType == "int64" || fieldType == "float64" {
-				// Editing an inline query requires the inline_message_id. However, if we send the empty chat_id with it,
-				// it'll fail with a "chat not found" error, since it believes were trying to access the chat with ID 0.
-				// To avoid this, we want to make sure not to add default integers or floats to requests.
-				// This is a good rule of thumb, however... it doesn't ALWAYS work.
-				// So, any exceptions should go here:
-				if methodName == "sendPoll" && f.Name == "correct_option_id" {
-					// correct_option_id (in sendPoll) is dependent on the "type" field being "quiz".
-					// It isn't used for "regular" polls. It still needs to be sent when the value is "0".
-					return fmt.Sprintf(`
+	if f.Required {
+		return fmt.Sprintf("\nv[\"%s\"] = %s", f.Name, goParam), nil
+	}
+
+	// Editing an inline query requires the inline_message_id. However, if we send the empty chat_id with it,
+	// it'll fail with a "chat not found" error, since it believes were trying to access the chat with ID 0.
+	// To avoid this, we want to make sure not to add default integers or floats to requests.
+	// This is a good rule of thumb, however... it doesn't ALWAYS work.
+	// So, any exceptions should go here:
+	if methodName == "sendPoll" && f.Name == "correct_option_id" {
+		// correct_option_id (in sendPoll) is dependent on the "type" field being "quiz".
+		// It isn't used for "regular" polls. It still needs to be sent when the value is "0".
+		return fmt.Sprintf(`
 if opts.Type == "quiz" {
 	// correct_option_id should always be set when the type is "quiz" - it doesnt need to be set for type "regular".
 	%s
 }`, fmt.Sprintf(`v["%s"] = %s`, f.Name, goParam)), nil
-				}
-
-				return fmt.Sprintf("\nv[\"%s\"] = %s", f.Name, goParam), nil
-			}
-
-			if isPointer(fieldType) {
-				return fmt.Sprintf(`
-if %s != nil {
-	v["%s"] = %s
-}`, goParam, f.Name, goParam), nil
-			}
-		}
-
-		return fmt.Sprintf("\nv[\"%s\"] = %s", f.Name, goParam), nil
 	}
 
-	if isPointer(fieldType) || isArray(fieldType) || fieldType == typeReplyMarkup {
-		return fmt.Sprintf(`
-if %s != nil {
-  v["%s"] = %s
-}`, goParam, f.Name, goParam), nil
+	// Telegram types can't be compared; we just add them automatically
+	if _, ok := d.Types[fieldType]; ok {
+		return "\n	v[\"" + f.Name + "\"] = " + goParam, nil
 	}
 
-	return "\n	v[\"" + f.Name + "\"] = " + goParam, nil
+	// otherwise, we only add the field if it's non-zero; this avoids us sending unnecessary data to tg
+	return fmt.Sprintf("\naddIfValueNotZero(v, \"%s\", %s, %s == %s)", f.Name, goParam, goParam, getDefaultTypeVal(d, fieldType)), nil
 }
 
 func getRetVarName(retType string) string {

--- a/scripts/generate/methods.go
+++ b/scripts/generate/methods.go
@@ -233,7 +233,7 @@ func generateValue(d APIDescription, methodName string, f Field, goParam string)
 		// It isn't used for "regular" polls. It still needs to be sent when the value is "0".
 		return fmt.Sprintf(`
 if opts.Type == "quiz" {
-	// correct_option_id should always be set when the type is "quiz" - it doesnt need to be set for type "regular".
+	// correct_option_id should always be set when the type is "quiz" - it doesn't need to be set for type "regular".
 	%s
 }`, fmt.Sprintf(`v["%s"] = %s`, f.Name, goParam)), nil
 	}


### PR DESCRIPTION
# What

Following #242, we now add all fields to our requests. We previously relied on the json library to trim these when sending via application/json.

This PR re-adds this behaviour through a helper function one-liner at each call site.

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
