### PR TITLE
Update to go 1.24

### DIFF
--- a/ext/context.go
+++ b/ext/context.go
@@ -16,7 +16,7 @@ type Context struct {
 	// Data represents update-local storage.
 	// This can be used to pass data across handlers - for example, to cache operations relevant to the current update,
 	// such as admin checks.
-	Data map[string]interface{}
+	Data map[string]any
 
 	// EffectiveMessage is the message which triggered the update, if available.
 	// If the message is an InaccessibleMessage (eg, from a callbackquery), the message contents may be inaccessible.
@@ -40,7 +40,7 @@ type Context struct {
 
 // NewContext populates a context with the relevant fields from the current bot and update.
 // It takes a data field in the case where custom data needs to be passed.
-func NewContext(b *gotgbot.Bot, update *gotgbot.Update, data map[string]interface{}) *Context {
+func NewContext(b *gotgbot.Bot, update *gotgbot.Update, data map[string]any) *Context {
 	var msg *gotgbot.Message
 	var chat *gotgbot.Chat
 	var user *gotgbot.User
@@ -149,7 +149,7 @@ func NewContext(b *gotgbot.Bot, update *gotgbot.Update, data map[string]interfac
 	}
 
 	if data == nil {
-		data = make(map[string]interface{})
+		data = make(map[string]any)
 	}
 
 	if sender == nil {

--- a/ext/dispatcher.go
+++ b/ext/dispatcher.go
@@ -24,7 +24,7 @@ type (
 	// It takes the non-nil error returned by the handler.
 	DispatcherErrorHandler func(b *gotgbot.Bot, ctx *Context, err error) DispatcherAction
 	// DispatcherPanicHandler allows for handling goroutine panics, where the 'r' value contains the reason for the panic.
-	DispatcherPanicHandler func(b *gotgbot.Bot, ctx *Context, r interface{})
+	DispatcherPanicHandler func(b *gotgbot.Bot, ctx *Context, r any)
 )
 
 type DispatcherAction string
@@ -253,7 +253,7 @@ func (d *Dispatcher) processRawUpdate(b *gotgbot.Bot, r json.RawMessage) error {
 
 // ProcessUpdate iterates over the list of groups to execute the matching handlers.
 // This is also where we recover from any panics that are thrown by user code, to avoid taking down the bot.
-func (d *Dispatcher) ProcessUpdate(b *gotgbot.Bot, u *gotgbot.Update, data map[string]interface{}) (err error) {
+func (d *Dispatcher) ProcessUpdate(b *gotgbot.Bot, u *gotgbot.Update, data map[string]any) (err error) {
 	ctx := NewContext(b, u, data)
 
 	defer func() {

--- a/ext/updater_test.go
+++ b/ext/updater_test.go
@@ -87,7 +87,7 @@ func TestUpdaterSupportsWebhookReAdding(t *testing.T) {
 //
 // NOTE: IF THIS FAILS, IT IS NOT A FLAKE! Investigate!
 func TestUpdaterPollingConcurrency(t *testing.T) {
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		t.Run(fmt.Sprintf("run_%d", i), func(t *testing.T) {
 			concurrentTest(t)
 		})
@@ -610,7 +610,7 @@ func benchmarkUpdaterWithNBots(b *testing.B, numBot int) {
 		return nil
 	}})
 
-	for i := 0; i < numBot; i++ {
+	for i := range numBot {
 		token := strconv.Itoa(i)
 		err := u.AddWebhook(&gotgbot.Bot{
 			Token:     token,

--- a/formatting.go
+++ b/formatting.go
@@ -2,6 +2,7 @@ package gotgbot
 
 import (
 	"html"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode"
@@ -304,19 +305,10 @@ func splitEdgeWhitespace(text string, ent MessageEntity) (pre string, cntnt stri
 func escapeContainedMDV1(data []rune, mdType []rune) string {
 	out := strings.Builder{}
 	for _, x := range data {
-		if contains(x, mdType) {
+		if slices.Contains(mdType, x) {
 			out.WriteRune('\\')
 		}
 		out.WriteRune(x)
 	}
 	return out.String()
-}
-
-func contains(r rune, rs []rune) bool {
-	for _, rr := range rs {
-		if r == rr {
-			return true
-		}
-	}
-	return false
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/PaulSonOfLars/gotgbot/v2
 
-go 1.22
+go 1.24

--- a/request.go
+++ b/request.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -140,9 +141,7 @@ func (bot *BaseBotClient) RequestWithContext(parentCtx context.Context, token st
 	defer cancel()
 
 	if opts != nil {
-		for k, v := range opts.OverrideParams {
-			params[k] = v
-		}
+		maps.Copy(params, opts.OverrideParams)
 	}
 
 	buf := bytes.NewBuffer(nil)

--- a/samples/callbackqueryBot/go.mod
+++ b/samples/callbackqueryBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/callbackqueryBot
 
-go 1.22
+go 1.24
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/commandBot/go.mod
+++ b/samples/commandBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/commandBot
 
-go 1.22
+go 1.24
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/conversationBot/go.mod
+++ b/samples/conversationBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/conversationBot
 
-go 1.22
+go 1.24
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/echoBot/go.mod
+++ b/samples/echoBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/echoBot
 
-go 1.22
+go 1.24
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/echoMultiBot/go.mod
+++ b/samples/echoMultiBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/echoMultiBot
 
-go 1.22
+go 1.24
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/echoWebhookBot/go.mod
+++ b/samples/echoWebhookBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/echoWebhookBot
 
-go 1.22
+go 1.24
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/inlinequeryBot/go.mod
+++ b/samples/inlinequeryBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/inlinequeryBot
 
-go 1.22
+go 1.24
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/metricsBot/go.mod
+++ b/samples/metricsBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/metricsBot
 
-go 1.22
+go 1.24
 
 require (
 	github.com/PaulSonOfLars/gotgbot/v2 v2.99.99

--- a/samples/middlewareBot/go.mod
+++ b/samples/middlewareBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/middlewareBot
 
-go 1.22
+go 1.24
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/paymentsBot/go.mod
+++ b/samples/paymentsBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/paymentsBot
 
-go 1.22
+go 1.24
 
 require (
 	github.com/PaulSonOfLars/gotgbot/v2 v2.99.99

--- a/samples/statefulClientBot/go.mod
+++ b/samples/statefulClientBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/statefulClientBot
 
-go 1.22
+go 1.24
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/samples/webappBot/go.mod
+++ b/samples/webappBot/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaulSonOfLars/gotgbot/samples/webappBot
 
-go 1.22
+go 1.24
 
 require github.com/PaulSonOfLars/gotgbot/v2 v2.99.99
 

--- a/scripts/generate/common.go
+++ b/scripts/generate/common.go
@@ -9,19 +9,10 @@ import (
 	"strings"
 )
 
-func contains(s string, ss []string) bool {
-	for _, str := range ss {
-		if s == str {
-			return true
-		}
-	}
-	return false
-}
-
 func snakeToTitle(s string) string {
 	bd := strings.Builder{}
 
-	for _, split := range strings.Split(s, "_") {
+	for split := range strings.SplitSeq(s, "_") {
 		bd.WriteString(strings.Title(split))
 	}
 

--- a/scripts/generate/gen.go
+++ b/scripts/generate/gen.go
@@ -5,6 +5,7 @@ import (
 	"go/format"
 	"os"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"unicode"
@@ -92,7 +93,7 @@ func (td TypeDescription) isChildType(d APIDescription, t string, typeName strin
 		return true
 	}
 
-	if contains(t, skip) {
+	if slices.Contains(skip, t) {
 		return false
 	}
 

--- a/scripts/generate/types.go
+++ b/scripts/generate/types.go
@@ -423,8 +423,7 @@ func generateStructFields(d APIDescription, fields []Field, constantFields []str
 			return "", fmt.Errorf("failed to get preferred type: %w", err)
 		}
 
-		skip := slices.Contains(constantFields, f.Name)
-		if skip {
+		if slices.Contains(constantFields, f.Name) {
 			continue
 		}
 

--- a/scripts/generate/types.go
+++ b/scripts/generate/types.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"slices"
 	"strconv"
 	"strings"
 	"text/template"
@@ -422,13 +423,7 @@ func generateStructFields(d APIDescription, fields []Field, constantFields []str
 			return "", fmt.Errorf("failed to get preferred type: %w", err)
 		}
 
-		skip := false
-		for _, constantField := range constantFields {
-			if f.Name == constantField {
-				skip = true
-				break
-			}
-		}
+		skip := slices.Contains(constantFields, f.Name)
 		if skip {
 			continue
 		}
@@ -471,7 +466,7 @@ func generateGenericInterfaceType(d APIDescription, name string, subtypes []Type
 	}
 
 	// If the inputfile is a common field, then the interface contains fields.
-	hasInputFile = hasInputFile && contains(fieldName, getFieldNames(commonFields))
+	hasInputFile = hasInputFile && slices.Contains(getFieldNames(commonFields), fieldName)
 
 	bd := strings.Builder{}
 	bd.WriteString(fmt.Sprintf("\ntype %s interface{", name))


### PR DESCRIPTION
# What

Now that go 1.26 is out, our minimum supported version is 1.24 - so let's update the go.mod for it.

And as a drive by, run `go fix ./...` to apply some easy optimisations and cleanups from the latest upgrades!

# Impact

- Are your changes backwards compatible? Forces an upgrade to newer go, but OK otherwise. Newer toolchains should self-update.
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
