### PR TITLE
Don't buffer files in memory at send time

### DIFF
--- a/ext/handler_mapping_test.go
+++ b/ext/handler_mapping_test.go
@@ -62,11 +62,16 @@ func Test_handlerMappings_getGroupsConcurrentSafe(t *testing.T) {
 }
 
 func checkList(t *testing.T, name string, got []Handler, expected ...Handler) {
+	t.Helper()
+
 	if len(got) != len(expected) {
 		t.Errorf("mismatch on length of expected outputs for %s - got %d, expected %d", name, len(got), len(expected))
 	}
+
 	for idx, v := range got {
+		//nolint:gosec
 		if v.Name() != expected[idx].Name() {
+			//nolint:gosec
 			t.Errorf("unexpected output name for %s - IDX %d got %s, expected %s", name, idx, v.Name(), expected[idx].Name())
 		}
 	}

--- a/request.go
+++ b/request.go
@@ -1,7 +1,6 @@
 package gotgbot
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -172,33 +171,77 @@ func (bot *BaseBotClient) RequestWithContext(parentCtx context.Context, token st
 	return r.Result, nil
 }
 
+func allFilesSeekable(params map[string]any) bool {
+	for _, v := range params {
+		if f, ok := v.(*FileReader); ok && f.Data != nil {
+			if _, ok := f.Data.(io.Seeker); !ok {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 func (bot *BaseBotClient) buildRequest(params map[string]any, ctx context.Context, token string, method string, opts *RequestOpts) (*http.Request, error) {
-	bodyData, contentType, err := buildMultipart(params)
+	body, contentType, err := buildMultipart(params)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, bot.methodEndpoint(token, method, opts), bytes.NewReader(bodyData))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, bot.methodEndpoint(token, method, opts), body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build POST request to %s: %w", method, err)
 	}
 
 	req.Header.Set("Content-Type", contentType)
-	// Setup GetBody such that the request can be replayed and automatically retried by the HTTP client if necessary.
-	// This should handle HTTP2 GO_AWAY errors.
-	req.GetBody = func() (io.ReadCloser, error) {
-		return io.NopCloser(bytes.NewReader(bodyData)), nil
+
+	if allFilesSeekable(params) {
+		req.GetBody = func() (io.ReadCloser, error) {
+			retryBody, contentType, err := buildMultipart(params)
+			if err != nil {
+				return nil, fmt.Errorf("failed to rebuild multipart body for retry: %w", err)
+			}
+			req.Header.Set("Content-Type", contentType)
+			return io.NopCloser(retryBody), nil
+		}
 	}
 	return req, nil
 }
 
-func buildMultipart(params map[string]any) ([]byte, string, error) {
-	buf := bytes.NewBuffer(nil)
-	contentType, err := fillBuffer(buf, params)
-	if err != nil {
-		return nil, "", err
-	}
-	return buf.Bytes(), contentType, err
+// buildMultipart creates a lazy multipart reader/writer which only writes while it gets read.
+func buildMultipart(params map[string]any) (io.Reader, string, error) {
+	pr, pw := io.Pipe()
+	w := multipart.NewWriter(pw)
+
+	go func() {
+		if len(params) == 0 {
+			if err := w.WriteField("_empty", ""); err != nil {
+				pw.CloseWithError(fmt.Errorf("failed to write empty multipart field: %w", err))
+				return
+			}
+		}
+
+		for k, v := range params {
+			contents, err := getFieldContents(v, k, w)
+			if err != nil {
+				pw.CloseWithError(err)
+				return
+			}
+
+			if err := w.WriteField(k, contents); err != nil {
+				pw.CloseWithError(fmt.Errorf("failed to write multipart field %s with value %v: %w", k, v, err))
+				return
+			}
+		}
+
+		if err := w.Close(); err != nil {
+			pw.CloseWithError(fmt.Errorf("failed to close multipart form writer: %w", err))
+			return
+		}
+		pw.Close()
+	}()
+
+	return pr, w.FormDataContentType(), nil
 }
 
 // Sanitize the error to avoid token leak.
@@ -210,34 +253,6 @@ func sanitizeError(token string, err error) error {
 	}
 
 	return err
-}
-
-// fillBuffer fills a byte buffer with the multipart writer data which is going to be sent.
-func fillBuffer(buf *bytes.Buffer, params map[string]any) (string, error) {
-	w := multipart.NewWriter(buf)
-
-	if len(params) == 0 {
-		if err := w.WriteField("_empty", ""); err != nil {
-			return "", fmt.Errorf("failed to write empty multipart field: %w", err)
-		}
-	}
-
-	for k, v := range params {
-		contents, err := getFieldContents(v, k, w)
-		if err != nil {
-			return "", err
-		}
-
-		if err := w.WriteField(k, contents); err != nil {
-			return "", fmt.Errorf("failed to write multipart field %s with value %v: %w", k, v, err)
-		}
-	}
-
-	if err := w.Close(); err != nil {
-		return "", fmt.Errorf("failed to close multipart form writer: %w", err)
-	}
-
-	return w.FormDataContentType(), nil
 }
 
 func getFieldContents(v any, k string, w *multipart.Writer) (string, error) {

--- a/request.go
+++ b/request.go
@@ -143,23 +143,9 @@ func (bot *BaseBotClient) RequestWithContext(parentCtx context.Context, token st
 		maps.Copy(params, opts.OverrideParams)
 	}
 
-	buf := bytes.NewBuffer(nil)
-	contentType, err := fillBuffer(buf, params)
+	req, err := bot.buildRequest(params, ctx, token, method, opts)
 	if err != nil {
 		return nil, err
-	}
-	bodyData := buf.Bytes()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, bot.methodEndpoint(token, method, opts), bytes.NewReader(bodyData))
-	if err != nil {
-		return nil, fmt.Errorf("failed to build POST request to %s: %w", method, err)
-	}
-
-	req.Header.Set("Content-Type", contentType)
-	// Setup GetBody such that the request can be replayed and automatically retried by the HTTP client if necessary.
-	// This should handle HTTP2 GO_AWAY errors.
-	req.GetBody = func() (io.ReadCloser, error) {
-		return io.NopCloser(bytes.NewReader(bodyData)), nil
 	}
 
 	resp, err := bot.Client.Do(req)
@@ -184,6 +170,35 @@ func (bot *BaseBotClient) RequestWithContext(parentCtx context.Context, token st
 	}
 
 	return r.Result, nil
+}
+
+func (bot *BaseBotClient) buildRequest(params map[string]any, ctx context.Context, token string, method string, opts *RequestOpts) (*http.Request, error) {
+	bodyData, contentType, err := buildMultipart(params)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, bot.methodEndpoint(token, method, opts), bytes.NewReader(bodyData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to build POST request to %s: %w", method, err)
+	}
+
+	req.Header.Set("Content-Type", contentType)
+	// Setup GetBody such that the request can be replayed and automatically retried by the HTTP client if necessary.
+	// This should handle HTTP2 GO_AWAY errors.
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(bodyData)), nil
+	}
+	return req, nil
+}
+
+func buildMultipart(params map[string]any) ([]byte, string, error) {
+	buf := bytes.NewBuffer(nil)
+	contentType, err := fillBuffer(buf, params)
+	if err != nil {
+		return nil, "", err
+	}
+	return buf.Bytes(), contentType, err
 }
 
 // Sanitize the error to avoid token leak.

--- a/request.go
+++ b/request.go
@@ -104,7 +104,7 @@ func (bot *BaseBotClient) getTimeoutContext(parentCtx context.Context, opts *Req
 		}
 	}
 
-	return context.WithTimeout(parentCtx, DefaultTimeout)
+	return context.WithTimeout(parentCtx, DefaultTimeout) //nolint:gosec
 }
 
 func timeoutFromOpts(parentCtx context.Context, opts *RequestOpts) (context.Context, context.CancelFunc) {
@@ -118,7 +118,7 @@ func timeoutFromOpts(parentCtx context.Context, opts *RequestOpts) (context.Cont
 	}
 
 	if opts.Timeout > 0 {
-		return context.WithTimeout(parentCtx, opts.Timeout)
+		return context.WithTimeout(parentCtx, opts.Timeout) //nolint:gosec
 
 	} else if opts.Timeout < 0 {
 		// < 0  no timeout; infinite.
@@ -183,10 +183,7 @@ func allFilesSeekable(params map[string]any) bool {
 }
 
 func (bot *BaseBotClient) buildRequest(params map[string]any, ctx context.Context, token string, method string, opts *RequestOpts) (*http.Request, error) {
-	body, contentType, err := buildMultipart(params)
-	if err != nil {
-		return nil, err
-	}
+	body, contentType := buildMultipart(params)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, bot.methodEndpoint(token, method, opts), body)
 	if err != nil {
@@ -197,10 +194,7 @@ func (bot *BaseBotClient) buildRequest(params map[string]any, ctx context.Contex
 
 	if allFilesSeekable(params) {
 		req.GetBody = func() (io.ReadCloser, error) {
-			retryBody, contentType, err := buildMultipart(params)
-			if err != nil {
-				return nil, fmt.Errorf("failed to rebuild multipart body for retry: %w", err)
-			}
+			retryBody, contentType := buildMultipart(params)
 			req.Header.Set("Content-Type", contentType)
 			return io.NopCloser(retryBody), nil
 		}
@@ -209,7 +203,7 @@ func (bot *BaseBotClient) buildRequest(params map[string]any, ctx context.Contex
 }
 
 // buildMultipart creates a lazy multipart reader/writer which only writes while it gets read.
-func buildMultipart(params map[string]any) (io.Reader, string, error) {
+func buildMultipart(params map[string]any) (io.Reader, string) {
 	pr, pw := io.Pipe()
 	w := multipart.NewWriter(pw)
 
@@ -241,7 +235,7 @@ func buildMultipart(params map[string]any) (io.Reader, string, error) {
 		pw.Close()
 	}()
 
-	return pr, w.FormDataContentType(), nil
+	return pr, w.FormDataContentType()
 }
 
 // Sanitize the error to avoid token leak.

--- a/request_test.go
+++ b/request_test.go
@@ -1,6 +1,9 @@
 package gotgbot
 
 import (
+	"bytes"
+	"context"
+	"io"
 	"mime/multipart"
 	"strconv"
 	"testing"
@@ -62,5 +65,93 @@ func Test_getFieldContents(t *testing.T) {
 				t.Errorf("getFieldContents() got = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+type countingReader struct {
+	r         io.Reader
+	bytesRead int64
+}
+
+func (c *countingReader) Read(p []byte) (n int, err error) {
+	n, err = c.r.Read(p)
+	c.bytesRead += int64(n)
+	return
+}
+
+func TestFileNotBufferedIntoMemory(t *testing.T) {
+	fileContents := []byte("hello, this is some file content")
+
+	cr := &countingReader{r: bytes.NewReader(fileContents)}
+
+	// Wire up a FileReader with the counting reader as Data.
+	// Intentionally NOT an io.Seeker — we want to catch greedy reads.
+	params := map[string]any{
+		"document": &FileReader{
+			Name: "test.txt",
+			Data: cr,
+		},
+	}
+
+	bs, _, err := buildMultipart(params)
+	if err != nil {
+		t.Fatalf("unexpected error building multipart: %v", err)
+	}
+
+	// Before draining: file should not have been read yet (streaming, not buffered)
+	if cr.bytesRead != 0 {
+		t.Errorf("file was read during multipart construction: %d bytes read, expected 0", cr.bytesRead)
+	}
+
+	// Drain the multipart body as the HTTP transport would.
+	if _, err := io.Copy(io.Discard, bytes.NewBuffer(bs)); err != nil {
+		t.Fatalf("unexpected error reading multipart body: %v", err)
+	}
+
+	// Sanity check: file was actually sent (and was only read once)
+	if cr.bytesRead != int64(len(fileContents)) {
+		t.Errorf("file was read %d bytes after drain, expected exactly %d", cr.bytesRead, len(fileContents))
+	}
+}
+
+// We want to make sure that retriable requests can in fact be retried - this simulates the HTTP2 GOAWAY state.
+func TestGetBodyReturnsCorrectRetryReader(t *testing.T) {
+	fileContents := []byte("hello, this is some file content")
+
+	params := map[string]any{
+		"document": &FileReader{
+			Name: "test.txt",
+			Data: bytes.NewReader(fileContents),
+		},
+	}
+
+	req, err := (&BaseBotClient{}).buildRequest(params, context.Background(), "test-token", "sendDocument", nil)
+	if err != nil {
+		t.Fatalf("unexpected error building request: %v", err)
+	}
+
+	if req.GetBody == nil {
+		t.Fatal("GetBody should be set for seekable files")
+	}
+
+	// Read the request body, simulating our "first request" hitting an HTTP2 GOAWAY
+	// GOAWAY would discard the body, but we store it to check equality.
+	originalBody, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("failed to read original body: %v", err)
+	}
+
+	retryBody, err := req.GetBody()
+	if err != nil {
+		t.Fatalf("GetBody returned error: %v", err)
+	}
+
+	retryBodyBytes, err := io.ReadAll(retryBody)
+	if err != nil {
+		t.Fatalf("failed to read retry body: %v", err)
+	}
+
+	if !bytes.Equal(originalBody, retryBodyBytes) {
+		t.Errorf("retry body does not match original body")
 	}
 }

--- a/request_test.go
+++ b/request_test.go
@@ -99,10 +99,7 @@ func TestFileNotBufferedIntoMemory(t *testing.T) {
 		},
 	}
 
-	r, _, err := buildMultipart(params)
-	if err != nil {
-		t.Fatalf("unexpected error building multipart: %v", err)
-	}
+	r, _ := buildMultipart(params)
 
 	// Before draining: file should not have been read yet (streaming, not buffered)
 	if cr.bytesRead != 0 {

--- a/request_test.go
+++ b/request_test.go
@@ -101,7 +101,7 @@ func TestFileNotBufferedIntoMemory(t *testing.T) {
 
 	r, _ := buildMultipart(params)
 
-	// Before draining: file should not have been read yet (streaming, not buffered)
+	// Before draining: file should not have been read yet (streaming, not buffered).
 	if cr.bytesRead != 0 {
 		t.Errorf("file was read during multipart construction: %d bytes read, expected 0", cr.bytesRead)
 	}
@@ -111,7 +111,7 @@ func TestFileNotBufferedIntoMemory(t *testing.T) {
 		t.Fatalf("unexpected error reading multipart body: %v", err)
 	}
 
-	// Sanity check: file was actually sent (and was only read once)
+	// Which means that we should now have read the file.
 	if cr.bytesRead != int64(len(fileContents)) {
 		t.Errorf("file was read %d bytes after drain, expected exactly %d", cr.bytesRead, len(fileContents))
 	}
@@ -146,6 +146,7 @@ func TestGetBodyReturnsCorrectRetryReader(t *testing.T) {
 	}
 	origContentType := req.Header.Get("Content-Type")
 
+	// We should now have read the file once
 	if cr.bytesRead != int64(len(fileContents)) {
 		t.Errorf("expected file to be read exactly once after first attempt, got %d bytes read", cr.bytesRead)
 	}
@@ -161,14 +162,19 @@ func TestGetBodyReturnsCorrectRetryReader(t *testing.T) {
 	}
 	retryContentType := req.Header.Get("Content-Type")
 
+	// Retry - we have now read the file twice
 	if cr.bytesRead != int64(len(fileContents))*2 {
 		t.Errorf("expected file to be read exactly twice after retry, got %d bytes read", cr.bytesRead)
 	}
 
 	originalFile := extractFileFromMultipart(t, origContentType, originalBody, "document")
+	if !bytes.Equal(fileContents, originalFile) {
+		t.Errorf("local file contents do not match original file")
+	}
+
 	retryFile := extractFileFromMultipart(t, retryContentType, retryBodyBytes, "document")
 	if !bytes.Equal(originalFile, retryFile) {
-		t.Errorf("retry file contents do not match original")
+		t.Errorf("retry file do not match original file")
 	}
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -117,11 +117,12 @@ func TestFileNotBufferedIntoMemory(t *testing.T) {
 // We want to make sure that retriable requests can in fact be retried - this simulates the HTTP2 GOAWAY state.
 func TestGetBodyReturnsCorrectRetryReader(t *testing.T) {
 	fileContents := []byte("hello, this is some file content")
+	cr := &countingReader{r: bytes.NewReader(fileContents)}
 
 	params := map[string]any{
 		"document": &FileReader{
 			Name: "test.txt",
-			Data: bytes.NewReader(fileContents),
+			Data: cr,
 		},
 	}
 
@@ -141,6 +142,10 @@ func TestGetBodyReturnsCorrectRetryReader(t *testing.T) {
 		t.Fatalf("failed to read original body: %v", err)
 	}
 
+	if cr.bytesRead != int64(len(fileContents)) {
+		t.Errorf("expected file to be read exactly once after first attempt, got %d bytes read", cr.bytesRead)
+	}
+
 	retryBody, err := req.GetBody()
 	if err != nil {
 		t.Fatalf("GetBody returned error: %v", err)
@@ -149,6 +154,10 @@ func TestGetBodyReturnsCorrectRetryReader(t *testing.T) {
 	retryBodyBytes, err := io.ReadAll(retryBody)
 	if err != nil {
 		t.Fatalf("failed to read retry body: %v", err)
+	}
+
+	if cr.bytesRead != int64(len(fileContents))*2 {
+		t.Errorf("expected file to be read exactly twice after retry, got %d bytes read", cr.bytesRead)
 	}
 
 	if !bytes.Equal(originalBody, retryBodyBytes) {

--- a/request_test.go
+++ b/request_test.go
@@ -3,7 +3,9 @@ package gotgbot
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
+	"mime"
 	"mime/multipart"
 	"strconv"
 	"testing"
@@ -69,7 +71,7 @@ func Test_getFieldContents(t *testing.T) {
 }
 
 type countingReader struct {
-	r         io.Reader
+	r         io.ReadSeeker
 	bytesRead int64
 }
 
@@ -77,6 +79,10 @@ func (c *countingReader) Read(p []byte) (n int, err error) {
 	n, err = c.r.Read(p)
 	c.bytesRead += int64(n)
 	return
+}
+
+func (c *countingReader) Seek(offset int64, whence int) (int64, error) {
+	return c.r.Seek(offset, whence)
 }
 
 func TestFileNotBufferedIntoMemory(t *testing.T) {
@@ -93,7 +99,7 @@ func TestFileNotBufferedIntoMemory(t *testing.T) {
 		},
 	}
 
-	bs, _, err := buildMultipart(params)
+	r, _, err := buildMultipart(params)
 	if err != nil {
 		t.Fatalf("unexpected error building multipart: %v", err)
 	}
@@ -104,7 +110,7 @@ func TestFileNotBufferedIntoMemory(t *testing.T) {
 	}
 
 	// Drain the multipart body as the HTTP transport would.
-	if _, err := io.Copy(io.Discard, bytes.NewBuffer(bs)); err != nil {
+	if _, err := io.Copy(io.Discard, r); err != nil {
 		t.Fatalf("unexpected error reading multipart body: %v", err)
 	}
 
@@ -141,6 +147,7 @@ func TestGetBodyReturnsCorrectRetryReader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read original body: %v", err)
 	}
+	origContentType := req.Header.Get("Content-Type")
 
 	if cr.bytesRead != int64(len(fileContents)) {
 		t.Errorf("expected file to be read exactly once after first attempt, got %d bytes read", cr.bytesRead)
@@ -155,12 +162,45 @@ func TestGetBodyReturnsCorrectRetryReader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read retry body: %v", err)
 	}
+	retryContentType := req.Header.Get("Content-Type")
 
 	if cr.bytesRead != int64(len(fileContents))*2 {
 		t.Errorf("expected file to be read exactly twice after retry, got %d bytes read", cr.bytesRead)
 	}
 
-	if !bytes.Equal(originalBody, retryBodyBytes) {
-		t.Errorf("retry body does not match original body")
+	originalFile := extractFileFromMultipart(t, origContentType, originalBody, "document")
+	retryFile := extractFileFromMultipart(t, retryContentType, retryBodyBytes, "document")
+	if !bytes.Equal(originalFile, retryFile) {
+		t.Errorf("retry file contents do not match original")
 	}
+}
+
+func extractFileFromMultipart(t *testing.T, contentType string, body []byte, formName string) []byte {
+	t.Helper()
+
+	_, mediaParams, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		t.Fatalf("failed to parse content-type: %v", err)
+	}
+
+	mr := multipart.NewReader(bytes.NewReader(body), mediaParams["boundary"])
+	for {
+		part, err := mr.NextPart()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("failed to read multipart part: %v", err)
+		}
+
+		if part.FormName() == formName {
+			contents, err := io.ReadAll(part)
+			if err != nil {
+				t.Fatalf("failed to read file part: %v", err)
+			}
+			return contents
+		}
+	}
+	t.Fatalf("%s part not found in multipart body", formName)
+	return nil
 }


### PR DESCRIPTION
# What

Addresses #259 

Previously, we would pipe files while creating the multipart reader.
This changed in #242, where i opted to avoid double-marshalling fields - but introduced a regression where files were double-buffered in memory in an attempt to maintain the fix from #231.

This PR introduces regression tests to cover those edge cases, and then updates the requests code to correctly use pipes and allow retries without double-buffering files.

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y