### PR TITLE
fix: allow ChatMember handler to process MyChatMember updates

### DIFF
--- a/ext/handlers/chatmember.go
+++ b/ext/handlers/chatmember.go
@@ -21,11 +21,11 @@ func NewChatMember(f filters.ChatMember, r Response) ChatMember {
 }
 
 func (c ChatMember) CheckUpdate(b *gotgbot.Bot, ctx *ext.Context) bool {
-	if ctx.ChatMember == nil {
-		return false
+	m := ctx.ChatMember
+	if m == nil {
+		m = ctx.Update.MyChatMember
 	}
-
-	return c.Filter == nil || c.Filter(ctx.ChatMember)
+	return m != nil && (c.Filter == nil || c.Filter(m))
 }
 
 func (c ChatMember) HandleUpdate(b *gotgbot.Bot, ctx *ext.Context) error {


### PR DESCRIPTION
Currently, ChatMember.CheckUpdate only looks at ctx.ChatMember. This prevents the handler from catching bot-specific updates (like when the bot itself is added to a group), which are stored in ctx.Update.MyChatMember. This change fixes that while keeping the logic clean.

<!--
Hey, thank you for opening a PR!

Please fill out the details below; they're there to help both you and the maintainers!
-->

# What

Currently, the ChatMember handler only inspects the ctx.ChatMember field in its CheckUpdate method. However, according to the Telegram Bot API, status changes for the bot itself (e.g., being added/removed from a group, or having its administrator permissions modified) are delivered in the my_chat_member field, while changes for other users are delivered in chat_member.

Because the current implementation ignores ctx.Update.MyChatMember, the handler fails to trigger when the bot's own status changes, even if my_chat_member is explicitly included in AllowedUpdates.

# Impact

It maintains existing behavior for chat_member updates while expanding support for my_chat_member.

No changes needed to the public API; the handler simply becomes more robust.

This resolves issues where developers couldn't receive "bot added to group" or "bot permission changed" events using the standard ChatMember handler.
