### PR TITLE
Improve MultiPart reader handling

### DIFF
--- a/request.go
+++ b/request.go
@@ -142,7 +142,7 @@ func (bot *BaseBotClient) RequestWithContext(parentCtx context.Context, token st
 		maps.Copy(params, opts.OverrideParams)
 	}
 
-	req, err := bot.buildRequest(params, ctx, token, method, opts)
+	req, err := bot.buildRequest(ctx, params, token, method, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -182,8 +182,8 @@ func allFilesSeekable(params map[string]any) bool {
 	return true
 }
 
-func (bot *BaseBotClient) buildRequest(params map[string]any, ctx context.Context, token string, method string, opts *RequestOpts) (*http.Request, error) {
-	body, contentType := buildMultipart(params)
+func (bot *BaseBotClient) buildRequest(ctx context.Context, params map[string]any, token string, method string, opts *RequestOpts) (*http.Request, error) {
+	body, contentType := buildMultipart(ctx, params)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, bot.methodEndpoint(token, method, opts), body)
 	if err != nil {
@@ -194,7 +194,7 @@ func (bot *BaseBotClient) buildRequest(params map[string]any, ctx context.Contex
 
 	if allFilesSeekable(params) {
 		req.GetBody = func() (io.ReadCloser, error) {
-			retryBody, contentType := buildMultipart(params)
+			retryBody, contentType := buildMultipart(ctx, params)
 			req.Header.Set("Content-Type", contentType)
 			return io.NopCloser(retryBody), nil
 		}
@@ -203,11 +203,26 @@ func (bot *BaseBotClient) buildRequest(params map[string]any, ctx context.Contex
 }
 
 // buildMultipart creates a lazy multipart reader/writer which only writes while it gets read.
-func buildMultipart(params map[string]any) (io.Reader, string) {
+// If the ctx gets closed, so does this.
+func buildMultipart(ctx context.Context, params map[string]any) (io.Reader, string) {
 	pr, pw := io.Pipe()
 	w := multipart.NewWriter(pw)
 
 	go func() {
+		done := make(chan struct{})
+
+		go func() {
+			select {
+			case <-ctx.Done():
+				// If the context is done before we finish writing, abort the pipe.
+				// This unblocks any pw.Write() call and lets the goroutine exit.
+				pw.CloseWithError(ctx.Err())
+			case <-done:
+				// writer finished cleanly, nothing to do
+			}
+		}()
+		defer close(done)
+
 		if len(params) == 0 {
 			if err := w.WriteField("_empty", ""); err != nil {
 				pw.CloseWithError(fmt.Errorf("failed to write empty multipart field: %w", err))

--- a/request_test.go
+++ b/request_test.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"strconv"
 	"testing"
+	"time"
 )
 
 func Test_getFieldContents(t *testing.T) {
@@ -99,7 +100,7 @@ func TestFileNotBufferedIntoMemory(t *testing.T) {
 		},
 	}
 
-	r, _ := buildMultipart(params)
+	r, _ := buildMultipart(context.Background(), params)
 
 	// Before draining: file should not have been read yet (streaming, not buffered).
 	if cr.bytesRead != 0 {
@@ -129,7 +130,7 @@ func TestGetBodyReturnsCorrectRetryReader(t *testing.T) {
 		},
 	}
 
-	req, err := (&BaseBotClient{}).buildRequest(params, context.Background(), "test-token", "sendDocument", nil)
+	req, err := (&BaseBotClient{}).buildRequest(context.Background(), params, "test-token", "sendDocument", nil)
 	if err != nil {
 		t.Fatalf("unexpected error building request: %v", err)
 	}
@@ -206,4 +207,67 @@ func extractFileFromMultipart(t *testing.T, contentType string, body []byte, for
 	}
 	t.Fatalf("%s part not found in multipart body", formName)
 	return nil
+}
+
+func TestBuildMultipartContextHandling(t *testing.T) {
+	params := map[string]any{
+		"chat_id": "123",
+		"text":    "hello",
+	}
+
+	t.Run("body is readable with active context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		r, _ := buildMultipart(ctx, params)
+		_, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatalf("expected clean read, got: %v", err)
+		}
+	})
+
+	t.Run("body read fails after context cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		r, _ := buildMultipart(ctx, params)
+		cancel()
+		time.Sleep(10 * time.Millisecond)
+
+		_, err := io.ReadAll(r)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got: %v", err)
+		}
+	})
+
+	t.Run("body read fails after context deadline exceeded", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+
+		r, _ := buildMultipart(ctx, params)
+		time.Sleep(20 * time.Millisecond)
+
+		_, err := io.ReadAll(r)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected context.DeadlineExceeded, got: %v", err)
+		}
+	})
+
+	t.Run("mid-read fails after context cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		r, _ := buildMultipart(ctx, params)
+
+		buf := make([]byte, 4)
+		if _, err := r.Read(buf); err != nil {
+			t.Fatalf("unexpected error on first read: %v", err)
+		}
+
+		cancel()
+		time.Sleep(10 * time.Millisecond)
+
+		_, err := io.ReadAll(r)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled after mid-read cancel, got: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
# What

Recent changes to multipart reader logic caused some undesired behaviour, where goroutines would pile up endlessly without being cleaned up.

This PR attempts to clean this up by leveraging our request contexts as the signal to close things.

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
