### PR TITLE
Fix GetCanManageTags method for chat creators

### DIFF
--- a/custom_helpers.go
+++ b/custom_helpers.go
@@ -194,7 +194,7 @@ func (mcm ChatMemberAdministrator) GetCanManageTags() bool {
 }
 
 func (mcm MergedChatMember) GetCanManageTags() bool {
-	if mcm.Status != "administrator" {
+	if mcm.Status != "administrator" && mcm.Status != "creator" {
 		return false
 	}
 


### PR DESCRIPTION
# What

Chat creators can of course also edit tags

# Impact

- Are your changes backwards compatible? Y
- Have you included documentation, or updated existing documentation? Y
- Do errors and log messages provide enough context? Y
