### PR TITLE
fix(formatting): resolve trailing whitespace reversal bug in splitEdgeWhitespace

### DIFF
--- a/formatting.go
+++ b/formatting.go
@@ -361,20 +361,21 @@ func getChildEntities(ent MessageEntity, ents []MessageEntity) []MessageEntity {
 func splitEdgeWhitespace(text string, ent MessageEntity) (pre string, cntnt string, post string) {
 	keepNewLines := ent.Type == "pre"
 
-	bd := strings.Builder{}
 	rText := []rune(text)
-	for i := 0; i < len(rText) && unicode.IsSpace(rText[i]) && (!keepNewLines || rText[i] != '\n'); i++ {
-		bd.WriteRune(rText[i])
+	start := 0
+	for start < len(rText) && unicode.IsSpace(rText[start]) && (!keepNewLines || rText[start] != '\n') {
+		start++
 	}
-	pre = bd.String()
 
-	text = strings.TrimPrefix(text, pre)
-	bd.Reset()
-	for i := len(rText) - 1; i >= 0 && unicode.IsSpace(rText[i]); i-- {
-		bd.WriteRune(rText[i])
+	end := len(rText)
+	for end > start && unicode.IsSpace(rText[end-1]) {
+		end--
 	}
-	post = bd.String()
-	return pre, strings.TrimSuffix(text, post), post
+
+	pre = string(rText[:start])
+	cntnt = string(rText[start:end])
+	post = string(rText[end:])
+	return pre, cntnt, post
 }
 
 func escapeContainedMDV1(data []rune, mdType []rune) string {

--- a/formatting_test.go
+++ b/formatting_test.go
@@ -1,0 +1,75 @@
+package gotgbot
+
+import (
+	"testing"
+)
+
+func TestSplitEdgeWhitespace(t *testing.T) {
+	tests := []struct {
+		name    string
+		text    string
+		entType string
+		wantPre string
+		wantCnt string
+		wantPos string
+	}{
+		{
+			name:    "no whitespace",
+			text:    "hello",
+			entType: "bold",
+			wantPre: "",
+			wantCnt: "hello",
+			wantPos: "",
+		},
+		{
+			name:    "leading and trailing",
+			text:    "  hello  ",
+			entType: "bold",
+			wantPre: "  ",
+			wantCnt: "hello",
+			wantPos: "  ",
+		},
+		{
+			name:    "trailing tabs and spaces mixed",
+			text:    "hello \t",
+			entType: "bold",
+			wantPre: "",
+			wantCnt: "hello",
+			wantPos: " \t",
+		},
+		{
+			name:    "only spaces",
+			text:    "   ",
+			entType: "bold",
+			wantPre: "   ",
+			wantCnt: "",
+			wantPos: "",
+		},
+		{
+			name:    "newlines in pre",
+			text:    "\n hello \n",
+			entType: "pre",
+			wantPre: "",
+			wantCnt: "\n hello",
+			wantPos: " \n",
+		},
+		{
+			name:    "newlines in bold",
+			text:    "\n hello \n",
+			entType: "bold",
+			wantPre: "\n ",
+			wantCnt: "hello",
+			wantPos: " \n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pre, cnt, post := splitEdgeWhitespace(tt.text, MessageEntity{Type: tt.entType})
+			if pre != tt.wantPre || cnt != tt.wantCnt || post != tt.wantPos {
+				t.Errorf("splitEdgeWhitespace(%q, %q) = (%q, %q, %q); want (%q, %q, %q)",
+					tt.text, tt.entType, pre, cnt, post, tt.wantPre, tt.wantCnt, tt.wantPos)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
This PR fixes a bug in the `splitEdgeWhitespace` helper function where trailing whitespace characters (e.g. `" \t"`) were written in reverse order (`"\t "`). Because of this reversal, `strings.TrimSuffix` failed to match and strip the trailing whitespace, leading to whitespace duplication in the final formatted outputs.

### Changes
- Rewrote `splitEdgeWhitespace` in `formatting.go` using index pointers/rune slicing directly.
- Avoided `strings.Builder` allocations and substring searches.
- Created `formatting_test.go` to test whitespace edge cases (mixed whitespace, pre blocks, leading/trailing space).