### PR TITLE
perf(request): optimize getFieldContents primitive type formatting with strconv

### DIFF
--- a/request.go
+++ b/request.go
@@ -10,6 +10,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -276,8 +277,32 @@ func getFieldContents(v any, k string, w *multipart.Writer) (string, error) {
 		}
 		return *val, nil
 
-	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, bool:
-		return fmt.Sprint(val), nil
+	case int:
+		return strconv.Itoa(val), nil
+	case int8:
+		return strconv.FormatInt(int64(val), 10), nil
+	case int16:
+		return strconv.FormatInt(int64(val), 10), nil
+	case int32:
+		return strconv.FormatInt(int64(val), 10), nil
+	case int64:
+		return strconv.FormatInt(val, 10), nil
+	case uint:
+		return strconv.FormatUint(uint64(val), 10), nil
+	case uint8:
+		return strconv.FormatUint(uint64(val), 10), nil
+	case uint16:
+		return strconv.FormatUint(uint64(val), 10), nil
+	case uint32:
+		return strconv.FormatUint(uint64(val), 10), nil
+	case uint64:
+		return strconv.FormatUint(val, 10), nil
+	case float32:
+		return strconv.FormatFloat(float64(val), 'f', -1, 32), nil
+	case float64:
+		return strconv.FormatFloat(val, 'f', -1, 64), nil
+	case bool:
+		return strconv.FormatBool(val), nil
 
 	case Attach:
 		err := val.Attach(k, w)


### PR DESCRIPTION
## Description
This PR optimizes parameter serialization by replacing reflection-based `fmt.Sprint` with direct `strconv` function conversions for primitive parameters (integers, floats, booleans) in `request.go`.

### Changes
- Replaced `fmt.Sprint(val)` with explicit type cases (e.g., `strconv.Itoa`, `strconv.FormatInt`, `strconv.FormatBool`) in `getFieldContents`.
- This removes the reflection overhead and interface boxing allocations when converting query parameters to strings for multipart requests.