### PR TITLE
sec(request): wrap errors with sanitizedError to prevent token leaks

### DIFF
--- a/request.go
+++ b/request.go
@@ -149,7 +149,7 @@ func (bot *BaseBotClient) RequestWithContext(parentCtx context.Context, token st
 
 	resp, err := bot.Client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to execute POST request to %s: %w", method, sanitizeError(token, err))
+		return nil, fmt.Errorf("failed to execute POST request to %s: %w", method, &sanitizedError{err: err, token: token})
 	}
 	defer resp.Body.Close()
 
@@ -253,15 +253,17 @@ func buildMultipart(ctx context.Context, params map[string]any) (io.Reader, stri
 	return pr, w.FormDataContentType()
 }
 
-// Sanitize the error to avoid token leak.
-func sanitizeError(token string, err error) error {
-	var urlErr *url.Error
-	if errors.As(err, &urlErr) {
-		urlErr.URL = strings.ReplaceAll(urlErr.URL, token, "<TOKEN>")
-		return urlErr
-	}
+type sanitizedError struct {
+	err   error
+	token string
+}
 
-	return err
+func (s *sanitizedError) Error() string {
+	return strings.ReplaceAll(s.err.Error(), s.token, "<TOKEN>")
+}
+
+func (s *sanitizedError) Unwrap() error {
+	return s.err
 }
 
 func getFieldContents(v any, k string, w *multipart.Writer) (string, error) {

--- a/request_test.go
+++ b/request_test.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"mime"
 	"mime/multipart"
+	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -270,4 +272,32 @@ func TestBuildMultipartContextHandling(t *testing.T) {
 			t.Fatalf("expected context.Canceled after mid-read cancel, got: %v", err)
 		}
 	})
+}
+
+func TestSanitizeError(t *testing.T) {
+	token := "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+	rawErr := &url.Error{
+		Op:  "parse",
+		URL: "https://api.telegram.org/bot" + token + "/sendMessage",
+		Err: errors.New("connection timeout"),
+	}
+
+	var sanErr error = &sanitizedError{err: rawErr, token: token}
+
+	// Verify the error string does not contain the token
+	errStr := sanErr.Error()
+	if strings.Contains(errStr, token) {
+		t.Errorf("token leaked in error string: %s", errStr)
+	}
+	if !strings.Contains(errStr, "<TOKEN>") {
+		t.Errorf("expected error string to contain <TOKEN>: %s", errStr)
+	}
+
+	// Verify we can still unwrap and check the type of the underlying error
+	var urlErr *url.Error
+	if !errors.As(sanErr, &urlErr) {
+		t.Errorf("failed to unwrap and assert to *url.Error")
+	} else if urlErr.Op != "parse" {
+		t.Errorf("underlying error structure was not preserved")
+	}
 }


### PR DESCRIPTION
## Description
This PR improves token sanitization in `sanitizeError`. The previous implementation modified `url.Error` in-place, which would bypass redaction if the network error was structured/wrapped differently, risking token leaks in logs.

### Changes
- Introduced a custom `sanitizedError` wrapper type.
- Implemented `Error() string` to redact the bot token using `strings.ReplaceAll` for all wrapped errors.
- Implemented `Unwrap() error` so that callers can still use `errors.As` and `errors.Is` to check the underlying error types (e.g. network timeouts).
- Added `TestSanitizeError` unit tests to verify unwrapping and token redaction.