### PR TITLE
Comitted

### DIFF
--- a/ext/botmapping.go
+++ b/ext/botmapping.go
@@ -93,7 +93,9 @@ func (m *botMapping) addBot(b *gotgbot.Bot, urlPath string, webhookSecret string
 	}
 
 	m.mapping[bData.bot.Token] = bData
-	m.urlMapping[bData.urlPath] = bData.bot.Token
+	if bData.urlPath != "" {
+		m.urlMapping[bData.urlPath] = bData.bot.Token
+	}
 	return &bData, nil
 }
 

--- a/ext/handler_mapping.go
+++ b/ext/handler_mapping.go
@@ -27,7 +27,11 @@ func (m *handlerMapping) add(h Handler, group int) {
 		m.handlerGroups = append(m.handlerGroups, group)
 		sort.Ints(m.handlerGroups)
 	}
-	m.handlers[group] = append(currHandlers, h)
+
+	newHandlers := make([]Handler, len(currHandlers)+1)
+	copy(newHandlers, currHandlers)
+	newHandlers[len(currHandlers)] = h
+	m.handlers[group] = newHandlers
 }
 
 func (m *handlerMapping) remove(name string, group int) bool {


### PR DESCRIPTION
**# What**
This change addresses two concurrency and state management bugs in the ext package:
1. Thread-Safe Copy-on-Write for Handler Registrations (` ext/handler_mapping.go`)

**Problem:** In Go, slices returned from methods share the underlying backing array unless explicitly copied. While `remove() `implemented copy-on-write semantics to avoid mutating slices in use by concurrent goroutines, `add()` previously used `m.handlers[group] = append(currHandlers, h)`. If the slice had remaining capacity, append modified the underlying array in-place, creating data races with goroutines that had previously retrieved the handler group slice via ` getGroups()`. 

**Resolution:** Updated add() to allocate a new slice (make(`[]Handler, len(currHandlers)+1`)), copy existing handlers, and insert the new handler. This guarantees that handler lists are immutable and thread-safe across concurrent update processing cycles.

2. URL Path Mapping Isolation for Polling Bots ( `ext/botmapping.go`)
**Problem:**  `addBot()` is shared by both webhook bots (which have non-empty URL paths) and polling bots (which pass `urlPath = ""`). Unconditionally executing `m.urlMapping[bData.urlPath] = bData.bot.Token` caused polling bots to register an empty string key ("") in `urlMapping`.  

**Consequently:** Registering multiple polling bots caused subsequent bots to overwrite the "" entry. Removing a polling bot via  `removeBot()` deleted the "" key from `urlMapping`.
Resolution: Added a guard if `bData.urlPath != ""` before writing to `m.urlMapping`, ensuring `urlMapping` only contains valid webhook endpoints.

#Impact
Backwards Compatibility: Fully backwards compatible. No public API signatures, struct definitions, or behavioral contracts were altered. Documentation: Preserved existing code formatting, comments, and docstrings across both files. 

**Error Handling & Logs**: No error types or log formats were changed. Existing errors such as **ErrBotAlreadyExists** and **ErrBotUrlPathAlreadyExists** continue to operate as expected.